### PR TITLE
Use Container_HostInventory as test instead of Container_DaemonEvent

### DIFF
--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -9,7 +9,7 @@ ${{OMI_SERVICE}} reload
 ${{OMS_SERVICE}} reload
 
 if ${{PERFORMING_UPGRADE_NOT}}; then
-	/opt/omi/bin/omicli ei root/cimv2 Container_DaemonEvent
+	/opt/omi/bin/omicli ei root/cimv2 Container_HostInventory
 fi
 
 %Postuninstall_1000


### PR DESCRIPTION
The point of the test at the end of installation is to check if the provider lib was installed successfully. In case this is used in an environment where there are a bunch of containers running this results in a bunch of messages immediately after installation. The same result can be achieved by testing with Container_HostInventory and hence changing it . 
Example install message now 
chocoboy@chocoboyLnx:~$ sudo sh docker-cimprov-1.0.0-26.universal.x86_64.sh --install
Extracting...
Installing container agent ...
----- Installing package: docker-cimprov (docker-cimprov-1.0.0-26.universal.x86_64) -----
Selecting previously unselected package docker-cimprov.
(Reading database ... 513641 files and directories currently installed.)
Preparing to unpack docker-cimprov-1.0.0-26.universal.x86_64.deb ...
Unpacking docker-cimprov (1.0.0.26) ...
Setting up docker-cimprov (1.0.0.26) ...
instance of Container_HostInventory
{
    [Key] InstanceID=44ae54be-e6aa-432d-9bfb-13156a042ce9
    Computer=chocoboyLnx
    DockerVersion=17.06.0-ce
    OperatingSystem=Ubuntu 16.04.2 LTS
    Volume=local
    Network=bridge host macvlan null overlay
    NodeRole=Not Orchestrated
    OrchestratorType=None
}
@keikhara  please review and approve 