### PR TITLE
Add PodUid to ContainerProcess

### DIFF
--- a/source/code/mof/docker.mof
+++ b/source/code/mof/docker.mof
@@ -225,3 +225,57 @@ class Container_HostInventory : CIM_ManagedElement
 	[ Description ( "Cluster orchestator type" ) ]
 	String OrchestratorType;
 };
+
+// Container_Process
+// -------------------------------------------------------------------
+[   Version ( "1.0.0" ),
+	Description ( "Container process" )
+]
+class Container_Process : CIM_ManagedElement
+{
+	[ Key, Description ( "GUID" ) ]
+	String InstanceID;
+
+	[ Description ( "User ID number" ) ]
+	String Uid;
+
+	[ Description ( "Process ID" ) ]
+	String PID;
+
+	[ Description ( "Parent process ID" ) ]
+	String PPID;
+
+	[ Description ( "Cpu utilization" ) ]
+	String C;
+
+	[ Description ( "Host volume information" ) ]
+	String STIME;
+
+	[ Description ( "The device number of the controling tty" ) ]
+	String Tty;
+
+	[ Description ( "Time process was started" ) ]
+	String TIME;
+
+	[ Description ( "Name of executable" ) ]
+	String Cmd;
+	
+	[ Description ( "Cluster orchestator type" ) ]
+	String Id;
+	
+	[ Description ( "Container name" ) ]
+	String Name;
+	
+	[ Description ( "pod name" ) ]
+	String Pod;
+	
+	[ Description ( "Pod uuid" ) ]
+	String PodUid;
+	
+	[ Description ( "Namespace " ) ]
+	String Namespace;
+	
+	[ Description ( "Host name" ) ]
+	String Computer;
+};
+

--- a/source/code/providers/Container_Process.h
+++ b/source/code/providers/Container_Process.h
@@ -43,6 +43,7 @@ typedef struct _Container_Process /* extends CIM_ManagedElement */
     MI_ConstStringField Id;
     MI_ConstStringField Name;
     MI_ConstStringField Pod;
+    MI_ConstStringField PodUid;
     MI_ConstStringField Namespace;
     MI_ConstStringField Computer;
 }
@@ -616,13 +617,45 @@ MI_INLINE MI_Result MI_CALL Container_Process_Clear_Pod(
         14);
 }
 
