### PR TITLE
Status for paused container is being reported as ‘Running’.

### DIFF
--- a/source/code/providers/Container_ContainerInventory_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerInventory_Class_Provider.cpp
@@ -191,21 +191,8 @@ private:
             }
             else
             {
-                if (cJSON_GetObjectItem(state, "Running")->valueint)
-                {
-                    // Container running
-                    instance.State_value("Running");
-                }
-                else if (cJSON_GetObjectItem(state, "Paused")->valueint)
-                {
-                    // Container paused
-                    instance.State_value("Paused");
-                }
-                else
-                {
-                    // Container exited
-                    instance.State_value("Stopped");
-                }
+                // Set the Container status : Running/Paused/Stopped
+                instance.State_value(cJSON_GetObjectItem(state, "Status")->valuestring);
             }
 
             instance.StartedTime_value(cJSON_GetObjectItem(state, "StartedAt")->valuestring);


### PR DESCRIPTION
@Microsoft/omsagent-devs @keikhara 

OMI provider is constructing status information from ‘Running’ & ‘Paused’ flag, both of these flags are true when container is paused.

Fixed the OMI provider for getting this information directly from State->Status node.