### PR TITLE
Initial commit adding Type=ContainerNodeInventory_CL

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -238,7 +238,8 @@ STATIC_PROVIDERLIB_SRCFILES = \
 	$(PROVIDER_DIR)/Container_ContainerStatistics_Class_Provider.cpp \
 	$(PROVIDER_DIR)/Container_DaemonEvent_Class_Provider.cpp \
 	$(PROVIDER_DIR)/Container_ImageInventory_Class_Provider.cpp \
-	$(PROVIDER_DIR)/Container_ContainerLog_Class_Provider.cpp
+	$(PROVIDER_DIR)/Container_ContainerLog_Class_Provider.cpp \
+	$(PROVIDER_DIR)/Container_HostInventory_Class_Provider.cpp
 
 STATIC_PROVIDERLIB_SRCFILES += \
 	$(PROVIDER_DIR)/module.cpp \
@@ -281,6 +282,7 @@ STATIC_PROVIDER_UNITFILES = \
 	$(PROVIDER_TEST_DIR)/Container_ContainerStatistics_Class_Provider_UnitTest.cpp \
 	$(PROVIDER_TEST_DIR)/Container_DaemonEvent_Class_Provider_UnitTest.cpp \
 	$(PROVIDER_TEST_DIR)/Container_ImageInventory_Class_Provider_UnitTest.cpp \
+	$(PROVIDER_TEST_DIR)/Container_HostInventory_Class_Provider_UnitTest.cpp \
 	$(PROVIDER_TEST_DIR)/support/testrunnerlogpolicy.cpp \
 	$(PROVIDER_TEST_DIR)/support/productdependencies.cpp \
 	$(PROVIDER_TEST_DIR)/providertestutils.cpp

--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -17,13 +17,13 @@
 <source>
 	type oms_omi
 	object_name "Container"
-	interval 30s
+	interval 15s
 </source>
 
 # Container inventory
 <source>
 	type omi
-	run_interval 30s
+	run_interval 60s
 	tag oms.container.containerinventory
 	items [
 		["root/cimv2","Container_ContainerInventory"]
@@ -33,7 +33,7 @@
 # Image inventory
 <source>
 	type omi
-	run_interval 30s
+	run_interval 60s
 	tag oms.container.imageinventory
 	items [
 		["root/cimv2","Container_ImageInventory"]
@@ -60,10 +60,34 @@
 	]
 </source>
 
+# Container host inventory
+<source>
+	type omi
+	run_interval 60s
+	tag oms.api.ContainerNodeInventory
+	items [
+		["root/cimv2","Container_HostInventory"]
+	]
+</source>
+
 # Filter for correct format to endpoint
 <filter oms.container.**>
 	type filter_container
 </filter>
+
+<match oms.api.ContainerNodeInventory**>
+  type out_oms_api
+  log_level debug
+  buffer_chunk_limit 20m
+  buffer_type file
+  buffer_path %STATE_DIR_WS%/out_oms_containerinventory*.buffer
+  buffer_queue_limit 20
+  flush_interval 20s
+  retry_limit 10
+  retry_wait 15s
+  max_retry_wait 9m
+</match>
+
 
 #separate buffer for containers
 <match oms.container.**>

--- a/installer/conf/omi/container.reg
+++ b/installer/conf/omi/container.reg
@@ -6,3 +6,4 @@ CLASS=Container_ContainerStatistics:CIM_StatisticalData:CIM_ManagedElement
 CLASS=Container_DaemonEvent:CIM_ManagedElement
 CLASS=Container_ImageInventory:CIM_ManagedElement
 CLASS=Container_ContainerLog:CIM_ManagedElement
+CLASS=Container_HostInventory:CIM_ManagedElement

--- a/source/code/dockerapi/DockerRemoteApi.h
+++ b/source/code/dockerapi/DockerRemoteApi.h
@@ -16,5 +16,6 @@ vector<string> listContainer(bool all = false);
 vector<cJSON*> getResponse(vector<string>& request, bool isMultiJson = false, bool ignoreResponse = false);
 vector<string> getContainerLogs(string& request);
 string getDockerHostName();
+cJSON* parseJson(string& );
 
 #endif

--- a/source/code/mof/docker.mof
+++ b/source/code/mof/docker.mof
@@ -190,3 +190,38 @@ class Container_ContainerLog : CIM_ManagedElement
 	[ Description ( "Host name of Docker host" ) ]
 	String Computer;
 };
+
+// Container_HostInventory
+// -------------------------------------------------------------------
+[   Version ( "1.0.0" ),
+	Description ( "Docker Host Inventory" )
+]
+class Container_HostInventory : CIM_ManagedElement
+{
+	[ Key, Description ( "GUID" ) ]
+	String InstanceID;
+
+	[ Description ( "Host name of Docker host" ) ]
+	String Computer;
+
+	[ Description ( "Docker version" ) ]
+	String DockerVersion;
+
+	[ Description ( "Host operating system" ) ]
+	String OperatingSystem;
+
+	[ Description ( "Host volume information" ) ]
+	String Volume;
+
+	[ Description ( "Host network information" ) ]
+	String Network;
+
+	[ Description ( "Host internal IP information" ) ]
+	String InternalIp;
+
+	[ Description ( "Host role" ) ]
+	String NodeRole;
+
+	[ Description ( "Cluster orchestator type" ) ]
+	String OrchestratorType;
+};

--- a/source/code/providers/Container_ContainerLog_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerLog_Class_Provider.cpp
@@ -15,26 +15,11 @@
 #include "../cjson/cJSON.h"
 #include "../dockerapi/DockerRemoteApi.h"
 #include "../dockerapi/DockerRestHelper.h"
+#include "Helper.h"
 
 #define LASTLOGQUERYTIMEFILE "/var/opt/microsoft/docker-cimprov/state/LastLogQueryTime.txt"
 
 using namespace std;
-
-class Guid
-{
-public:
-    ///
-    /// Create a guid and represent it as string
-    ///
-    static string NewToString()
-    {
-        uuid_t uuid;
-        uuid_generate_random(uuid);
-        char s[37];
-        uuid_unparse(uuid, s);
-        return string(s);
-    }
-};
 
 MI_BEGIN_NAMESPACE
 

--- a/source/code/providers/Container_DaemonEvent_Class_Provider.cpp
+++ b/source/code/providers/Container_DaemonEvent_Class_Provider.cpp
@@ -16,27 +16,12 @@
 #include "../dockerapi/DockerRemoteApi.h"
 #include "../dockerapi/DockerRestHelper.h"
 #include "Container_ContainerLogFileReader.h"
+#include "Helper.h"
 
 #define LASTQUERYTIMEFILE "/var/opt/microsoft/docker-cimprov/state/LastEventQueryTime.txt"
 #define TEST_LASTQUERYTIMEFILE "./LastEventQueryTime.txt"
 
 using namespace std;
-
-class Guid
-{
-public:
-    ///
-    /// Create a guid and represent it as string
-    ///
-    static string NewToString()
-    {
-        uuid_t uuid;
-        uuid_generate_random(uuid);
-        char s[37];
-        uuid_unparse(uuid, s);
-        return string(s);
-    }
-};
 
 MI_BEGIN_NAMESPACE
 