-MI_INLINE MI_Result MI_CALL Container_Process_Set_Namespace(
+MI_INLINE MI_Result MI_CALL Container_Process_Set_PodUid(
     Container_Process* self,
     const MI_Char* str)
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
         15,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL Container_Process_SetPtr_PodUid(
+    Container_Process* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        15,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL Container_Process_Clear_PodUid(
+    Container_Process* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        15);
+}
+
+MI_INLINE MI_Result MI_CALL Container_Process_Set_Namespace(
+    Container_Process* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        16,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -634,7 +667,7 @@ MI_INLINE MI_Result MI_CALL Container_Process_SetPtr_Namespace(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        15,
+        16,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -645,7 +678,7 @@ MI_INLINE MI_Result MI_CALL Container_Process_Clear_Namespace(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        15);
+        16);
 }
 
 MI_INLINE MI_Result MI_CALL Container_Process_Set_Computer(
@@ -654,7 +687,7 @@ MI_INLINE MI_Result MI_CALL Container_Process_Set_Computer(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        16,
+        17,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -666,7 +699,7 @@ MI_INLINE MI_Result MI_CALL Container_Process_SetPtr_Computer(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        16,
+        17,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -677,7 +710,7 @@ MI_INLINE MI_Result MI_CALL Container_Process_Clear_Computer(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        16);
+        17);
 }
 
 /*
@@ -1243,6 +1276,46 @@ public:
     void Pod_clear()
     {
         const size_t n = offsetof(Self, Pod);
+        GetField<String>(n).Clear();
+    }
+
+    //
+    // Container_Process_Class.PodUid
+    //
+    
+    const Field<String>& PodUid() const
+    {
+        const size_t n = offsetof(Self, PodUid);
+        return GetField<String>(n);
+    }
+    
+    void PodUid(const Field<String>& x)
+    {
+        const size_t n = offsetof(Self, PodUid);
+        GetField<String>(n) = x;
+    }
+    
+    const String& PodUid_value() const
+    {
+        const size_t n = offsetof(Self, PodUid);
+        return GetField<String>(n).value;
+    }
+    
+    void PodUid_value(const String& x)
+    {
+        const size_t n = offsetof(Self, PodUid);
+        GetField<String>(n).Set(x);
+    }
+    
+    bool PodUid_exists() const
+    {
+        const size_t n = offsetof(Self, PodUid);
+        return GetField<String>(n).exists ? true : false;
+    }
+    
+    void PodUid_clear()
+    {
+        const size_t n = offsetof(Self, PodUid);
         GetField<String>(n).Clear();
     }
 

--- a/source/code/providers/Container_Process_Class_Provider.cpp
+++ b/source/code/providers/Container_Process_Class_Provider.cpp
@@ -11,6 +11,8 @@
 #include "../dockerapi/DockerRemoteApi.h"
 #include "../dockerapi/DockerRestHelper.h"
 
+#define EMPTYGUID "00000000-0000-0000-0000-000000000000"
+
 using namespace std;
 
 MI_BEGIN_NAMESPACE
@@ -58,7 +60,8 @@ public:
                 {
                     string containerId = string(cJSON_GetObjectItem(containerEntry, "Id")->valuestring);
                     string containerName;
-                    string containerPod;                    
+                    string containerPod;      
+                    string containerPodUid;              
                     string containerNamespace;
 
                     // Get container name
@@ -73,11 +76,13 @@ public:
                             //add namespace pod info
                             containerPod = containerMetaInformation[2];
                             containerNamespace = containerMetaInformation[3];
+                            containerPodUid = containerMetaInformation[4];
                         }
                         else
                         {
                             containerPod = "None";
                             containerNamespace = "None";
+                            containerPodUid = EMPTYGUID;
                         }
                     }
 
@@ -112,6 +117,7 @@ public:
                                     processInstance.Id_value(containerId.c_str());
                                     processInstance.Name_value(containerName.c_str());
                                     processInstance.Pod_value(containerPod.c_str());
+                                    processInstance.PodUid_value(containerPodUid.c_str());
                                     processInstance.Namespace_value(containerNamespace.c_str());
                                     processInstance.Computer_value(hostname.c_str());                                
                                 }

--- a/source/code/providers/schema.c
+++ b/source/code/providers/schema.c
@@ -1864,7 +1864,7 @@ static MI_CONST MI_PropertyDecl Container_Process_Tty_prop =
 static MI_CONST MI_PropertyDecl Container_Process_TIME_prop =
 {
     MI_FLAG_PROPERTY, /* flags */
-    0x00736509, /* code */
+    0x00746504, /* code */
     MI_T("TIME"), /* name */
     NULL, /* qualifiers */
     0, /* numQualifiers */
@@ -1945,6 +1945,23 @@ static MI_CONST MI_PropertyDecl Container_Process_Pod_prop =
     NULL,
 };
 
+/* property Container_Process.PodUid */
+static MI_CONST MI_PropertyDecl Container_Process_PodUid_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00706406, /* code */
+    MI_T("PodUid"), /* name */
+    NULL, /* qualifiers */
+    0, /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(Container_Process, PodUid), /* offset */
+    MI_T("Container_Process"), /* origin */
+    MI_T("Container_Process"), /* propagator */
+    NULL,
+};
+
 /* property Container_Process.Namespace */
 static MI_CONST MI_PropertyDecl Container_Process_Namespace_prop =
 {
@@ -1996,6 +2013,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST Container_Process_props[] =
     &Container_Process_Id_prop,
     &Container_Process_Name_prop,
     &Container_Process_Pod_prop,
+    &Container_Process_PodUid_prop,
     &Container_Process_Namespace_prop,
     &Container_Process_Computer_prop,
 };

--- a/test/code/providers/Container_Process_Class_Provider_UnitTest.cpp
+++ b/test/code/providers/Container_Process_Class_Provider_UnitTest.cpp
@@ -53,6 +53,7 @@ protected:
             wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
             CPPUNIT_ASSERT(instanceId.length());
             CPPUNIT_ASSERT_EQUAL(wstring(L"cptpodname"), context[i].GetProperty(L"Pod", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(wstring(L"cptid"), context[i].GetProperty(L"PodUid", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT_EQUAL(wstring(L"cptnamepsace"), context[i].GetProperty(L"Namespace", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT_EQUAL(wstring(L"root"), context[i].GetProperty(L"Uid", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT(context[i].GetProperty(L"PID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());
@@ -86,6 +87,7 @@ protected:
             wstring instanceId = context[i].GetProperty(L"InstanceID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg));
             CPPUNIT_ASSERT(instanceId.length());
             CPPUNIT_ASSERT_EQUAL(wstring(L"None"), context[i].GetProperty(L"Pod", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
+            CPPUNIT_ASSERT_EQUAL(wstring(L"00000000-0000-0000-0000-000000000000"), context[i].GetProperty(L"PodUid", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT_EQUAL(wstring(L"None"), context[i].GetProperty(L"Namespace", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT_EQUAL(wstring(L"root"),context[i].GetProperty(L"Uid", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)));
             CPPUNIT_ASSERT(context[i].GetProperty(L"PID", CALL_LOCATION(errMsg)).GetValue_MIString(CALL_LOCATION(errMsg)).length());


### PR DESCRIPTION
The purpose of this PR is to add a PodUid field to the ContainerProcess table. This is to enable joining the KubePodInventory table with ContainerProcess table on PodUid
Also added the mof modifications I had missed in the initial commit for Container_Process provider.