### PR TITLE
Collect container last state

### DIFF
--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -317,6 +317,19 @@ module Fluent
                   record["ContainerStatusReason"] = containerStatus[containerStatus.keys[0]]["reason"]
                 end
               end
+
+              # Record the last state of the container. This may have information on why a container was killed.
+              if container["lastState"].keys.length > 0
+                lastStateName = container["lastState"].keys[0]
+                record["ContainerLastStatus"] = Hash.new
+                record["ContainerLastStatus"]["lastState"] = lastStateName  # get the name of the last state (ex: terminated)
+                record["ContainerLastStatus"]["reason"] = container["lastState"][lastStateName]["reason"]  # (ex: OOMKilled)
+                record["ContainerLastStatus"]["startedAt"] = container["lastState"][lastStateName]["startedAt"]  # (ex: 2019-07-02T14:58:51Z)
+                record["ContainerLastStatus"]["finishedAt"] = container["lastState"][lastStateName]["finishedAt"]  # (ex: 2019-07-02T14:58:52Z)
+              else
+                record["ContainerLastStatus"] = container["lastState"]  # this is an empty json hash (hashmap)
+              end
+
               podRestartCount += containerRestartCount
               records.push(record.dup)
 

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -319,15 +319,19 @@ module Fluent
               end
 
               # Record the last state of the container. This may have information on why a container was killed.
-              if container["lastState"].keys.length > 0
-                lastStateName = container["lastState"].keys[0]
+              begin 
+                if container["lastState"].keys.length > 0
+                  lastStateName = container["lastState"].keys[0]
+                  record["ContainerLastStatus"] = Hash.new
+                  record["ContainerLastStatus"]["lastState"] = lastStateName  # get the name of the last state (ex: terminated)
+                  record["ContainerLastStatus"]["reason"] = container["lastState"][lastStateName]["reason"]  # (ex: OOMKilled)
+                  record["ContainerLastStatus"]["startedAt"] = container["lastState"][lastStateName]["startedAt"]  # (ex: 2019-07-02T14:58:51Z)
+                  record["ContainerLastStatus"]["finishedAt"] = container["lastState"][lastStateName]["finishedAt"]  # (ex: 2019-07-02T14:58:52Z)
+                else
+                  record["ContainerLastStatus"] = Hash.new
+                end
+              rescue
                 record["ContainerLastStatus"] = Hash.new
-                record["ContainerLastStatus"]["lastState"] = lastStateName  # get the name of the last state (ex: terminated)
-                record["ContainerLastStatus"]["reason"] = container["lastState"][lastStateName]["reason"]  # (ex: OOMKilled)
-                record["ContainerLastStatus"]["startedAt"] = container["lastState"][lastStateName]["startedAt"]  # (ex: 2019-07-02T14:58:51Z)
-                record["ContainerLastStatus"]["finishedAt"] = container["lastState"][lastStateName]["finishedAt"]  # (ex: 2019-07-02T14:58:52Z)
-              else
-                record["ContainerLastStatus"] = container["lastState"]  # this is an empty hash
               end
 
               podRestartCount += containerRestartCount

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -327,7 +327,7 @@ module Fluent
                 record["ContainerLastStatus"]["startedAt"] = container["lastState"][lastStateName]["startedAt"]  # (ex: 2019-07-02T14:58:51Z)
                 record["ContainerLastStatus"]["finishedAt"] = container["lastState"][lastStateName]["finishedAt"]  # (ex: 2019-07-02T14:58:52Z)
               else
-                record["ContainerLastStatus"] = container["lastState"]  # this is an empty json hash (hashmap)
+                record["ContainerLastStatus"] = container["lastState"]  # this is an empty hash
               end
 
               podRestartCount += containerRestartCount


### PR DESCRIPTION
This PR adds the ContainerLastStatus field to KubePodInventory. It writes the fields lastState, reason, startedAt, and finishedAt from the `kubectl describe pod` command into ContainerLastStatus (as a Json object). If a pod has no last state then `{}` is written into the ContainerLastStatus field.

(tagging @ganga1980)