### PR TITLE
Docker-Provider updates for robustness

### DIFF
--- a/source/code/cjson/cJSON.c
+++ b/source/code/cjson/cJSON.c
@@ -660,7 +660,15 @@ static char *print_object(cJSON *item,int depth,int fmt,printbuffer *p)
 /* Get Array size/item / object item. */
 int    cJSON_GetArraySize(cJSON *array)							{cJSON *c=array->child;int i=0;while(c)i++,c=c->next;return i;}
 cJSON *cJSON_GetArrayItem(cJSON *array,int item)				{cJSON *c=array->child;  while (c && item>0) item--,c=c->next; return c;}
-cJSON *cJSON_GetObjectItem(cJSON *object,const char *string)	{cJSON *c=object->child; while (c && cJSON_strcasecmp(c->string,string)) c=c->next; return c;}
+cJSON *cJSON_GetObjectItem(cJSON *object, const char *string)
+{
+    cJSON *c = object ? object->child : NULL;
+    while (c && cJSON_strcasecmp(c->string, string))
+    {
+        c = c->next;
+    }
+    return c;
+}
 
 /* Utility for array list handling. */
 static void suffix_object(cJSON *prev,cJSON *item) {prev->next=item;item->prev=prev;}

--- a/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
@@ -55,8 +55,11 @@ private:
             {
                 // Docker 1.8.x
                 network = cJSON_GetObjectItem(stats, "network");
-                totalRx = cJSON_GetObjectItem(network, "rx_bytes")->valueint;
-                totalTx = cJSON_GetObjectItem(network, "tx_bytes")->valueint;
+		if (network)
+		{
+                    totalRx = cJSON_GetObjectItem(network, "rx_bytes")->valueint;
+                    totalTx = cJSON_GetObjectItem(network, "tx_bytes")->valueint;
+		}
             }
         }
         else


### PR DESCRIPTION
This PR addresses two issues:

1) Make the JSON parser more reliable to handle parsing requests

2) CIM Provider needs to handle cases when container stats do not contain 'Network' information in the REST response. We were segfaulting here earlier.