### PR TITLE
Coredump, memory leak and missing container logs fix

### DIFF
--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -50,10 +50,10 @@
 	]
 </source>
 
-# Container service log
+# Container log
 <source>
 	type omi
-	run_interval 30s
+	run_interval 300s
 	tag oms.container.log
 	items [
 		["root/cimv2","Container_ContainerLog"]

--- a/source/code/dockerapi/DockerRestHelper.h
+++ b/source/code/dockerapi/DockerRestHelper.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string>
 #include <string.h>
+#include <stdlib.h>
 
 #include "../cjson/cJSON.h"
 
@@ -92,7 +93,7 @@ public:
     static string restDockerLogs(string id, int start)
     {
         char result[516];
-        snprintf(result, 516, "GET /containers/%s/logs?stderr=1&stdout=1&since=%d HTTP/1.1\r\nHost: localhost\r\n\r\n", id.c_str(), start);
+        snprintf(result, 516, "GET /containers/%s/logs?stderr=1&stdout=1&since=%d&timestamps=1 HTTP/1.1\r\nHost: localhost\r\n\r\n", id.c_str(), start);
         return string(result);
     }
 
@@ -139,6 +140,9 @@ public:
         char result[2048];
         snprintf(result, 2048, "POST /containers/%s/exec HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: %zu\r\n\r\n%s", id.c_str(), strlen(json), json);
 
+        if(root) cJSON_Delete(root);
+        if(json) free(json);
+
         return string(result);
     }
 
@@ -161,6 +165,9 @@ public:
 
         char result[512];
         snprintf(result, 512, "POST /exec/%s/start HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: %zu\r\n\r\n%s", execId.c_str(), strlen(json), json);
+
+        if(root) cJSON_Delete(root);
+        if(json) free(json);
 
         return string(result);
     }

--- a/source/code/providers/Container_ContainerLogFileReader.h
+++ b/source/code/providers/Container_ContainerLogFileReader.h
@@ -53,6 +53,7 @@ private:
         {
             // POST exec create requests
             vector<cJSON*> response = getResponse(createRequests);
+            vector<cJSON*> tempResponse ; //need a temp var so I can delete the response,usage will make this note clearer
             vector<string> startRequests;
 
             // See https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#exec-create for example output
@@ -72,7 +73,17 @@ private:
             if (startRequests.size())
             {
                 // POST exec start requests
-                getResponse(startRequests, false, true);
+                tempResponse = getResponse(startRequests, false, true);
+            }
+
+            //clean up
+            for (unsigned i = 0; i < response.size(); i++)
+            {
+                cJSON_Delete(response[i]);
+            }
+            for (unsigned i = 0; i < tempResponse.size(); i++)
+            {
+                cJSON_Delete(tempResponse[i]);
             }
         }
     }
@@ -94,57 +105,60 @@ public:
         {
             // Get the container state
             cJSON* state = cJSON_GetObjectItem(response[0], "State");
-			
-            // Check if container is running first
-            if (cJSON_GetObjectItem(state, "Running")->valueint)
-            {
-                // Get the container config
-                cJSON* config = cJSON_GetObjectItem(response[0], "Config");
 
-                if (config)
+            if(state != NULL)
+            {			
+                // Check if container is running first
+                if (cJSON_GetObjectItem(state, "Running")->valueint)
                 {
-                    // Get environment variables
-                    cJSON* env = cJSON_GetObjectItem(config, "Env");
-					
-                    if (env)
+                    // Get the container config
+                    cJSON* config = cJSON_GetObjectItem(response[0], "Config");
+
+                    if (config)
                     {
-                        int length = cJSON_GetArraySize(env);
-
-                        // Allow exit from loop if both OMSLOGS and OMSERRLOGS were found so that the remaining environment variables don't have to be parsed
-                        bool logfound = false;
-                        bool errfound = false;
-
-                        for (int i = 0; !logfound && !errfound && i < length; i++)
+                        // Get environment variables
+                        cJSON* env = cJSON_GetObjectItem(config, "Env");
+                        
+                        if (env)
                         {
-                            //Initialize an empty string
-                            string var = "";
-                            cJSON* arrItem = cJSON_GetArrayItem(env, i);
-                            //Try a string cast only if the json object exists and is of type string, a cast of type string(NULL) results in a coredump
-                            if(arrItem != NULL)
+                            int length = cJSON_GetArraySize(env);
+
+                            // Allow exit from loop if both OMSLOGS and OMSERRLOGS were found so that the remaining environment variables don't have to be parsed
+                            bool logfound = false;
+                            bool errfound = false;
+
+                            for (int i = 0; !logfound && !errfound && i < length; i++)
                             {
-                                if(arrItem->valuestring != NULL)
+                                //Initialize an empty string
+                                string var = "";
+                                cJSON* arrItem = cJSON_GetArrayItem(env, i);
+                                //Try a string cast only if the json object exists and is of type string, a cast of type string(NULL) results in a coredump
+                                if(arrItem != NULL)
                                 {
-                                    var = string(arrItem->valuestring);
+                                    if(arrItem->valuestring != NULL)
+                                    {
+                                        var = string(arrItem->valuestring);
+                                    }
                                 }
-                            }
-                            // Check beginning of string
-                            if (!logfound && var.length() > 8 && !var.find("OMSLOGS="))
-                            {
-                                logfound = true;
-                                ParseAndExec(containerId, var.substr(8));
-                            }
-                            else if (!errfound && var.length() > 11 && !var.find("OMSERRLOGS="))
-                            {
-                                errfound = true;
-                                ParseAndExec(containerId, var.substr(11), true);
+                                // Check beginning of string
+                                if (!logfound && var.length() > 8 && !var.find("OMSLOGS="))
+                                {
+                                    logfound = true;
+                                    ParseAndExec(containerId, var.substr(8));
+                                }
+                                else if (!errfound && var.length() > 11 && !var.find("OMSERRLOGS="))
+                                {
+                                    errfound = true;
+                                    ParseAndExec(containerId, var.substr(11), true);
+                                }
                             }
                         }
                     }
                 }
-            }
-            else
-            {
-                syslog(LOG_NOTICE, "Container %s is not running; cannot exec", containerId.c_str());
+                else
+                {
+                    syslog(LOG_NOTICE, "Container %s is not running; cannot exec", containerId.c_str());
+                }
             }
 
             // Clean up object

--- a/source/code/providers/Container_ContainerLog_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerLog_Class_Provider.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <uuid/uuid.h>
 #include <vector>
+#include <deque>
 
 #include "../cjson/cJSON.h"
 #include "../dockerapi/DockerRemoteApi.h"
@@ -103,9 +104,9 @@ public:
     ///
     /// \returns Vector containing logs for each container
     ///
-    static vector<Container_ContainerLog_Class> QueryAll()
+    static deque<Container_ContainerLog_Class> QueryAll()
     {
-        vector<Container_ContainerLog_Class> result;
+        deque<Container_ContainerLog_Class> result;
 
         string logDriver = getLogDriverName();
         if (logDriver.compare("json-file") != 0)
@@ -171,7 +172,7 @@ public:
                                 }
                             }
                             instance.Computer_value(hostname.c_str());
-                            result.push_back(instance);
+                            result.push_front(instance);
                         }
 
                         logResponse.clear();
