### PR TITLE
Remove non-applicable installation message

### DIFF
--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -12,16 +12,6 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
 	/opt/omi/bin/omicli ei root/cimv2 Container_DaemonEvent
 fi
 
-echo
-echo "In order to view container logs in OMS, Docker needs to be configured" 1>&2
-echo "with the correct log driver using the option:" 1>&2
-echo 1>&2
-echo "    --log-driver=fluentd --log-opt fluentd-address=localhost:<port>" 1>&2
-echo 1>&2
-echo "where <port> is the port that is exposed in the config file (default:" 1>&2
-echo "25225). Specify this option either when starting the Docker daemon or" 1>&2
-echo "when starting any container that you want to send logs to OMS." 1>&2
-
 %Postuninstall_1000
 # Calling sequence for RPM pre/post scripts, during upgrade, is as follows:
 #   1. Run the %pre section of the RPM being installed.

--- a/source/code/cjson/cJSON.c
+++ b/source/code/cjson/cJSON.c
@@ -660,7 +660,15 @@ static char *print_object(cJSON *item,int depth,int fmt,printbuffer *p)
 /* Get Array size/item / object item. */
 int    cJSON_GetArraySize(cJSON *array)							{cJSON *c=array->child;int i=0;while(c)i++,c=c->next;return i;}
 cJSON *cJSON_GetArrayItem(cJSON *array,int item)				{cJSON *c=array->child;  while (c && item>0) item--,c=c->next; return c;}
-cJSON *cJSON_GetObjectItem(cJSON *object,const char *string)	{cJSON *c=object->child; while (c && cJSON_strcasecmp(c->string,string)) c=c->next; return c;}
+cJSON *cJSON_GetObjectItem(cJSON *object, const char *string)
+{
+    cJSON *c = object ? object->child : NULL;
+    while (c && cJSON_strcasecmp(c->string, string))
+    {
+        c = c->next;
+    }
+    return c;
+}
 
 /* Utility for array list handling. */
 static void suffix_object(cJSON *prev,cJSON *item) {prev->next=item;item->prev=prev;}

--- a/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
@@ -55,8 +55,11 @@ private:
             {
                 // Docker 1.8.x
                 network = cJSON_GetObjectItem(stats, "network");
-                totalRx = cJSON_GetObjectItem(network, "rx_bytes")->valueint;
-                totalTx = cJSON_GetObjectItem(network, "tx_bytes")->valueint;
+		if (network)
+		{
+                    totalRx = cJSON_GetObjectItem(network, "rx_bytes")->valueint;
+                    totalTx = cJSON_GetObjectItem(network, "tx_bytes")->valueint;
+		}
             }
         }
         else


### PR DESCRIPTION
We no longer use this global setting to configure the Docker log driver. This message is confusing and not required and has prevented our customers from performing Docker tasks.