### PR TITLE
Add separate buffer for container data types

### DIFF
--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -64,3 +64,17 @@
 <filter oms.container.**>
 	type filter_container
 </filter>
+
+#separate buffer for containers
+<match oms.container.**>
+  type out_oms
+  log_level info
+  buffer_chunk_limit 20m
+  buffer_type file
+  buffer_path /var/opt/microsoft/omsagent/state/state/out_oms_docker*.buffer
+  buffer_queue_limit 20
+  flush_interval 20s
+  retry_limit 10
+  retry_wait 15s
+  max_retry_wait 9m
+</match>

--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -71,7 +71,7 @@
   log_level info
   buffer_chunk_limit 20m
   buffer_type file
-  buffer_path /var/opt/microsoft/omsagent/state/state/out_oms_docker*.buffer
+  buffer_path %STATE_DIR_WS%/out_oms_docker*.buffer
   buffer_queue_limit 20
   flush_interval 20s
   retry_limit 10


### PR DESCRIPTION
Separating the buffer for container data types. Container log volumes are quite high and they were filling up the common buffer leading to queues getting backed up. Separated thew buffers to alleviate the problem.
@Microsoft/omsagent-devs @keikhara 