--- a/source/code/providers/Container_HostInventory.h
+++ b/source/code/providers/Container_HostInventory.h
@@ -1,0 +1,971 @@
+/* @migen@ */
+/*
+**==============================================================================
+**
+** WARNING: THIS FILE WAS AUTOMATICALLY GENERATED. PLEASE DO NOT EDIT.
+**
+**==============================================================================
+*/
+#ifndef _Container_HostInventory_h
+#define _Container_HostInventory_h
+
+#include <MI.h>
+#include "CIM_ManagedElement.h"
+
+/*
+**==============================================================================
+**
+** Container_HostInventory [Container_HostInventory]
+**
+** Keys:
+**    InstanceID
+**
+**==============================================================================
+*/
+
+typedef struct _Container_HostInventory /* extends CIM_ManagedElement */
+{
+    MI_Instance __instance;
+    /* CIM_ManagedElement properties */
+    /*KEY*/ MI_ConstStringField InstanceID;
+    MI_ConstStringField Caption;
+    MI_ConstStringField Description;
+    MI_ConstStringField ElementName;
+    /* Container_HostInventory properties */
+    MI_ConstStringField Computer;
+    MI_ConstStringField DockerVersion;
+    MI_ConstStringField OperatingSystem;
+    MI_ConstStringField Volume;
+    MI_ConstStringField Network;
+    MI_ConstStringField InternalIp;
+    MI_ConstStringField NodeRole;
+    MI_ConstStringField OrchestratorType;
+}
+Container_HostInventory;
+
+typedef struct _Container_HostInventory_Ref
+{
+    Container_HostInventory* value;
+    MI_Boolean exists;
+    MI_Uint8 flags;
+}
+Container_HostInventory_Ref;
+
+typedef struct _Container_HostInventory_ConstRef
+{
+    MI_CONST Container_HostInventory* value;
+    MI_Boolean exists;
+    MI_Uint8 flags;
+}
+Container_HostInventory_ConstRef;
+
+typedef struct _Container_HostInventory_Array
+{
+    struct _Container_HostInventory** data;
+    MI_Uint32 size;
+}
+Container_HostInventory_Array;
+
+typedef struct _Container_HostInventory_ConstArray
+{
+    struct _Container_HostInventory MI_CONST* MI_CONST* data;
+    MI_Uint32 size;
+}
+Container_HostInventory_ConstArray;
+
+typedef struct _Container_HostInventory_ArrayRef
+{
+    Container_HostInventory_Array value;
+    MI_Boolean exists;
+    MI_Uint8 flags;
+}
+Container_HostInventory_ArrayRef;
+
+typedef struct _Container_HostInventory_ConstArrayRef
+{
+    Container_HostInventory_ConstArray value;
+    MI_Boolean exists;
+    MI_Uint8 flags;
+}
+Container_HostInventory_ConstArrayRef;
+
+MI_EXTERN_C MI_CONST MI_ClassDecl Container_HostInventory_rtti;
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Construct(
+    Container_HostInventory* self,
+    MI_Context* context)
+{
+    return MI_ConstructInstance(context, &Container_HostInventory_rtti,
+        (MI_Instance*)&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clone(
+    const Container_HostInventory* self,
+    Container_HostInventory** newInstance)
+{
+    return MI_Instance_Clone(
+        &self->__instance, (MI_Instance**)newInstance);
+}
+
+MI_INLINE MI_Boolean MI_CALL Container_HostInventory_IsA(
+    const MI_Instance* self)
+{
+    MI_Boolean res = MI_FALSE;
+    return MI_Instance_IsA(self, &Container_HostInventory_rtti, &res) == MI_RESULT_OK && res;
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Destruct(Container_HostInventory* self)
+{
+    return MI_Instance_Destruct(&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Delete(Container_HostInventory* self)
+{
+    return MI_Instance_Delete(&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Post(
+    const Container_HostInventory* self,
+    MI_Context* context)
+{
+    return MI_PostInstance(context, &self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_InstanceID(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        0,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_InstanceID(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        0,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_InstanceID(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_Caption(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        1,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_Caption(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        1,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_Caption(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        1);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_Description(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        2,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_Description(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        2,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_Description(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        2);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_ElementName(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        3,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_ElementName(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        3,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_ElementName(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        3);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_Computer(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        4,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_Computer(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        4,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_Computer(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        4);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_DockerVersion(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        5,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_DockerVersion(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        5,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_DockerVersion(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        5);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_OperatingSystem(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        6,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_OperatingSystem(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        6,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_OperatingSystem(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        6);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_Volume(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        7,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_Volume(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        7,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_Volume(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        7);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_Network(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        8,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_Network(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        8,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_Network(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        8);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_InternalIp(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        9,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_InternalIp(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        9,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_InternalIp(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        9);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_NodeRole(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        10,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_NodeRole(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        10,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_NodeRole(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        10);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Set_OrchestratorType(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        11,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_SetPtr_OrchestratorType(
+    Container_HostInventory* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        11,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_HostInventory_Clear_OrchestratorType(
+    Container_HostInventory* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        11);
+}
+
+/*
+**==============================================================================
+**
+** Container_HostInventory provider function prototypes
+**
+**==============================================================================
+*/
+
+/* The developer may optionally define this structure */
+typedef struct _Container_HostInventory_Self Container_HostInventory_Self;
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_Load(
+    Container_HostInventory_Self** self,
+    MI_Module_Self* selfModule,
+    MI_Context* context);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_Unload(
+    Container_HostInventory_Self* self,
+    MI_Context* context);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_EnumerateInstances(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const MI_PropertySet* propertySet,
+    MI_Boolean keysOnly,
+    const MI_Filter* filter);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_GetInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* instanceName,
+    const MI_PropertySet* propertySet);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_CreateInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* newInstance);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_ModifyInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* modifiedInstance,
+    const MI_PropertySet* propertySet);
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_DeleteInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* instanceName);
+
+
+/*
+**==============================================================================
+**
+** Container_HostInventory_Class
+**
+**==============================================================================
+*/
+
+#ifdef __cplusplus
+# include <micxx/micxx.h>
+
+MI_BEGIN_NAMESPACE
+
+class Container_HostInventory_Class : public CIM_ManagedElement_Class
+{
+public:
+    
+    typedef Container_HostInventory Self;
+    
+    Container_HostInventory_Class() :
+        CIM_ManagedElement_Class(&Container_HostInventory_rtti)
+    {
+    }
+    
+    Container_HostInventory_Class(
+        const Container_HostInventory* instanceName,
+        bool keysOnly) :
+        CIM_ManagedElement_Class(
+            &Container_HostInventory_rtti,
+            &instanceName->__instance,
+            keysOnly)
+    {
+    }
+    
+    Container_HostInventory_Class(
+        const MI_ClassDecl* clDecl,
+        const MI_Instance* instance,
+        bool keysOnly) :
+        CIM_ManagedElement_Class(clDecl, instance, keysOnly)
+    {
+    }
+    
+    Container_HostInventory_Class(
+        const MI_ClassDecl* clDecl) :
+        CIM_ManagedElement_Class(clDecl)
+    {
+    }
+    
+    Container_HostInventory_Class& operator=(
+        const Container_HostInventory_Class& x)
+    {
+        CopyRef(x);
+        return *this;
+    }
+    
+    Container_HostInventory_Class(
+        const Container_HostInventory_Class& x) :
+        CIM_ManagedElement_Class(x)
+    {
+    }
+
+    static const MI_ClassDecl* GetClassDecl()
+    {
+        return &Container_HostInventory_rtti;
+    }
+
+    //
+    // Container_HostInventory_Class.Computer
+    //
+    
+    const Field<String>& Computer() const
+    {
+        const size_t n = offsetof(Self, Computer);
+        return GetField<String>(n);
+    }
+    
+    void Computer(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, Computer);
+        GetField<String>(n) = x;
+    }
+    
+    const String& Computer_value() const
+    {
+        const size_t n = offsetof(Self, Computer);
+        return GetField<String>(n).value;
+    }
+    
+    void Computer_value(const String& x)
+    {
+        const size_t n = offsetof(Self, Computer);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool Computer_exists() const
+    {
+        const size_t n = offsetof(Self, Computer);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void Computer_clear()
+    {
+        const size_t n = offsetof(Self, Computer);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.DockerVersion
+    //
+    
+    const Field<String>& DockerVersion() const
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        return GetField<String>(n);
+    }
+    
+    void DockerVersion(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        GetField<String>(n) = x;
+    }
+    
+    const String& DockerVersion_value() const
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        return GetField<String>(n).value;
+    }
+    
+    void DockerVersion_value(const String& x)
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool DockerVersion_exists() const
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void DockerVersion_clear()
+    {
+        const size_t n = offsetof(Self, DockerVersion);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.OperatingSystem
+    //
+    
+    const Field<String>& OperatingSystem() const
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        return GetField<String>(n);
+    }
+    
+    void OperatingSystem(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        GetField<String>(n) = x;
+    }
+    
+    const String& OperatingSystem_value() const
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        return GetField<String>(n).value;
+    }
+    
+    void OperatingSystem_value(const String& x)
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool OperatingSystem_exists() const
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void OperatingSystem_clear()
+    {
+        const size_t n = offsetof(Self, OperatingSystem);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.Volume
+    //
+    
+    const Field<String>& Volume() const
+    {
+        const size_t n = offsetof(Self, Volume);
+        return GetField<String>(n);
+    }
+    
+    void Volume(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, Volume);
+        GetField<String>(n) = x;
+    }
+    
+    const String& Volume_value() const
+    {
+        const size_t n = offsetof(Self, Volume);
+        return GetField<String>(n).value;
+    }
+    
+    void Volume_value(const String& x)
+    {
+        const size_t n = offsetof(Self, Volume);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool Volume_exists() const
+    {
+        const size_t n = offsetof(Self, Volume);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void Volume_clear()
+    {
+        const size_t n = offsetof(Self, Volume);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.Network
+    //
+    
+    const Field<String>& Network() const
+    {
+        const size_t n = offsetof(Self, Network);
+        return GetField<String>(n);
+    }
+    
+    void Network(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, Network);
+        GetField<String>(n) = x;
+    }
+    
+    const String& Network_value() const
+    {
+        const size_t n = offsetof(Self, Network);
+        return GetField<String>(n).value;
+    }
+    
+    void Network_value(const String& x)
+    {
+        const size_t n = offsetof(Self, Network);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool Network_exists() const
+    {
+        const size_t n = offsetof(Self, Network);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void Network_clear()
+    {
+        const size_t n = offsetof(Self, Network);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.InternalIp
+    //
+    
+    const Field<String>& InternalIp() const
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        return GetField<String>(n);
+    }
+    
+    void InternalIp(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        GetField<String>(n) = x;
+    }
+    
+    const String& InternalIp_value() const
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        return GetField<String>(n).value;
+    }
+    
+    void InternalIp_value(const String& x)
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool InternalIp_exists() const
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void InternalIp_clear()
+    {
+        const size_t n = offsetof(Self, InternalIp);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.NodeRole
+    //
+    
+    const Field<String>& NodeRole() const
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        return GetField<String>(n);
+    }
+    
+    void NodeRole(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        GetField<String>(n) = x;
+    }
+    
+    const String& NodeRole_value() const
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        return GetField<String>(n).value;
+    }
+    
+    void NodeRole_value(const String& x)
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool NodeRole_exists() const
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void NodeRole_clear()
+    {
+        const size_t n = offsetof(Self, NodeRole);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_HostInventory_Class.OrchestratorType
+    //
+    
+    const Field<String>& OrchestratorType() const
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        return GetField<String>(n);
+    }
+    
+    void OrchestratorType(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        GetField<String>(n) = x;
+    }
+    
+    const String& OrchestratorType_value() const
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        return GetField<String>(n).value;
+    }
+    
+    void OrchestratorType_value(const String& x)
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool OrchestratorType_exists() const
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void OrchestratorType_clear()
+    {
+        const size_t n = offsetof(Self, OrchestratorType);
+        GetField<String>(n).Clear();
+    }
+};
+
+typedef Array<Container_HostInventory_Class> Container_HostInventory_ClassA;
+
+MI_END_NAMESPACE
+
+#endif /* __cplusplus */
+
+#endif /* _Container_HostInventory_h */

--- a/source/code/providers/Container_HostInventory_Class_Provider.cpp
+++ b/source/code/providers/Container_HostInventory_Class_Provider.cpp
@@ -1,0 +1,227 @@
+/* @migen@ */
+#include <MI.h>
+#include "Container_HostInventory_Class_Provider.h"
+
+#include <vector>
+#include <string>
+#include <syslog.h>
+#include <stdio.h>
+#include <uuid/uuid.h>
+#include <cstdlib>
+
+#include "../cjson/cJSON.h"
+#include "../dockerapi/DockerRemoteApi.h"
+#include "../dockerapi/DockerRestHelper.h"
+#include "Helper.h"
+
+using namespace std;
+
+MI_BEGIN_NAMESPACE
+
+class ContainerHostInventoryQuery
+{
+public:
+    ///
+    /// \returns Object representing the host
+    ///
+    static Container_HostInventory_Class InspectHost()
+    {
+        Container_HostInventory_Class hostInventoryInstance;
+
+        // Request containers
+        vector<string> request(1, DockerRestHelper::restDockerInfo());
+        vector<cJSON*> response;
+
+        //check to see if its a test environment
+        if(getenv(DOCKER_TESTRUNNER_STRING) != NULL)
+        {
+            //fake response for test
+            char* testResponseStr = getenv(DOCKER_TESTRUNNER_STRING);
+            string tempStr = testResponseStr;
+            cJSON* testJsonObject = parseJson(tempStr);
+            response.push_back(testJsonObject);
+        }
+        else
+        {
+            //regular code path, get response from rest call
+            response = getResponse(request);
+        }
+
+        // See https://docs.docker.com/engine/api/v1.27/#section/Versioning for example output
+        if (!response.empty() && response[0])
+        {   
+            PopulateInstanceFromJson(hostInventoryInstance, response[0]);
+            // Clean up object
+            cJSON_Delete(response[0]);
+        }
+        else
+        {
+            syslog(LOG_WARNING, "API call in Container_HostInventory::InspectHost to get host info returned null");
+        }
+        return hostInventoryInstance;
+    }
+
+    static void PopulateInstanceFromJson(Container_HostInventory_Class &instance, cJSON* responseJson)
+    {
+            instance.InstanceID_value(Guid::NewToString().c_str());
+            string computerName = string((cJSON_GetObjectItem(responseJson, "Name")->valuestring));
+            instance.Computer_value(computerName.c_str());
+            instance.DockerVersion_value((cJSON_GetObjectItem(responseJson, "ServerVersion")->valuestring));
+            instance.OperatingSystem_value((cJSON_GetObjectItem(responseJson, "OperatingSystem")->valuestring));
+            //Get Volume and Network info from "Plugins"
+            cJSON* plugins_entry = cJSON_GetObjectItem(responseJson, "Plugins");
+            if(plugins_entry != NULL)
+            {
+                //Get volume info
+                cJSON* volumeEntry = cJSON_GetObjectItem(plugins_entry, "Volume");
+                string volumeList;
+                if(volumeEntry != NULL)
+                {
+                    for(int i =0; i < cJSON_GetArraySize(volumeEntry);i++)
+                    {
+                        volumeList.append(string(cJSON_GetArrayItem(volumeEntry, i)->valuestring));
+                    }
+                }
+                instance.Volume_value(volumeList.c_str());
+                //Get network info
+                cJSON* networkEntry = cJSON_GetObjectItem(plugins_entry, "Network");
+                string networkList;
+                if(networkEntry != NULL)
+                {
+                    for(int i =0; i < cJSON_GetArraySize(networkEntry);i++)
+                    {
+                        networkList.append(string(cJSON_GetArrayItem(networkEntry, i)->valuestring));
+                        networkList.append(" ");
+                    }
+                }
+                instance.Network_value(networkList.c_str());
+            }
+
+            //Node role is obtained from the computer name. e.g. k8s-master-71E8D996-0 => master role
+            if(computerName.find("master") != string::npos || computerName.find("manager") != string::npos)
+            {
+                //swarm
+                instance.NodeRole_value("Master");  
+            }
+            else if(computerName.find("agent") != string::npos)
+            {
+                //swarm
+                instance.NodeRole_value("Agent");  
+            }
+            else
+            {
+                instance.NodeRole_value("Not Orchestrated");  
+            }   
+
+            //Orchestrator type is obtained from the node name. example of node names swarm-manager-vmss_0 for swarm, k8s-master-71E8D996-0 for kubernetes
+            if(computerName.find("swarmm") != string::npos)
+            {
+                //swarm
+                instance.OrchestratorType_value("Swarm Mode");  
+            }
+            else if(computerName.find("swarm") != string::npos)
+            {
+                //swarm
+                instance.OrchestratorType_value("Swarm");  
+            }
+            else if(computerName.find("k8") != string::npos)
+            {
+                //swarm
+                instance.OrchestratorType_value("Kubernetes");  
+            }
+            else if(computerName.find("dcos") != string::npos)
+            {
+                //swarm
+                instance.OrchestratorType_value("DC/OS");  
+            }
+            else
+            {
+                instance.OrchestratorType_value("None");  
+            }   
+    }
+};
+
+Container_HostInventory_Class_Provider::Container_HostInventory_Class_Provider(
+    Module* module) :
+    m_Module(module)
+{
+}
+
+Container_HostInventory_Class_Provider::~Container_HostInventory_Class_Provider()
+{
+}
+
+void Container_HostInventory_Class_Provider::Load(
+        Context& context)
+{
+    context.Post(MI_RESULT_OK);
+}
+
+void Container_HostInventory_Class_Provider::Unload(
+        Context& context)
+{
+    context.Post(MI_RESULT_OK);
+}
+
+void Container_HostInventory_Class_Provider::EnumerateInstances(
+    Context& context,
+    const String& nameSpace,
+    const PropertySet& propertySet,
+    bool keysOnly,
+    const MI_Filter* filter)
+{
+    try
+    {
+        Container_HostInventory_Class queryResult = ContainerHostInventoryQuery::InspectHost();
+        context.Post(queryResult);
+        context.Post(MI_RESULT_OK);
+    }
+    catch (std::exception &e)
+    {
+        syslog(LOG_ERR, "Container_HostInventory %s", e.what());
+        context.Post(MI_RESULT_FAILED);
+    }
+    catch (...)
+    {
+        syslog(LOG_ERR, "Container_HostInventory Unknown exception");
+        context.Post(MI_RESULT_FAILED);
+    }
+}
+
+void Container_HostInventory_Class_Provider::GetInstance(
+    Context& context,
+    const String& nameSpace,
+    const Container_HostInventory_Class& instanceName,
+    const PropertySet& propertySet)
+{
+    context.Post(MI_RESULT_NOT_SUPPORTED);
+}
+
+void Container_HostInventory_Class_Provider::CreateInstance(
+    Context& context,
+    const String& nameSpace,
+    const Container_HostInventory_Class& newInstance)
+{
+    context.Post(MI_RESULT_NOT_SUPPORTED);
+}
+
+void Container_HostInventory_Class_Provider::ModifyInstance(
+    Context& context,
+    const String& nameSpace,
+    const Container_HostInventory_Class& modifiedInstance,
+    const PropertySet& propertySet)
+{
+    context.Post(MI_RESULT_NOT_SUPPORTED);
+}
+
+void Container_HostInventory_Class_Provider::DeleteInstance(
+    Context& context,
+    const String& nameSpace,
+    const Container_HostInventory_Class& instanceName)
+{
+    context.Post(MI_RESULT_NOT_SUPPORTED);
+}
+
+
+MI_END_NAMESPACE
+

--- a/source/code/providers/Container_HostInventory_Class_Provider.h
+++ b/source/code/providers/Container_HostInventory_Class_Provider.h
@@ -1,0 +1,82 @@
+/* @migen@ */
+#ifndef _Container_HostInventory_Class_Provider_h
+#define _Container_HostInventory_Class_Provider_h
+
+#include "Container_HostInventory.h"
+#ifdef __cplusplus
+# include <micxx/micxx.h>
+# include "module.h"
+
+#define DOCKER_TESTRUNNER_STRING "DOCKER_TESTRUNNER_STRING"
+
+MI_BEGIN_NAMESPACE
+
+/*
+**==============================================================================
+**
+** Container_HostInventory provider class declaration
+**
+**==============================================================================
+*/
+
+class Container_HostInventory_Class_Provider
+{
+/* @MIGEN.BEGIN@ CAUTION: PLEASE DO NOT EDIT OR DELETE THIS LINE. */
+private:
+    Module* m_Module;
+
+public:
+    Container_HostInventory_Class_Provider(
+        Module* module);
+
+    ~Container_HostInventory_Class_Provider();
+
+    inline Module* getModule()
+    {
+        return m_Module;
+    }
+
+    void Load(
+        Context& context);
+
+    void Unload(
+        Context& context);
+
+    void EnumerateInstances(
+        Context& context,
+        const String& nameSpace,
+        const PropertySet& propertySet,
+        bool keysOnly,
+        const MI_Filter* filter);
+
+    void GetInstance(
+        Context& context,
+        const String& nameSpace,
+        const Container_HostInventory_Class& instance,
+        const PropertySet& propertySet);
+
+    void CreateInstance(
+        Context& context,
+        const String& nameSpace,
+        const Container_HostInventory_Class& newInstance);
+
+    void ModifyInstance(
+        Context& context,
+        const String& nameSpace,
+        const Container_HostInventory_Class& modifiedInstance,
+        const PropertySet& propertySet);
+
+    void DeleteInstance(
+        Context& context,
+        const String& nameSpace,
+        const Container_HostInventory_Class& instance);
+
+/* @MIGEN.END@ CAUTION: PLEASE DO NOT EDIT OR DELETE THIS LINE. */
+};
+
+MI_END_NAMESPACE
+
+#endif /* __cplusplus */
+
+#endif /* _Container_HostInventory_Class_Provider_h */
+

--- a/source/code/providers/Helper.h
+++ b/source/code/providers/Helper.h
@@ -1,0 +1,20 @@
+#ifndef _HELPER_H_
+#define _HELPER_H_
+
+class Guid
+{
+public:
+    ///
+    /// Create a guid and represent it as string
+    ///
+    static string NewToString()
+    {
+        uuid_t uuid;
+        uuid_generate_random(uuid);
+        char s[37];
+        uuid_unparse(uuid, s);
+        return string(s);
+    }
+};
+
+#endif /* _HELPER_H_ */

--- a/source/code/providers/schema.c
+++ b/source/code/providers/schema.c
@@ -13,6 +13,7 @@
 #include "Container_ContainerStatistics.h"
 #include "Container_ContainerInventory.h"
 #include "Container_ContainerLog.h"
+#include "Container_HostInventory.h"
 
 /*
 **==============================================================================
@@ -1490,6 +1491,246 @@ MI_CONST MI_ClassDecl Container_ContainerLog_rtti =
     NULL, /* owningClass */
 };
 
+/*
+**==============================================================================
+**
+** Container_HostInventory
+**
+**==============================================================================
+*/
+
+/* property Container_HostInventory.InstanceID */
+static MI_CONST MI_PropertyDecl Container_HostInventory_InstanceID_prop =
+{
+    MI_FLAG_PROPERTY|MI_FLAG_KEY, /* flags */
+    0x0069640A, /* code */
+    MI_T("InstanceID"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, InstanceID), /* offset */
+    MI_T("CIM_ManagedElement"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.Computer */
+static MI_CONST MI_PropertyDecl Container_HostInventory_Computer_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00637208, /* code */
+    MI_T("Computer"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, Computer), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.DockerVersion */
+static MI_CONST MI_PropertyDecl Container_HostInventory_DockerVersion_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00646E0D, /* code */
+    MI_T("DockerVersion"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, DockerVersion), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.OperatingSystem */
+static MI_CONST MI_PropertyDecl Container_HostInventory_OperatingSystem_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x006F6D0F, /* code */
+    MI_T("OperatingSystem"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, OperatingSystem), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.Volume */
+static MI_CONST MI_PropertyDecl Container_HostInventory_Volume_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00766506, /* code */
+    MI_T("Volume"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, Volume), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.Network */
+static MI_CONST MI_PropertyDecl Container_HostInventory_Network_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x006E6B07, /* code */
+    MI_T("Network"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, Network), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.InternalIp */
+static MI_CONST MI_PropertyDecl Container_HostInventory_InternalIp_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x0069700A, /* code */
+    MI_T("InternalIp"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, InternalIp), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.NodeRole */
+static MI_CONST MI_PropertyDecl Container_HostInventory_NodeRole_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x006E6508, /* code */
+    MI_T("NodeRole"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, NodeRole), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+/* property Container_HostInventory.OrchestratorType */
+static MI_CONST MI_PropertyDecl Container_HostInventory_OrchestratorType_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x006F6510, /* code */
+    MI_T("OrchestratorType"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_HostInventory, OrchestratorType), /* offset */
+    MI_T("Container_HostInventory"), /* origin */
+    MI_T("Container_HostInventory"), /* propagator */
+    NULL,
+};
+
+static MI_PropertyDecl MI_CONST* MI_CONST Container_HostInventory_props[] =
+{
+    &Container_HostInventory_InstanceID_prop,
+    &CIM_ManagedElement_Caption_prop,
+    &CIM_ManagedElement_Description_prop,
+    &CIM_ManagedElement_ElementName_prop,
+    &Container_HostInventory_Computer_prop,
+    &Container_HostInventory_DockerVersion_prop,
+    &Container_HostInventory_OperatingSystem_prop,
+    &Container_HostInventory_Volume_prop,
+    &Container_HostInventory_Network_prop,
+    &Container_HostInventory_InternalIp_prop,
+    &Container_HostInventory_NodeRole_prop,
+    &Container_HostInventory_OrchestratorType_prop,
+};
+
+static MI_CONST MI_ProviderFT Container_HostInventory_funcs =
+{
+  (MI_ProviderFT_Load)Container_HostInventory_Load,
+  (MI_ProviderFT_Unload)Container_HostInventory_Unload,
+  (MI_ProviderFT_GetInstance)Container_HostInventory_GetInstance,
+  (MI_ProviderFT_EnumerateInstances)Container_HostInventory_EnumerateInstances,
+  (MI_ProviderFT_CreateInstance)Container_HostInventory_CreateInstance,
+  (MI_ProviderFT_ModifyInstance)Container_HostInventory_ModifyInstance,
+  (MI_ProviderFT_DeleteInstance)Container_HostInventory_DeleteInstance,
+  (MI_ProviderFT_AssociatorInstances)NULL,
+  (MI_ProviderFT_ReferenceInstances)NULL,
+  (MI_ProviderFT_EnableIndications)NULL,
+  (MI_ProviderFT_DisableIndications)NULL,
+  (MI_ProviderFT_Subscribe)NULL,
+  (MI_ProviderFT_Unsubscribe)NULL,
+  (MI_ProviderFT_Invoke)NULL,
+};
+
+static MI_CONST MI_Char* Container_HostInventory_UMLPackagePath_qual_value = MI_T("CIM::Core::CoreElements");
+
+static MI_CONST MI_Qualifier Container_HostInventory_UMLPackagePath_qual =
+{
+    MI_T("UMLPackagePath"),
+    MI_STRING,
+    0,
+    &Container_HostInventory_UMLPackagePath_qual_value
+};
+
+static MI_CONST MI_Char* Container_HostInventory_Version_qual_value = MI_T("1.0.0");
+
+static MI_CONST MI_Qualifier Container_HostInventory_Version_qual =
+{
+    MI_T("Version"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TRANSLATABLE|MI_FLAG_RESTRICTED,
+    &Container_HostInventory_Version_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST Container_HostInventory_quals[] =
+{
+    &Container_HostInventory_UMLPackagePath_qual,
+    &Container_HostInventory_Version_qual,
+};
+
+/* class Container_HostInventory */
+MI_CONST MI_ClassDecl Container_HostInventory_rtti =
+{
+    MI_FLAG_CLASS, /* flags */
+    0x00637917, /* code */
+    MI_T("Container_HostInventory"), /* name */
+    Container_HostInventory_quals, /* qualifiers */
+    MI_COUNT(Container_HostInventory_quals), /* numQualifiers */
+    Container_HostInventory_props, /* properties */
+    MI_COUNT(Container_HostInventory_props), /* numProperties */
+    sizeof(Container_HostInventory), /* size */
+    MI_T("CIM_ManagedElement"), /* superClass */
+    &CIM_ManagedElement_rtti, /* superClassDecl */
+    NULL, /* methods */
+    0, /* numMethods */
+    &schemaDecl, /* schema */
+    &Container_HostInventory_funcs, /* functions */
+    NULL, /* owningClass */
+};
 
 /*
 **==============================================================================
@@ -1516,6 +1757,7 @@ static MI_ClassDecl MI_CONST* MI_CONST classes[] =
     &Container_DaemonEvent_rtti,
     &Container_ImageInventory_rtti,
     &Container_ContainerLog_rtti,
+    &Container_HostInventory_rtti,
 };
 
 MI_SchemaDecl schemaDecl =

--- a/source/code/providers/stubs.cpp
+++ b/source/code/providers/stubs.cpp
@@ -13,6 +13,7 @@
 #include "Container_ContainerStatistics_Class_Provider.h"
 #include "Container_ContainerInventory_Class_Provider.h"
 #include "Container_ContainerLog_Class_Provider.h"
+#include "Container_HostInventory_Class_Provider.h"
 
 using namespace mi;
 
@@ -611,6 +612,126 @@ MI_EXTERN_C void MI_CALL Container_ContainerLog_DeleteInstance(
 
     cxxSelf->DeleteInstance(cxxContext, nameSpace, cxxInstanceName);
 }
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_Load(
+    Container_HostInventory_Self** self,
+    MI_Module_Self* selfModule,
+    MI_Context* context)
+{
+    MI_Result r = MI_RESULT_OK;
+    Context ctx(context, &r);
+    Container_HostInventory_Class_Provider* prov = new Container_HostInventory_Class_Provider((Module*)selfModule);
+
+    prov->Load(ctx);
+    if (MI_RESULT_OK != r)
+    {
+        delete prov;
+        MI_Context_PostResult(context, r);
+        return;
+    }
+    *self = (Container_HostInventory_Self*)prov;
+    MI_Context_PostResult(context, MI_RESULT_OK);
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_Unload(
+    Container_HostInventory_Self* self,
+    MI_Context* context)
+{
+    MI_Result r = MI_RESULT_OK;
+    Context ctx(context, &r);
+    Container_HostInventory_Class_Provider* prov = (Container_HostInventory_Class_Provider*)self;
+
+    prov->Unload(ctx);
+    delete ((Container_HostInventory_Class_Provider*)self);
+    MI_Context_PostResult(context, r);
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_EnumerateInstances(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const MI_PropertySet* propertySet,
+    MI_Boolean keysOnly,
+    const MI_Filter* filter)
+{
+    Container_HostInventory_Class_Provider* cxxSelf =((Container_HostInventory_Class_Provider*)self);
+    Context  cxxContext(context);
+
+    cxxSelf->EnumerateInstances(
+        cxxContext,
+        nameSpace,
+        __PropertySet(propertySet),
+        __bool(keysOnly),
+        filter);
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_GetInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* instanceName,
+    const MI_PropertySet* propertySet)
+{
+    Container_HostInventory_Class_Provider* cxxSelf =((Container_HostInventory_Class_Provider*)self);
+    Context  cxxContext(context);
+    Container_HostInventory_Class cxxInstanceName(instanceName, true);
+
+    cxxSelf->GetInstance(
+        cxxContext,
+        nameSpace,
+        cxxInstanceName,
+        __PropertySet(propertySet));
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_CreateInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* newInstance)
+{
+    Container_HostInventory_Class_Provider* cxxSelf =((Container_HostInventory_Class_Provider*)self);
+    Context  cxxContext(context);
+    Container_HostInventory_Class cxxNewInstance(newInstance, false);
+
+    cxxSelf->CreateInstance(cxxContext, nameSpace, cxxNewInstance);
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_ModifyInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* modifiedInstance,
+    const MI_PropertySet* propertySet)
+{
+    Container_HostInventory_Class_Provider* cxxSelf =((Container_HostInventory_Class_Provider*)self);
+    Context  cxxContext(context);
+    Container_HostInventory_Class cxxModifiedInstance(modifiedInstance, false);
+
+    cxxSelf->ModifyInstance(
+        cxxContext,
+        nameSpace,
+        cxxModifiedInstance,
+        __PropertySet(propertySet));
+}
+
+MI_EXTERN_C void MI_CALL Container_HostInventory_DeleteInstance(
+    Container_HostInventory_Self* self,
+    MI_Context* context,
+    const MI_Char* nameSpace,
+    const MI_Char* className,
+    const Container_HostInventory* instanceName)
+{
+    Container_HostInventory_Class_Provider* cxxSelf =((Container_HostInventory_Class_Provider*)self);
+    Context  cxxContext(context);
+    Container_HostInventory_Class cxxInstanceName(instanceName, true);
+
+    cxxSelf->DeleteInstance(cxxContext, nameSpace, cxxInstanceName);
+}
+
 
 MI_EXTERN_C MI_SchemaDecl schemaDecl;
 

--- a/test/code/providers/Container_HostInventory_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_HostInventory_Class_Provider_UnitTest.cpp
@@ -1,0 +1,190 @@
+#include <set>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
+#include <uuid/uuid.h>
+#include <vector>
+
+#include <scxcorelib/scxcmn.h>
+#include <scxcorelib/scxprocess.h>
+#include <scxcorelib/stringaid.h>
+#include <testutils/scxunit.h>
+#include <testutils/providertestutils.h>
+
+#include "Container_HostInventory_Class_Provider.h"
+#include "cjson/cJSON.h"
+
+using namespace std;
+using namespace SCXCoreLib;
+
+class ContainerHostInventoryTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(ContainerHostInventoryTest);
+    CPPUNIT_TEST(TestK8Parsing);
+    CPPUNIT_TEST(TestDcosParsing);
+    CPPUNIT_TEST(TestSwarmModeParsing);
+    CPPUNIT_TEST(TestSwarmParsing);
+    CPPUNIT_TEST(TestNonOrchestratedParsing);
+    //Running this test at the end to test that the unset of DOCKER_TESTRUNNER_STRING is successful
+    CPPUNIT_TEST(TestEnumerateInstances);
+    CPPUNIT_TEST_SUITE_END();
+private:
+
+public:
+    
+protected:
+    void TestEnumerateInstances()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+
+        // Enumerate provider. This just tests if the provider is able to pick up properties from a docker info call on the machine
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());        
+		
+        // Only check that the values are present and within the valid range because it is not possible to create a controlled environment
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"DockerVersion", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"OperatingSystem", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"Volume", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"Network", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+            CPPUNIT_ASSERT(context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
+        }
+    }
+
+    void TestK8Parsing()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+        string k8NodeInfoString = "\r\n{\"ID\":\"4H4P:Z5O5:MMPA:BSDD:44TG:3FRY:AJ5Z:SPU4:LIEV:2XIF:SDJ3:FWLL\",\"Containers\":23,\"ContainersRunning\":13,\"ContainersPaused\":0,\"ContainersStopped\":10,\"Images\":25,\"Driver\":\"overlay\",\"DriverStatus\":[[\"Backing Filesystem\",\"extfs\"]],\"SystemStatus\":null,\"Plugins\":{\"Volume\":[\"local\"],\"Network\":[\"host\",\"bridge\",\"null\",\"overlay\"],\"Authorization\":null},\"MemoryLimit\":true,\"SwapLimit\":false,\"KernelMemory\":true,\"CpuCfsPeriod\":true,\"CpuCfsQuota\":true,\"CPUShares\":true,\"CPUSet\":true,\"IPv4Forwarding\":true,\"BridgeNfIptables\":true,\"BridgeNfIp6tables\":true,\"Debug\":false,\"NFd\":89,\"OomKillDisable\":true,\"NGoroutines\":89,\"SystemTime\":\"2017-04-25T22:06:56.371719716Z\",\"ExecutionDriver\":\"\",\"LoggingDriver\":\"json-file\",\"CgroupDriver\":\"cgroupfs\",\"NEventsListener\":0,\"KernelVersion\":\"4.4.0-72-generic\",\"OperatingSystem\":\"Ubuntu 16.04 LTS\",\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"RegistryConfig\":{\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"],\"IndexConfigs\":{\"docker.io\":{\"Name\":\"docker.io\",\"Mirrors\":null,\"Secure\":true,\"Official\":true}},\"Mirrors\":null},\"NCPU\":2,\"MemTotal\":7305641984,\"DockerRootDir\":\"/var/lib/docker\",\"HttpProxy\":\"\",\"HttpsProxy\":\"\",\"NoProxy\":\"\",\"Name\":\"k8-master-71E8D996-0\",\"Labels\":null,\"ExperimentalBuild\":false,\"ServerVersion\":\"1.12.6\",\"ClusterStore\":\"\",\"ClusterAdvertise\":\"\",\"SecurityOptions\":[\"apparmor\",\"seccomp\"],\"Runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"DefaultRuntime\":\"runc\",\"Swarm\":{\"NodeID\":\"\",\"NodeAddr\":\"\",\"LocalNodeState\":\"inactive\",\"ControlAvailable\":false,\"Error\":\"\",\"RemoteManagers\":null,\"Nodes\":0,\"Managers\":0,\"Cluster\":{\"ID\":\"\",\"Version\":{},\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"Spec\":{\"Orchestration\":{},\"Raft\":{},\"Dispatcher\":{},\"CAConfig\":{},\"TaskDefaults\":{}}}},\"LiveRestoreEnabled\":false}";
+        setenv(DOCKER_TESTRUNNER_STRING,k8NodeInfoString.c_str(),1);
+
+        // Enumerate provider. Use k8 specific response instead of the standard docker info response
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());
+
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"k8-master-71E8D996-0"), context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg))) ;
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"1.12.6"), context[i].GetProperty(L"DockerVersion", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Ubuntu 16.04 LTS"), context[i].GetProperty(L"OperatingSystem", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"local"), context[i].GetProperty(L"Volume", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Master"), context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Kubernetes"), context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+        }
+
+        unsetenv(DOCKER_TESTRUNNER_STRING);
+    }
+
+    void TestDcosParsing()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+        string dcosNodeInfoString = "\r\n{\"ID\":\"4H4P:Z5O5:MMPA:BSDD:44TG:3FRY:AJ5Z:SPU4:LIEV:2XIF:SDJ3:FWLL\",\"Containers\":23,\"ContainersRunning\":13,\"ContainersPaused\":0,\"ContainersStopped\":10,\"Images\":25,\"Driver\":\"overlay\",\"DriverStatus\":[[\"Backing Filesystem\",\"extfs\"]],\"SystemStatus\":null,\"Plugins\":{\"Volume\":[\"local\"],\"Network\":[\"host\",\"bridge\",\"null\",\"overlay\"],\"Authorization\":null},\"MemoryLimit\":true,\"SwapLimit\":false,\"KernelMemory\":true,\"CpuCfsPeriod\":true,\"CpuCfsQuota\":true,\"CPUShares\":true,\"CPUSet\":true,\"IPv4Forwarding\":true,\"BridgeNfIptables\":true,\"BridgeNfIp6tables\":true,\"Debug\":false,\"NFd\":89,\"OomKillDisable\":true,\"NGoroutines\":89,\"SystemTime\":\"2017-04-25T22:06:56.371719716Z\",\"ExecutionDriver\":\"\",\"LoggingDriver\":\"json-file\",\"CgroupDriver\":\"cgroupfs\",\"NEventsListener\":0,\"KernelVersion\":\"4.4.0-72-generic\",\"OperatingSystem\":\"Ubuntu 16.04 LTS\",\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"RegistryConfig\":{\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"],\"IndexConfigs\":{\"docker.io\":{\"Name\":\"docker.io\",\"Mirrors\":null,\"Secure\":true,\"Official\":true}},\"Mirrors\":null},\"NCPU\":2,\"MemTotal\":7305641984,\"DockerRootDir\":\"/var/lib/docker\",\"HttpProxy\":\"\",\"HttpsProxy\":\"\",\"NoProxy\":\"\",\"Name\":\"dcos-master-71E8D996-0\",\"Labels\":null,\"ExperimentalBuild\":false,\"ServerVersion\":\"1.12.6\",\"ClusterStore\":\"\",\"ClusterAdvertise\":\"\",\"SecurityOptions\":[\"apparmor\",\"seccomp\"],\"Runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"DefaultRuntime\":\"runc\",\"Swarm\":{\"NodeID\":\"\",\"NodeAddr\":\"\",\"LocalNodeState\":\"inactive\",\"ControlAvailable\":false,\"Error\":\"\",\"RemoteManagers\":null,\"Nodes\":0,\"Managers\":0,\"Cluster\":{\"ID\":\"\",\"Version\":{},\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"Spec\":{\"Orchestration\":{},\"Raft\":{},\"Dispatcher\":{},\"CAConfig\":{},\"TaskDefaults\":{}}}},\"LiveRestoreEnabled\":false}";
+        setenv(DOCKER_TESTRUNNER_STRING,dcosNodeInfoString.c_str(),1);
+
+        // Enumerate provider. Similar to k8 testing
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());
+
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"dcos-master-71E8D996-0"), context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg))) ;
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Master"), context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"DC/OS"), context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+        }
+
+        unsetenv(DOCKER_TESTRUNNER_STRING);
+    }
+
+    void TestSwarmModeParsing()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+        string swarmModeNodeInfoString = "\r\n{\"ID\":\"4H4P:Z5O5:MMPA:BSDD:44TG:3FRY:AJ5Z:SPU4:LIEV:2XIF:SDJ3:FWLL\",\"Containers\":23,\"ContainersRunning\":13,\"ContainersPaused\":0,\"ContainersStopped\":10,\"Images\":25,\"Driver\":\"overlay\",\"DriverStatus\":[[\"Backing Filesystem\",\"extfs\"]],\"SystemStatus\":null,\"Plugins\":{\"Volume\":[\"local\"],\"Network\":[\"host\",\"bridge\",\"null\",\"overlay\"],\"Authorization\":null},\"MemoryLimit\":true,\"SwapLimit\":false,\"KernelMemory\":true,\"CpuCfsPeriod\":true,\"CpuCfsQuota\":true,\"CPUShares\":true,\"CPUSet\":true,\"IPv4Forwarding\":true,\"BridgeNfIptables\":true,\"BridgeNfIp6tables\":true,\"Debug\":false,\"NFd\":89,\"OomKillDisable\":true,\"NGoroutines\":89,\"SystemTime\":\"2017-04-25T22:06:56.371719716Z\",\"ExecutionDriver\":\"\",\"LoggingDriver\":\"json-file\",\"CgroupDriver\":\"cgroupfs\",\"NEventsListener\":0,\"KernelVersion\":\"4.4.0-72-generic\",\"OperatingSystem\":\"Ubuntu 16.04 LTS\",\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"RegistryConfig\":{\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"],\"IndexConfigs\":{\"docker.io\":{\"Name\":\"docker.io\",\"Mirrors\":null,\"Secure\":true,\"Official\":true}},\"Mirrors\":null},\"NCPU\":2,\"MemTotal\":7305641984,\"DockerRootDir\":\"/var/lib/docker\",\"HttpProxy\":\"\",\"HttpsProxy\":\"\",\"NoProxy\":\"\",\"Name\":\"swarmm-agent-71E8D996-0\",\"Labels\":null,\"ExperimentalBuild\":false,\"ServerVersion\":\"1.12.6\",\"ClusterStore\":\"\",\"ClusterAdvertise\":\"\",\"SecurityOptions\":[\"apparmor\",\"seccomp\"],\"Runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"DefaultRuntime\":\"runc\",\"Swarm\":{\"NodeID\":\"\",\"NodeAddr\":\"\",\"LocalNodeState\":\"inactive\",\"ControlAvailable\":false,\"Error\":\"\",\"RemoteManagers\":null,\"Nodes\":0,\"Managers\":0,\"Cluster\":{\"ID\":\"\",\"Version\":{},\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"Spec\":{\"Orchestration\":{},\"Raft\":{},\"Dispatcher\":{},\"CAConfig\":{},\"TaskDefaults\":{}}}},\"LiveRestoreEnabled\":false}";
+        setenv(DOCKER_TESTRUNNER_STRING,swarmModeNodeInfoString.c_str(),1);
+
+        // Enumerate provider. Similar to k8 testing
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());
+
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());  
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"swarmm-agent-71E8D996-0"), context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg))) ;
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Agent"), context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Swarm Mode"), context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+        }
+
+        unsetenv(DOCKER_TESTRUNNER_STRING);
+    }
+
+    void TestSwarmParsing()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+        string swarmNodeInfoString = "\r\n{\"ID\":\"4H4P:Z5O5:MMPA:BSDD:44TG:3FRY:AJ5Z:SPU4:LIEV:2XIF:SDJ3:FWLL\",\"Containers\":23,\"ContainersRunning\":13,\"ContainersPaused\":0,\"ContainersStopped\":10,\"Images\":25,\"Driver\":\"overlay\",\"DriverStatus\":[[\"Backing Filesystem\",\"extfs\"]],\"SystemStatus\":null,\"Plugins\":{\"Volume\":[\"local\"],\"Network\":[\"host\",\"bridge\",\"null\",\"overlay\"],\"Authorization\":null},\"MemoryLimit\":true,\"SwapLimit\":false,\"KernelMemory\":true,\"CpuCfsPeriod\":true,\"CpuCfsQuota\":true,\"CPUShares\":true,\"CPUSet\":true,\"IPv4Forwarding\":true,\"BridgeNfIptables\":true,\"BridgeNfIp6tables\":true,\"Debug\":false,\"NFd\":89,\"OomKillDisable\":true,\"NGoroutines\":89,\"SystemTime\":\"2017-04-25T22:06:56.371719716Z\",\"ExecutionDriver\":\"\",\"LoggingDriver\":\"json-file\",\"CgroupDriver\":\"cgroupfs\",\"NEventsListener\":0,\"KernelVersion\":\"4.4.0-72-generic\",\"OperatingSystem\":\"Ubuntu 16.04 LTS\",\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"RegistryConfig\":{\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"],\"IndexConfigs\":{\"docker.io\":{\"Name\":\"docker.io\",\"Mirrors\":null,\"Secure\":true,\"Official\":true}},\"Mirrors\":null},\"NCPU\":2,\"MemTotal\":7305641984,\"DockerRootDir\":\"/var/lib/docker\",\"HttpProxy\":\"\",\"HttpsProxy\":\"\",\"NoProxy\":\"\",\"Name\":\"swarm-agent-71E8D996-0\",\"Labels\":null,\"ExperimentalBuild\":false,\"ServerVersion\":\"1.12.6\",\"ClusterStore\":\"\",\"ClusterAdvertise\":\"\",\"SecurityOptions\":[\"apparmor\",\"seccomp\"],\"Runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"DefaultRuntime\":\"runc\",\"Swarm\":{\"NodeID\":\"\",\"NodeAddr\":\"\",\"LocalNodeState\":\"inactive\",\"ControlAvailable\":false,\"Error\":\"\",\"RemoteManagers\":null,\"Nodes\":0,\"Managers\":0,\"Cluster\":{\"ID\":\"\",\"Version\":{},\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"Spec\":{\"Orchestration\":{},\"Raft\":{},\"Dispatcher\":{},\"CAConfig\":{},\"TaskDefaults\":{}}}},\"LiveRestoreEnabled\":false}";
+        setenv(DOCKER_TESTRUNNER_STRING,swarmNodeInfoString.c_str(),1);
+
+        // Enumerate provider. Similar to k8 testing
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());
+
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"swarm-agent-71E8D996-0"), context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg))) ;
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Agent"), context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Swarm"), context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+        }
+    }
+
+    void TestNonOrchestratedParsing()
+    {
+        wstring errMsg;
+        TestableContext context;
+        vector<wstring> m_keyNames;
+        m_keyNames.push_back(L"InstanceID");
+        string  nonOrechestratedNodeInfoString = "\r\n{\"ID\":\"MR7R:T4QM:X3TD:VL6Q:BTO3:54RC:VEAX:2ERN:AWEX:DLFA:6YEP:SZ6I\",\"Containers\":105,\"ContainersRunning\":0,\"ContainersPaused\":0,\"ContainersStopped\":105,\"Images\":9,\"Driver\":\"aufs\",\"DriverStatus\":[[\"Root Dir\",\"/var/lib/docker/aufs\"],[\"Backing Filesystem\",\"extfs\"],[\"Dirs\",\"233\"],[\"Dirperm1 Supported\",\"true\"]],\"SystemStatus\":null,\"Plugins\":{\"Volume\":[\"local\"],\"Network\":[\"bridge\",\"host\",\"macvlan\",\"null\",\"overlay\"],\"Authorization\":null},\"MemoryLimit\":true,\"SwapLimit\":false,\"KernelMemory\":true,\"CpuCfsPeriod\":true,\"CpuCfsQuota\":true,\"CPUShares\":true,\"CPUSet\":true,\"IPv4Forwarding\":true,\"BridgeNfIptables\":true,\"BridgeNfIp6tables\":true,\"Debug\":false,\"NFd\":15,\"OomKillDisable\":true,\"NGoroutines\":23,\"SystemTime\":\"2017-04-25T18:05:00.430709779-04:00\",\"LoggingDriver\":\"json-file\",\"CgroupDriver\":\"cgroupfs\",\"NEventsListener\":0,\"KernelVersion\":\"4.4.0-72-generic\",\"OperatingSystem\":\"Ubuntu 16.04.2 LTS\",\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"RegistryConfig\":{\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"],\"IndexConfigs\":{\"docker.io\":{\"Name\":\"docker.io\",\"Mirrors\":null,\"Secure\":true,\"Official\":true}},\"Mirrors\":[]},\"NCPU\":4,\"MemTotal\":8336683008,\"DockerRootDir\":\"/var/lib/docker\",\"HttpProxy\":\"\",\"HttpsProxy\":\"\",\"NoProxy\":\"\",\"Name\":\"chocoboyLnx\",\"Labels\":null,\"ExperimentalBuild\":false,\"ServerVersion\":\"17.03.0-ce\",\"ClusterStore\":\"\",\"ClusterAdvertise\":\"\",\"Runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"DefaultRuntime\":\"runc\",\"Swarm\":{\"NodeID\":\"\",\"NodeAddr\":\"\",\"LocalNodeState\":\"inactive\",\"ControlAvailable\":false,\"Error\":\"\",\"RemoteManagers\":null,\"Nodes\":0,\"Managers\":0,\"Cluster\":{\"ID\":\"\",\"Version\":{},\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"Spec\":{\"Orchestration\":{},\"Raft\":{\"ElectionTick\":0,\"HeartbeatTick\":0},\"Dispatcher\":{},\"CAConfig\":{},\"TaskDefaults\":{},\"EncryptionConfig\":{\"AutoLockManagers\":false}}}},\"LiveRestoreEnabled\":false,\"Isolation\":\"\",\"InitBinary\":\"docker-init\",\"ContainerdCommit\":{\"ID\":\"977c511eda0925a723debdc94d09459af49d082a\",\"Expected\":\"977c511eda0925a723debdc94d09459af49d082a\"},\"RuncCommit\":{\"ID\":\"a01dafd48bc1c7cc12bdb01206f9fea7dd6feb70\",\"Expected\":\"a01dafd48bc1c7cc12bdb01206f9fea7dd6feb70\"},\"InitCommit\":{\"ID\":\"949e6fa\",\"Expected\":\"949e6fa\"},\"SecurityOptions\":[\"name=apparmor\",\"name=seccomp,profile=default\"]}";
+        setenv(DOCKER_TESTRUNNER_STRING,nonOrechestratedNodeInfoString.c_str(),1);
+
+        // Enumerate provider. Similar to k8 testing
+        StandardTestEnumerateInstances<mi::Container_HostInventory_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
+        CPPUNIT_ASSERT_EQUAL(1, context.Size());
+
+        for (unsigned i = 0; i < context.Size(); ++i)
+        {
+            wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
+            CPPUNIT_ASSERT(instanceId.length());
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"chocoboyLnx"), context[i].GetProperty(L"Computer", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg))) ;
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"17.03.0-ce"), context[i].GetProperty(L"DockerVersion", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Ubuntu 16.04.2 LTS"), context[i].GetProperty(L"OperatingSystem", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"Not Orchestrated"), context[i].GetProperty(L"NodeRole", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(std::wstring(L"None"), context[i].GetProperty(L"OrchestratorType", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+        }
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ContainerHostInventoryTest);


### PR DESCRIPTION
Added a new provider class Container_HostInventory_Class_Provider . It collects some node inventory data from the rest api version of "docker info". It also parses the node name to determine orchestrator. I have verified the functionality. I will work on adding a unit test for this. Meanwhile I could use some feedback on this. 
![image](https://cloud.githubusercontent.com/assets/25937992/25297426/847535a6-26a2-11e7-915d-d3feb500228a.png)
I have attached a sample of the search query in OMS
I also modified the frequency of data, ContainerNodeInventory_CL, ContainerInventory and ContainerImageInventory are set at a frequency of 1 minute, ContainerLog and Perf are set to a frequency of 15 s since they need to be more real time.
@Microsoft/omsagent-devs @jeffaco @keikhara @amitsara 