### PR TITLE
Add frozen string directive and fix emitting of pod record

### DIFF
--- a/source/code/plugin/CAdvisorMetricsAPIClient.rb
+++ b/source/code/plugin/CAdvisorMetricsAPIClient.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 class CAdvisorMetricsAPIClient
     

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 class KubernetesApiClient
 

--- a/source/code/plugin/containerlogtailfilereader.rb
+++ b/source/code/plugin/containerlogtailfilereader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 require 'json'
 require 'logger'

--- a/source/code/plugin/filter_container.rb
+++ b/source/code/plugin/filter_container.rb
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 
+# frozen_string_literal: true
+
 module Fluent
 	require 'logger'
 

--- a/source/code/plugin/filter_container_log.rb
+++ b/source/code/plugin/filter_container_log.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fluent/filter'
 
 module Fluent

--- a/source/code/plugin/filter_docker_log.rb
+++ b/source/code/plugin/filter_docker_log.rb
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 
+# frozen_string_literal: true
+
 module Fluent
 	require 'logger'
 	require 'socket'

--- a/source/code/plugin/in_containerlog_sudo_tail.rb
+++ b/source/code/plugin/in_containerlog_sudo_tail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yajl'
 require 'fluent/input'
 require 'fluent/event'

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 module Fluent
 

--- a/source/code/plugin/in_kube_logs.rb
+++ b/source/code/plugin/in_kube_logs.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 module Fluent
 

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 module Fluent
 

--- a/source/code/plugin/in_kube_perf.rb
+++ b/source/code/plugin/in_kube_perf.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 module Fluent
     

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -129,9 +129,9 @@ module Fluent
                   eventStream.add(emitTime, record) if record 
                   #router.emit(@tag, emitTime, record) 
                 end    		
-              end
-              router.emit_stream(@tag, eventStream) if eventStream       
+              end      
             end
+            router.emit_stream(@tag, eventStream) if eventStream 
           end  
         rescue  => errorStr
           $log.warn "Failed to retrieve pod inventory: #{errorStr}"

--- a/source/code/plugin/in_kube_services.rb
+++ b/source/code/plugin/in_kube_services.rb
@@ -1,4 +1,5 @@
 #!/usr/local/bin/ruby
+# frozen_string_literal: true
 
 module Fluent
     


### PR DESCRIPTION
This PR has three fixes
1. Added the frozen strings directive so strings become immutable and so reduce the live object count
2. For kubepodinventory we were emitting the entire buffer for every pod. Was a bug. Moved it outside the pod parsing loop and emitting it only once now. 
3. Pick up pod config hash for some control-plane pods