### PR TITLE
Fix for mooncake (disable telemetry optionally)

### DIFF
--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -120,7 +120,7 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 	}
 
 	TelemetryClient = appinsights.NewTelemetryClient(string(decIkey))
-	telemetryOffSwitch = os.Getenv("DISABLE_TELEMETRY")
+	telemetryOffSwitch := os.Getenv("DISABLE_TELEMETRY")
 	if strings.Compare(strings.ToLower(telemetryOffSwitch), "true") == 0 {
 		Log("Appinsights telemetry is disabled \n")
 		TelemetryClient.SetIsEnabled(false)

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -120,6 +120,11 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 	}
 
 	TelemetryClient = appinsights.NewTelemetryClient(string(decIkey))
+	telemetryOffSwitch = os.Getenv("DISABLE_TELEMETRY")
+	if strings.Compare(strings.ToLower(telemetryOffSwitch), "true") == 0 {
+		Log("Appinsights telemetry is disabled \n")
+		TelemetryClient.SetIsEnabled(false)
+	}
 
 	CommonProperties = make(map[string]string)
 	CommonProperties["Computer"] = Computer

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -61,9 +61,16 @@ class ApplicationInsightsUtility
                 @@CustomProperties['AgentVersion'] = ENV[@@EnvAgentVersion]
                 @@CustomProperties['ControllerType'] = ENV[@@EnvControllerType]
                 encodedAppInsightsKey = ENV[@@EnvApplicationInsightsKey]
-                if !encodedAppInsightsKey.nil?
+
+                #Check if telemetry is turned off
+                telemetryOffSwitch = ENV['DISABLE_TELEMETRY']
+                if telemetryOffSwitch && !telemetryOffSwitch.nil? && !telemetryOffSwitch.empty? && telemetryOffSwitch.downcase == "true".downcase
+                    $log.warn("AppInsightsUtility: Telemetry is disabled")
+                    @@Tc = ApplicationInsights::TelemetryClient.new
+                elsif !encodedAppInsightsKey.nil?
                     decodedAppInsightsKey = Base64.decode64(encodedAppInsightsKey)
                     @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey
+                  
                 end
             rescue => errorStr
                 $log.warn("Exception in AppInsightsUtility: initilizeUtility - error: #{errorStr}")


### PR DESCRIPTION
Fix for mooncake (disable telemetry optionally)

*Doing this way, will not have to change in multiple places that sends telemetry.
*Also as per AppInsights, If no ikey (ruby) it will not create telemetry items 
* For Golang, it will collect but not send (as golang SDK will throw  errors if no ikey)

Check the below AppInsights Resource :
https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/692aea0b-2d89-4e7e-ae30-fffe40782ee2/resourceGroups/vishwamcTelemetry/providers/microsoft.insights/components/vishwamcTelemetry/overview

Check the below cluster :
https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/692aea0b-2d89-4e7e-ae30-fffe40782ee2/resourceGroups/vishwamcTelemetry/providers/Microsoft.ContainerService/managedClusters/vishwamcTelemetry/overview


Check the below workspace :
https://ms.portal.azure.com/#blade/Microsoft_OperationsManagementSuite_Workspace/AnalyticsBlade/initiator/WorkspaceLandingPage/scope/%7B%22resources%22%3A%5B%7B%22resourceId%22%3A%22%2Fsubscriptions%2F692aea0b-2d89-4e7e-ae30-fffe40782ee2%2Fresourcegroups%2Fvishwamctelemetry%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fvishwamctelemetry%22%7D%5D%7D/isQueryEditorVisible/true