@@ -225,7 +226,7 @@ void Container_ContainerLog_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
-    vector<Container_ContainerLog_Class> queryResult = ContainerLogQuery::QueryAll();
+    deque<Container_ContainerLog_Class> queryResult = ContainerLogQuery::QueryAll();
 
     for (unsigned i = 0; i < queryResult.size(); i++)
     {


### PR DESCRIPTION
This pull request addresses a number of issues 
Coredumps:
1. Modified  static vector<Container_DaemonEvent_Class> QueryAll() to only try to link stdout/stderr streams for newly created containers. It looks for create in status for all containers events gotten from docker daemon and then considers it a newly created container. This became a bug because it doesnt check whether the container is running now. Any container would go through a sequence of create/attach/stop/destroy. Its necessary to check if its currently running before trying to do anything with it\n
2. Modified static Container_ImageInventory_Class DeserializeObject(string& id). There were two issues here. A fixed buffer size was beign used. Since these files held a container inventory information I could see file sizes on my machine greater than 2KB. Its not unimaginable that someone might have file sizes greater than 4KB and so I decided to do away with the fixed file size and instead allocate a buffer based on the size of it. The other issue was that there was no check to see if it was able to successfully parse that data. If it failed it would still try to access members and crash. So added that check

Memory leak : There was a bunch of places where memory was being allocated but never freed and so I tracked them down and added appropirate deallocation. A classic example was fprintf(target, "%s", cJSON_PrintUnformatted(root)); This can allocate upto 2KB of memory and the string is written into a file and ther is no one to deallocate it. Any free () or  cJSON_Delete() calls added were done to address this 

Missing ContainerLogs: 
1.  There are identical logs only one of them would show up in OMS depsite all being posted to ODS. To make each record unique I added query docker logs with timestamps so each record becomes unique. 
2.  There was a 1 second timeout for the rest api call which is not enough in some cases. So the call would timeout, and the code would move forward asssuming there was no data. To resolve this I added a sort of a retrial mechanism with an increasing timeout. It would make six tries at max ,every time multiplying the timeout by a factor of 2. The max timeout would be 64 seconds ~ 1minute. 
3. There is some latency between an application writing to stdout/stderr and it showing up in docker logs. I observed this to be around ~ 3minutes. I increased the log upload frequencey to 5 minutes and that took care of this. This makes sure that there is definitely some logs which if generated were processed by docker. 
4. The issue is the way the docker -provider handles the logs themseves. It uses a vector and pushes each record onto the end .Docker gives us the logs in a chronologically ascending order. Because the agent posts an entire batch at a time they all get the same TimeGenerated stamp. Since they all have the same timestamp the records appear in the order they were in the batch, earlier ones first. In order to get around this I used a deque instead and I add each record at the front. Switched to a double ended queue since its more efficient to add to the front compared to a vector.

@Microsoft/omsagent-devs @keikhara 