### PR TITLE
Fixing parseNodeLimits failed: undefined local variable or method 

### DIFF
--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -270,7 +270,7 @@ class KubernetesApiClient
                             metricItem['DataItems'] = []
                             metricProps = {}
                             metricProps['Timestamp'] = metricTime
-                            metricProps['Host'] = hostName
+                            metricProps['Host'] = node['metadata']['name']
                             metricProps['ObjectName'] = "K8SNode"
                             metricProps['InstanceName'] = node['metadata']['name']
                             metricProps['Collections'] = []


### PR DESCRIPTION
Fixing the following error 
W, [2018-01-31T22:18:11.694502 #249]  WARN -- : parseNodeLimits failed: undefined local variable or method `hostName' for KubernetesApiClient:Class for metric allocatable cpu
W, [2018-01-31T22:18:11.694674 #249]  WARN -- : parseNodeLimits failed: undefined local variable or method `hostName' for KubernetesApiClient:Class for metric allocatable memory
