### PR TITLE
DaemonEvent unit test: use temp file location if testing, ignore non-…

### DIFF
--- a/source/code/dockerapi/DockerRemoteApi.cpp
+++ b/source/code/dockerapi/DockerRemoteApi.cpp
@@ -171,7 +171,7 @@ void getResponseInBatch(vector<string>& request, vector<cJSON*>& response, unsig
 	for (int i = 0; !ignoreResponse && i < n; i++)
 	{
 		char readBuf[bufferSize + 1];
-		size_t read_n = 0;
+		int read_n = 0;
 		string raw_response;
 		response.push_back(NULL);
 

--- a/test/code/providers/Container_DaemonEvent_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_DaemonEvent_Class_Provider_UnitTest.cpp
@@ -19,6 +19,7 @@
 #include "cjson/cJSON.h"
 
 #define LASTQUERYTIMEFILE "/var/opt/microsoft/docker-cimprov/state/LastEventQueryTime.txt"
+#define TEST_LASTQUERYTIMEFILE "./LastEventQueryTime.txt"
 
 using namespace std;
 using namespace SCXCoreLib;
@@ -89,7 +90,7 @@ protected:
 		m_keyNames.push_back(L"InstanceID");
 
 		// Read the time from disk
-		FILE* file = fopen(LASTQUERYTIMEFILE, "r");
+		FILE* file = fopen(TEST_LASTQUERYTIMEFILE, "r");
 		int fileTime = time(NULL);
 
 		if (file)
@@ -98,7 +99,7 @@ protected:
 		}
 		else
 		{
-			file = fopen(LASTQUERYTIMEFILE, "w");
+			file = fopen(TEST_LASTQUERYTIMEFILE, "w");
 			CPPUNIT_ASSERT(file);
 			fprintf(file, "%d", fileTime);
 		}


### PR DESCRIPTION
3 fixes for DaemonEvent unit tests
use temp file location if testing
ignore non-container objects in response
handle read socket timeout (returns -1)

@jeffaco 