### PR TITLE
Update Disk Read/Write collector condition

### DIFF
--- a/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
+++ b/source/code/providers/Container_ContainerStatistics_Class_Provider.cpp
@@ -112,7 +112,7 @@ private:
                 bool readFlag = false;
                 bool writeFlag = false;
 
-                for (int i = 0; values && !readFlag && !writeFlag && i < cJSON_GetArraySize(values); i++)
+                for (int i = 0; values && !(readFlag && writeFlag) && i < cJSON_GetArraySize(values); i++)
                 {
                     cJSON* entry = cJSON_GetArrayItem(values, i);
 


### PR DESCRIPTION
Update Disk Read/Write collector condition only when both 'Read' and 'Write' bytes have been processed.