### PR TITLE
Uptime and PodUid fixes

### DIFF
--- a/source/code/plugin/CAdvisorMetricsAPIClient.rb
+++ b/source/code/plugin/CAdvisorMetricsAPIClient.rb
@@ -296,8 +296,7 @@ class CAdvisorMetricsAPIClient
                         metricProps['Collections'] = []
                         metricCollections = {}
                         metricCollections['CounterName'] = metricNametoReturn
-                        #metricCollections['Value'] = DateTime.parse(metricValue).to_time.to_i
-                        #Try to read it from /proc/uptime
+                        #Read it from /proc/uptime
                         metricCollections['Value'] = DateTime.parse(metricTime).to_time.to_i - IO.read("/proc/uptime").split[0].to_f
 
                         metricProps['Collections'].push(metricCollections)

--- a/source/code/plugin/CAdvisorMetricsAPIClient.rb
+++ b/source/code/plugin/CAdvisorMetricsAPIClient.rb
@@ -173,6 +173,7 @@ class CAdvisorMetricsAPIClient
                         end
                         rescue => error
                         @Log.warn("getcontainerMemoryMetricItems failed: #{error} for metric #{memoryMetricNameToCollect}")
+                        @Log.warn metricJSON
                         return metricItems
                     end
                     return metricItems                      
@@ -208,6 +209,7 @@ class CAdvisorMetricsAPIClient
                         
                         rescue => error
                         @Log.warn("getNodeMetricItem failed: #{error} for metric #{metricNameToCollect}")
+                        @Log.warn metricJSON
                         return metricItem
                     end
                     return metricItem                      
@@ -264,6 +266,7 @@ class CAdvisorMetricsAPIClient
                         
                         rescue => error
                         @Log.warn("getNodeMetricItemRate failed: #{error} for metric #{metricNameToCollect}")
+                        @Log.warn metricJSON
                         return nil
                     end
                     return metricItem
@@ -293,13 +296,16 @@ class CAdvisorMetricsAPIClient
                         metricProps['Collections'] = []
                         metricCollections = {}
                         metricCollections['CounterName'] = metricNametoReturn
-                        metricCollections['Value'] = DateTime.parse(metricValue).to_time.to_i
+                        #metricCollections['Value'] = DateTime.parse(metricValue).to_time.to_i
+                        #Try to read it from /proc/uptime
+                        metricCollections['Value'] = DateTime.parse(metricTime).to_time.to_i - IO.read("/proc/uptime").split[0].to_f
 
                         metricProps['Collections'].push(metricCollections)
                         metricItem['DataItems'].push(metricProps)
                         
                         rescue => error
                         @Log.warn("getNodeLastRebootTimeMetric failed: #{error} ")
+                        @Log.warn metricJSON
                         return metricItem
                     end
                     return metricItem                      
@@ -341,6 +347,7 @@ class CAdvisorMetricsAPIClient
                         end
                         rescue => error
                         @Log.warn("getContainerStartTimeMetric failed: #{error} for metric #{metricNametoReturn}")
+                        @Log.warn metricJSON
                         return metricItems
                     end
                     return metricItems                       


### PR DESCRIPTION
This PR has the following changes.
1. Pick up uptime from /proc/uptime . The cAdvisor startTime is not the node reboot time. I found cases where the node was under pressure and was never actually rebooted but cAdvisor startTime changes. So reading it from .proc/uptime instead. Validated it with mutliple starts. Looks good.
2. For some control-plane pods we pick up the config hash as poduid. We made this change for PodInventory, however missed it for the limit metrics. This addresses it. 