### PR TITLE
Fixes for Container_Process provider class & UTs

### DIFF
--- a/installer/conf/omi/container.reg
+++ b/installer/conf/omi/container.reg
@@ -7,3 +7,4 @@ CLASS=Container_DaemonEvent:CIM_ManagedElement
 CLASS=Container_ImageInventory:CIM_ManagedElement
 CLASS=Container_ContainerLog:CIM_ManagedElement
 CLASS=Container_HostInventory:CIM_ManagedElement
+CLASS=Container_Process:CIM_ManagedElement

--- a/test/code/providers/Container_ContainerInventory_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_ContainerInventory_Class_Provider_UnitTest.cpp
@@ -33,8 +33,10 @@ private:
 public:
     void setUp()
     {
-        // Get some images to use
         fputc('\n', stdout);
+        //delete all container
+        system("docker ps -a -q | xargs docker rm -f");
+        // Get some images to use
         TestHelper::RunCommand("docker pull hello-world");
         TestHelper::RunCommand("rm -f /var/opt/microsoft/docker-cimprov/state/ContainerInventory/*");
     }

--- a/test/code/providers/Container_ImageInventory_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_ImageInventory_Class_Provider_UnitTest.cpp
@@ -30,8 +30,11 @@ private:
 public:
     void setUp()
     {
-        // Get some images to use
         fputc('\n', stdout);
+        //clean up test environment 
+        system("docker ps -a -q | xargs docker rm -f");
+        system("docker images -q | xargs docker rmi ");
+        // Get some images to use
         TestHelper::RunCommand("docker pull hello-world");
         TestHelper::RunCommand("docker pull centos");
         TestHelper::RunCommand("rm -f /var/opt/microsoft/docker-cimprov/state/ImageInventory/*");

--- a/test/code/providers/Container_Process_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_Process_Class_Provider_UnitTest.cpp
@@ -25,6 +25,9 @@ public:
     {        
         processCmd.push_back(wstring(L"/bin/sh -c sleep inf;"));
         processCmd.push_back(wstring(L"sleep inf"));
+        fputc('\n', stdout);
+        //delete all running containers
+        system("docker ps -a -q | xargs docker rm -f");
     }
 
     void tearDown()
@@ -40,7 +43,7 @@ protected:
         vector<wstring> m_keyNames;
         m_keyNames.push_back(L"InstanceID");
 
-        TestHelper::RunCommand("docker run -d --name=k8s_cpt.sandboxname_cptpodname_cptnamepsace_cptid ubuntu /bin/sh -c \"sleep inf;\"");
+        system("docker run -d --name=k8s_cpt.sandboxname_cptpodname_cptnamepsace_cptid ubuntu /bin/sh -c \"sleep inf;\"");
 
         StandardTestEnumerateInstances<mi::Container_Process_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
         CPPUNIT_ASSERT_EQUAL(2, context.Size());        
@@ -62,7 +65,8 @@ protected:
             CPPUNIT_ASSERT(context[i].GetProperty(L"Id", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
             CPPUNIT_ASSERT_EQUAL(wstring(L"k8s_cpt.sandboxname_cptpodname_cptnamepsace_cptid"), context[i].GetProperty(L"Name", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
         }
-        TestHelper::RunCommand("docker rm -f k8s_cpt.sandboxname_cptpodname_cptnamepsace_cptid");
+        system("docker rm -f k8s_cpt.sandboxname_cptpodname_cptnamepsace_cptid");
+
     }
 
     void TestNonk8EnumerateInstances()
@@ -72,7 +76,7 @@ protected:
         vector<wstring> m_keyNames;
         m_keyNames.push_back(L"InstanceID");
 
-        TestHelper::RunCommand("docker run -d --name=ContainerProcessTest ubuntu /bin/sh -c \"sleep inf;\"");
+        system("docker run -d --name=ContainerProcessTest ubuntu /bin/sh -c \"sleep inf;\"");
 
         StandardTestEnumerateInstances<mi::Container_Process_Class_Provider>(m_keyNames, context, CALL_LOCATION(errMsg));
         CPPUNIT_ASSERT_EQUAL(2, context.Size());        
@@ -94,7 +98,7 @@ protected:
             CPPUNIT_ASSERT(context[i].GetProperty(L"Id", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
             CPPUNIT_ASSERT_EQUAL(wstring(L"ContainerProcessTest"),context[i].GetProperty(L"Name", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
         }
-        TestHelper::RunCommand("docker rm -f ContainerProcessTest");
+        system("docker rm -f ContainerProcessTest");
     }
 };
 


### PR DESCRIPTION
This PR has two commits:
1. Register the Container_Process class with OMI
2. Fix the unit tests so that they run with a clean envrionment. Helps make sure there are no traces of old test runs remaining

Verified  end-to-end