### PR TITLE
Installer fixes

### DIFF
--- a/installer/datafiles/base_container.data
+++ b/installer/datafiles/base_container.data
@@ -69,6 +69,7 @@ MAINTAINER:              'Microsoft Corporation'
 /var/opt/microsoft/docker-cimprov/state;                755; root; root
 /var/opt/microsoft/docker-cimprov/state/ContainerInventory; 755; root; root
 /var/opt/microsoft/docker-cimprov/state/ImageInventory; 755; root; root
+/var/opt/microsoft/docker-cimprov/log;                  755; root; root
 
 %Dependencies
 
@@ -80,7 +81,8 @@ WriteInstallInfo() {
 WriteInstallInfo
 
 #Setup sudo permission for containerlogtailfilereader
-if [[ -z $(cat /etc/sudoers.d/omsagent | grep /containerlogtailfilereader.rb) ]]; then
+if [ -z $(cat /etc/sudoers.d/omsagent | grep /containerlogtailfilereader.rb) ]
+then
     chmod +w /etc/sudoers.d/omsagent
     echo "#run containerlogtailfilereader.rb for docker-provider" >> /etc/sudoers.d/omsagent
     echo "omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/containerlogtailfilereader.rb *" >> /etc/sudoers.d/omsagent
@@ -100,6 +102,10 @@ touch /var/opt/microsoft/docker-cimprov/state/KubeLogQueryState.yaml
 chmod 644 /var/opt/microsoft/docker-cimprov/state/KubeLogQueryState.yaml
 chown omsagent:omsagent /var/opt/microsoft/docker-cimprov/state/KubeLogQueryState.yaml
 
+touch /var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt
+chmod 666 /var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt
+chown omsagent:omiusers /var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt
+
 mv /etc/opt/microsoft/docker-cimprov/container.conf /etc/opt/microsoft/omsagent/sysconf/omsagent.d/container.conf
 chown omsagent:omsagent /etc/opt/microsoft/omsagent/sysconf/omsagent.d/container.conf
 
@@ -109,11 +115,26 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
    # Clean up installinfo.txt file (registered as "conf" file to pass rpmcheck)
    rm -f /etc/opt/microsoft/docker-cimprov/conf/installinfo.txt*
    rm -f /var/opt/microsoft/docker-cimprov/state/LastEventQueryTime.txt
+   rm -f /var/opt/microsoft/docker-cimprov/state/KubeEventQueryState.yaml
+   rm -f /var/opt/microsoft/docker-cimprov/state/KubeLogQueryState.yaml
+   rm -f /var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt
    rm -f /etc/opt/microsoft/omsagent/conf/omsagent.d/container.conf
+   rmdir /var/opt/microsoft/docker-cimprov/log 2> /dev/null
+   rmdir /var/opt/microsoft/docker-cimprov/state/ContainerInventory 2> /dev/null
+   rmdir /var/opt/microsoft/docker-cimprov/state/ImageInventory 2> /dev/null
+   rmdir /var/opt/microsoft/docker-cimprov/state 2> /dev/null
+   rmdir /var/opt/microsoft/docker-cimprov 2> /dev/null
    rmdir /etc/opt/microsoft/docker-cimprov/conf 2> /dev/null
    rmdir /etc/opt/microsoft/docker-cimprov 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
+   #Remove sudoers file edit
+   if [ -s /etc/sudoers.d/omsagent ]
+   then
+    chmod +w /etc/sudoers.d/omsagent
+    sed -i '/docker\-provider/,+1 d' /etc/sudoers.d/omsagent
+    chmod 440 /etc/sudoers.d/omsagent
+   fi
 fi
 
 %Preinstall_0

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -17,7 +17,7 @@ class KubernetesApiClient
         @@IsValidRunningNode = nil
         @@IsLinuxCluster = nil
         @@KubeSystemNamespace = "kube-system"
-        @LogPath = "/var/opt/microsoft/omsagent/log/kubernetes_client_log.txt"
+        @LogPath = "/var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt"
         @Log = Logger.new(@LogPath, 'weekly')
         @@TokenFileName = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         @@TokenStr = nil

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -87,7 +87,7 @@ module Fluent
             writeEventQueryState(newEventQueryState)
           rescue  => errorStr
             $log.warn line.dump, error: errorStr.to_s
-            $log.debug_backtrace(e.backtrace)
+            $log.debug_backtrace(errorStr.backtrace)
           end   
         else
           record = {}
@@ -131,7 +131,7 @@ module Fluent
         end
       rescue  => errorStr
         $log.warn $log.warn line.dump, error: errorStr.to_s
-        $log.debug_backtrace(e.backtrace)
+        $log.debug_backtrace(errorStr.backtrace)
       end
       return eventQueryState
     end
@@ -141,7 +141,7 @@ module Fluent
         File.write(@@KubeEventsStateFile, eventQueryState.to_yaml)
       rescue  => errorStr
         $log.warn $log.warn line.dump, error: errorStr.to_s
-        $log.debug_backtrace(e.backtrace)
+        $log.debug_backtrace(errorStr.backtrace)
       end
     end
 

--- a/source/code/plugin/in_kube_logs.rb
+++ b/source/code/plugin/in_kube_logs.rb
@@ -159,9 +159,9 @@ module Fluent
                 done = @finished
                 @mutex.unlock
                 if !done
-                    $log.info "calling enumerate"
+                    $log.debug "calling enumerate for KubeLogs"
                     enumerate
-                    $log.info "done with enumerate"
+                    $log.debug "done with enumerate for KubeLogs"
                 end
                 @mutex.lock
             end


### PR DESCRIPTION
This PR addresses the following things
1. Fixed a copy paste error in in_kube_events.rb . The debug_backtrace was using e instead of errorStr.
2. Modified the kube api client logging file to "/var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt". This accounts for a race condition where the omsagent is installed but /var/opt/microsoft/log directory isnt created yet because of which sometimes there are errors while loading KubernetesApiClient.rb . It doesnt have any impact towards functionality , however it shows up as an error in the omsagent log. Moving it docker-cimprov direcroty makes sense since the docker-provider has total control of that directory and the can create the necessary directory and files. 
3. Modified base_container.data to create /var/opt/microsoft/docker-cimprov/log/kubernetes_client_log.txt with appropriate permissions. 
4. Modified base_container.data to setup sudo permission for containerlogtailfilereader. It had been implemetned for a bash shell, however the installer uses a bourne shell instead and so the if condition would throw an error on run and not do the requisite. Changed it to be consistent with bourne shell. 
5. Modified base_container.data so as to clean up properly when run with --remove or --purge 
6. Modified in_kube_logs.rb to use debug log level instead of info. This makes it less verbose. 