### PR TITLE
Reduce in_containerlog_sudo_tail shutdown time

### DIFF
--- a/source/code/plugin/in_containerlog_sudo_tail.rb
+++ b/source/code/plugin/in_containerlog_sudo_tail.rb
@@ -66,7 +66,8 @@ module Fluent
     end
 
     def shutdown
-      @finished = true 
+      @finished = true
+      @thread.kill
       @thread.join
     end
 


### PR DESCRIPTION
Your plugin in_containerlog_sudo_tail does create a thread with 15 seconds run interval and you are calling "@thread.join" in the shutdown which mean the shutdown will be delayed btw 1-to-15s

Thread will be mostly sleeping, so instead of waiting until the sleep complete we can Force the thread to exit before calling join.