### PR TITLE
* Rotate Log to 10 MB; keep last 2 logs for CAdvisor & Kube API logs

### DIFF
--- a/installer/conf/container.conf
+++ b/installer/conf/container.conf
@@ -87,6 +87,7 @@
 	type kubepodinventory
 	tag oms.api.KubePodInventory.CollectionTime
 	run_interval 60s
+  log_level trace
 </source>
 
 #Kubernetes perf
@@ -94,6 +95,7 @@
 	type kubeperf
 	tag oms.api.KubePerf
 	run_interval 60s
+  log_level trace
 </source>
 
 #Kubernetes events
@@ -101,6 +103,7 @@
 	type kubeevents
 	tag oms.api.KubeEvents.CollectionTime
 	run_interval 60s
+  log_level trace
 </source>
 
 #Kubernetes logs
@@ -115,6 +118,7 @@
 	type kubeservices
 	tag oms.api.KubeServices.CollectionTime
 	run_interval 60s
+  log_level trace
 </source>
 
 #Kubernetes Nodes
@@ -122,6 +126,7 @@
 	type kubenodeinventory
 	tag oms.api.KubeNodeInventory.CollectionTime
 	run_interval 60s
+  log_level trace
 </source>
 
 # Filter for correct format to endpoint
@@ -136,11 +141,13 @@
 
 <match oms.api.KubePodInventory**>
 	type out_oms_api
-	log_level debug
+	log_level trace
+  num_threads 5
 	buffer_chunk_limit 5m
 	buffer_type file
 	buffer_path %STATE_DIR_WS%/out_oms_api_kubepods*.buffer
 	buffer_queue_limit 10
+  buffer_queue_full_action drop_oldest_chunk
 	flush_interval 20s
 	retry_limit 10
 	retry_wait 30s
@@ -148,11 +155,13 @@
 
 <match oms.api.KubeEvents**>
 	type out_oms_api
-	log_level debug
+	log_level trace
+  num_threads 5
 	buffer_chunk_limit 5m
 	buffer_type file
 	buffer_path %STATE_DIR_WS%/out_oms_api_kubeevents*.buffer
 	buffer_queue_limit 10
+  buffer_queue_full_action drop_oldest_chunk
 	flush_interval 20s
 	retry_limit 10
 	retry_wait 30s
@@ -161,7 +170,7 @@
 <match oms.api.KubeLogs**>
 	type out_oms_api
 	log_level debug
-	buffer_chunk_limit 10m
+  buffer_chunk_limit 10m
 	buffer_type file
 	buffer_path %STATE_DIR_WS%/out_oms_api_kubernetes_logs*.buffer
 	buffer_queue_limit 10
@@ -223,11 +232,13 @@
 
 <match oms.container.log>
   type out_oms
-  log_level info
+  log_level trace
+  num_threads 5
   buffer_chunk_limit 20m
   buffer_type file
   buffer_path %STATE_DIR_WS%/out_oms_log*.buffer
   buffer_queue_limit 20
+  buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
   retry_limit 10
   retry_wait 15s
@@ -249,11 +260,13 @@
 
 <match oms.api.KubePerf**>	
   type out_oms
-  log_level info
+  log_level trace
+  num_threads 5
   buffer_chunk_limit 20m
   buffer_type file
   buffer_path %STATE_DIR_WS%/out_oms_kubeperf*.buffer
   buffer_queue_limit 20
+  buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
   retry_limit 10
   retry_wait 30s
@@ -262,11 +275,13 @@
 
 <match oms.api.KubeServices**>	  
   type out_oms_api
-  log_level info
+  log_level trace
+  num_threads 5
   buffer_chunk_limit 20m
   buffer_type file
   buffer_path %STATE_DIR_WS%/out_oms_kubeservices*.buffer
   buffer_queue_limit 20
+  buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
   retry_limit 10
   retry_wait 30s
@@ -275,11 +290,13 @@
 
 <match oms.api.KubeNodeInventory**>
   type out_oms_api
-  log_level info
+  log_level trace
+  num_threads 5
   buffer_chunk_limit 20m
   buffer_type file
   buffer_path %STATE_DIR_WS%/out_oms_kubenodes*.buffer
   buffer_queue_limit 20
+  buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
   retry_limit 10
   retry_wait 30s

--- a/source/code/plugin/CAdvisorMetricsAPIClient.rb
+++ b/source/code/plugin/CAdvisorMetricsAPIClient.rb
@@ -13,7 +13,7 @@ class CAdvisorMetricsAPIClient
             require_relative 'KubernetesApiClient'
     
             @LogPath = "/var/opt/microsoft/omsagent/log/kubernetes_perf_log.txt"
-            @Log = Logger.new(@LogPath, 'weekly')
+            @Log = Logger.new(@LogPath, 2, 10*1048576) #keep last 2 files, max log file size = 10M
             @@rxBytesLast = nil
             @@rxBytesTimeLast = nil
             @@txBytesLast = nil
@@ -65,10 +65,10 @@ class CAdvisorMetricsAPIClient
                         hostName = (OMS::Common.get_hostname)
                         metricInfo = JSON.parse(getSummaryStatsFromCAdvisor().body)
                         metricDataItems.concat(getContainerCpuMetricItems(metricInfo, hostName, "usageNanoCores","cpuUsageNanoCores"))
-                        metricDataItems.concat(getContainerMemoryMetricItems(metricInfo, hostName, "usageBytes", "memoryUsageBytes"))
+                        metricDataItems.concat(getContainerMemoryMetricItems(metricInfo, hostName, "workingSetBytes", "memoryUsageBytes"))
 
                         metricDataItems.push(getNodeMetricItem(metricInfo, hostName, "cpu", "usageNanoCores", "cpuUsageNanoCores"))
-                        metricDataItems.push(getNodeMetricItem(metricInfo, hostName, "memory", "usageBytes", "memoryUsageBytes"))
+                        metricDataItems.push(getNodeMetricItem(metricInfo, hostName, "memory", "workingSetBytes", "memoryUsageBytes"))
                         metricDataItems.push(getNodeMetricItem(metricInfo, hostName, "network", "rxBytes", "networkRxBytes"))
                         metricDataItems.push(getNodeMetricItem(metricInfo, hostName, "network", "txBytes", "networkTxBytes"))
                         metricDataItems.push(getNodeLastRebootTimeMetric(metricInfo, hostName, "restartTimeEpoch"))

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -114,7 +114,7 @@ module Fluent
               records.each do |record|
                 if !record.nil? 		
                   record['PodRestartCount'] = podRestartCount		
-                  $log.info record
+                  #$log.info record
                   router.emit(@tag, emitTime, record) 
                 end    		
               end       


### PR DESCRIPTION
* Rotate Log to 10 MB; keep last 2 logs for CAdvisor & Kube API logs
* Bump up #threads for output plugins to 5 (from 1)
* Increase log level to Trace for all Kube* plugins (to troubleshoot data stoppage issue)
* Remove noisy trace logs