### PR TITLE
Fixed: 'opendir() returned null: Too many open files' issue.

### DIFF
--- a/source/code/dockerapi/DockerRemoteApi.cpp
+++ b/source/code/dockerapi/DockerRemoteApi.cpp
@@ -212,6 +212,7 @@ vector<cJSON*> getResponse(vector<string>& request, bool isMultiJson, bool ignor
     {
         openlog("DockerRemoteApi", LOG_PID | LOG_NDELAY, LOG_LOCAL1);
         syslog(LOG_ERR, "%s", str.c_str());
+        closelog();
     }
 
     return response;
@@ -332,6 +333,7 @@ vector<string> getContainerLogs(string& request)
     {
         openlog("DockerRemoteApi", LOG_PID | LOG_NDELAY, LOG_LOCAL1);
         syslog(LOG_ERR, "%s", str.c_str());
+        closelog();
     }
 
     return response;

--- a/source/code/providers/Container_ContainerInventory_Validation.h
+++ b/source/code/providers/Container_ContainerInventory_Validation.h
@@ -29,13 +29,14 @@ public:
         // Get the container IDs stored previously
         if (dir)
         {
-            while (dt = readdir(dir))
+            while ((dt = readdir(dir)) != NULL)
             {
                 if (dt->d_name && strlen(dt->d_name) == 64)
                 {
                     internalSet.insert(string(dt->d_name));
                 }
             }
+            closedir(dir);
         }
         else
         {


### PR DESCRIPTION
docker-provider starts throwing 'opendir() returned null: Too many open files' error once opendir reaches to MAX_OPEN limit. 
An open directory must always be closed with the closedir to ensure that the next attempt to open that directory is successful.