### PR TITLE
Adding journald support

### DIFF
--- a/source/code/providers/Container_ContainerLog_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerLog_Class_Provider.cpp
@@ -109,7 +109,8 @@ public:
         deque<Container_ContainerLog_Class> result;
 
         string logDriver = getLogDriverName();
-        if (logDriver.compare("json-file") != 0)
+        //Docker rest api endpoint supports both json-file and journald logging drivers
+        if ((logDriver.compare("json-file") != 0) && (logDriver.compare("journald") != 0))
         {
             return result;
         }


### PR DESCRIPTION
The docker rest endpoint supports both json-file and journald logging drivers. There is no difference in the rest response between the two and so just allowing journald driver
@Microsoft/omsagent-devs 