### PR TITLE
Gangams/enable ai telemetry in mc

### DIFF
--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -42,6 +42,7 @@ const (
 	envAKSResourceID                                  = "AKS_RESOURCE_ID"
 	envACSResourceName                                = "ACS_RESOURCE_NAME"
 	envAppInsightsAuth                                = "APPLICATIONINSIGHTS_AUTH"
+	envAppInsightsEndpoint                            = "APPLICATIONINSIGHTS_ENDPOINT"
 	metricNameAvgFlushRate                            = "ContainerLogAvgRecordsFlushedPerSec"
 	metricNameAvgLogGenerationRate                    = "ContainerLogsGeneratedPerSec"
 	metricNameLogSize                                 = "ContainerLogsSize"
@@ -141,7 +142,9 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		return -1, err
 	}
 
-	TelemetryClient = appinsights.NewTelemetryClient(string(decIkey))
+	telemetryClientConfig :=  appinsights.NewTelemetryConfiguration(string(decIkey))
+	telemetryClientConfig.EndpointUrl = envAppInsightsEndpoint
+	TelemetryClient = appinsights.NewTelemetryClientFromConfig(telemetryClientConfig)
 	telemetryOffSwitch := os.Getenv("DISABLE_TELEMETRY")
 	if strings.Compare(strings.ToLower(telemetryOffSwitch), "true") == 0 {
 		Log("Appinsights telemetry is disabled \n")

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -72,10 +72,9 @@ class ApplicationInsightsUtility
           @@Tc = ApplicationInsights::TelemetryClient.new
         elsif !encodedAppInsightsKey.nil?
           decodedAppInsightsKey = Base64.decode64(encodedAppInsightsKey)
-          telemetryContext = ApplicationInsights::Channel::TelemetryContext.new
           telemetrySynchronousSender = ApplicationInsights::Channel::SynchronousSender.new appInsightsEndpoint
-          telemetrySynchronousQueue = ApplicationInsights::Channel::SynchronousQueue.new telemetrySynchronousSender
-          telemetryChannel = ApplicationInsights::Channel.TelemetryChannel.new telemetryContext, telemetrySynchronousQueue
+          telemetrySynchronousQueue = ApplicationInsights::Channel::SynchronousQueue.new(telemetrySynchronousSender)
+          telemetryChannel = ApplicationInsights::Channel::TelemetryChannel.new nil, telemetrySynchronousQueue
           @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey, telemetryChannel
         end
       rescue => errorStr


### PR DESCRIPTION
updated instance of telemetry client in go and ruby plugins to consume ai telemetry endpoint