### PR TITLE
Update base_container.data

### DIFF
--- a/installer/datafiles/base_container.data
+++ b/installer/datafiles/base_container.data
@@ -29,8 +29,8 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/in_kube_events.rb;			    source/code/plugin/in_kube_events.rb;				644; root; root
 /opt/microsoft/omsagent/plugin/in_kube_logs.rb;                         source/code/plugin/in_kube_logs.rb;                                 644; root; root
 /opt/microsoft/omsagent/plugin/KubernetesApiClient.rb;			source/code/plugin/KubernetesApiClient.rb;			644; root; root
-/opt/microsoft/omsagent/plugin/in_containerlog_sudo_tail.rb;	source/code/plugin/in_containerlog_sudo_tail.rb;	644; root; root
-/opt/microsoft/omsagent/plugin/containerlogtailfilereader.rb;	source/code/plugin/containerlogtailfilereader.rb;	744; omsagent; root 
+/opt/microsoft/omsagent/plugin/in_containerlog_sudo_tail.rb;		source/code/plugin/in_containerlog_sudo_tail.rb;	644; root; root
+/opt/microsoft/omsagent/plugin/containerlogtailfilereader.rb;		source/code/plugin/containerlogtailfilereader.rb;	744; root; root 
 
 /etc/opt/microsoft/docker-cimprov/container.conf;			    installer/conf/container.conf;                      644; root; root
 


### PR DESCRIPTION
Since there is a possibility that 'omsagent' user is not present, we initialize the owner of the file as root.