### PR TITLE
Fix Computer name for container request and limit perf counters

### DIFF
--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -232,7 +232,7 @@ class KubernetesApiClient
                                     
                                     metricProps = {}
                                     metricProps['Timestamp'] = metricTime
-                                    metricProps['Host'] = hostName
+                                    metricProps['Host'] = nodeName
                                     metricProps['ObjectName'] = "K8SContainer"
                                     metricProps['InstanceName'] = podUid + "/" + containerName
                                     
@@ -256,7 +256,7 @@ class KubernetesApiClient
                                         
                                         metricProps = {}
                                         metricProps['Timestamp'] = metricTime
-                                        metricProps['Host'] = hostName
+                                        metricProps['Host'] = nodeName
                                         metricProps['ObjectName'] = "K8SContainer"
                                         metricProps['InstanceName'] = podUid + "/" + containerName
                                         


### PR DESCRIPTION
Populate the Host field using the nodeName obtained from kube api to make sure container limit and request perf records are associated with the right nodes