### PR TITLE
Kaveesh/generic container log file path

### DIFF
--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -53,12 +53,11 @@
 # Container log
 # Example line which matches the format:
 # {"log"=>"Test 9th January\n", "stream"=>"stdout", "time"=>"2018-01-09T23:14:39.273429353Z", "ContainerID"=>"ee1ec26aa974af81b21fff24cef8ec78bf7ac1558b5de6f1eb1a5b28ecd6d559", "Image"=>"ubuntu", "Name"=>"determined_wilson", "SourceSystem"=>"Containers"}
-# NOTE: The TimeGeneratedByLog is just being appended in the begining of the LogEntry field. This is the actual time the log was generated and the TimeGenerated field in Kusto is different
 <source>
 	type containerlog_sudo_tail
 	pos_file /var/opt/microsoft/docker-cimprov/state/ContainerLogFile.pos.log
 	tag oms.container.log
-	format /\"log\"=>\"(?<LogEntry>.*)", \"stream\"=>\"(?<LogEntrySource>.*)", \"time\"=>\"(?<TimeGeneratedByLog>.*)", \"ContainerID\"=>\"(?<Id>.*)", \"Image\"=>\"(?<Image>.*)", \"Name\"=>\"(?<Name>.*)", \"SourceSystem\"=>\"(?<SourceSystem>.*)"}/
+	format /\"log\"=>\"(?<LogEntry>.*)", \"stream\"=>\"(?<LogEntrySource>.*)", \"time\"=>\"(?<LogTimeStamp>.*)", \"ContainerID\"=>\"(?<Id>.*)", \"Image\"=>\"(?<Image>.*)", \"Name\"=>\"(?<Name>.*)", \"SourceSystem\"=>\"(?<SourceSystem>.*)"}/
 	run_interval 15s
 </source>
 

--- a/source/code/plugin/filter_container_log.rb
+++ b/source/code/plugin/filter_container_log.rb
@@ -20,7 +20,6 @@ module Fluent
     
     def filter(tag, time, record)
       record['Computer'] =  @hostname
-      record['LogEntry'] = "#{record['TimeGeneratedByLog']} #{record['LogEntry']}"
       wrapper = {
                  "DataType"=>"CONTAINER_LOG_BLOB",
                  "IPName"=>"Containers",

--- a/source/code/plugin/in_containerlog_sudo_tail.rb
+++ b/source/code/plugin/in_containerlog_sudo_tail.rb
@@ -17,10 +17,6 @@ module Fluent
       @paths = []
       #This folder contains a list of all the containers running/stopped and we're using it to get all the container ID's which will be needed for the log file path below
       @containerIDFilePath = "/var/opt/microsoft/docker-cimprov/state/ContainerInventory/*"
-      #Using this to construct the file path for all every container json log file.
-      #Example container log file path -> /var/lib/docker/containers/{ContainerID}/{ContainerID}-json.log
-      #We have read permission on this file but don't have execute permission on the below mentioned path. Hence wildcard character searches to find the container ID's doesn't work.
-      @containerLogFilePath = "/var/lib/docker/containers/"
     end
 
     attr_accessor :command
@@ -113,7 +109,17 @@ module Fluent
       paths = ""
       Dir.glob(@containerIDFilePath).select { |p|
 	      cName = p.split('/').last;
-	      p = @containerLogFilePath + cName + "/" + cName + "-json.log"
+	      #Using docker inspect to find the generic log file path on all flavours of linux
+              #Example container log file path -> /var/lib/docker/containers/{ContainerID}/{ContainerID}-json.log
+              #We have read permission on this file but don't have execute permission on the below mentioned path. Hence wildcard character searches to find the container ID's doesn't work
+              begin
+                Open3.popen3("sudo docker inspect --format='{{.LogPath}}' #{cName}")  {|stdin, stdout, stderr|
+                p = stdout.gets
+              }
+              rescue
+                $log.warn "Error in popen3 docker inspect for log file path"
+              end
+              p = p.gsub("\n","")
 	      paths += readable_path(p) + " "
       }
       if !system("sudo test -r #{@pos_file}")


### PR DESCRIPTION
1. Update container.conf to use LogTimeStamp for the TimeGenerated
2. Use docker inspect to get generic log file path where docker stores the container logs
3. Remove TimeGenerated from in front of LogEntry
