### PR TITLE
Gangams/add telemetry hybrid

### DIFF
--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -240,15 +240,15 @@ class ApplicationInsightsUtility
           splitStrings = line.split("=")
           adminConf[splitStrings[0]] = splitStrings[1]
         end
-        workspaceDomain = adminConf["URL_TLD"]
+        workspaceDomain = adminConf["URL_TLD"].strip
         workspaceCloud = "AzureCloud"
         if workspaceDomain.casecmp("opinsights.azure.com") == 0
           workspaceCloud = "AzureCloud"
-        elsif wokrspaceDomain.casecmp("opinsights.azure.cn") == 0
+        elsif workspaceDomain.casecmp("opinsights.azure.cn") == 0
           workspaceCloud = "AzureChinaCloud"
-        elsif wokrspaceDomain.casecmp("opinsights.azure.us") == 0
+        elsif workspaceDomain.casecmp("opinsights.azure.us") == 0
           workspaceCloud = "AzureUSGovernment"
-        elsif wokrspaceDomain.casecmp("opinsights.azure.de") == 0
+        elsif workspaceDomain.casecmp("opinsights.azure.de") == 0
           workspaceCloud = "AzureGermanCloud"
         else
           workspaceCloud = "Unknown"

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -64,6 +64,7 @@ class ApplicationInsightsUtility
         @@CustomProperties["ControllerType"] = ENV[@@EnvControllerType]
         encodedAppInsightsKey = ENV[@@EnvApplicationInsightsKey]
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
+        @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud
 
         #Check if telemetry is turned off
         telemetryOffSwitch = ENV["DISABLE_TELEMETRY"]
@@ -228,6 +229,33 @@ class ApplicationInsightsUtility
         return workspaceId
       rescue => errorStr
         $log.warn("Exception in AppInsightsUtility: getWorkspaceId - error: #{errorStr}")
+      end
+    end
+
+    def getWorkspaceCloud()
+      begin
+        adminConf = {}
+        confFile = File.open(@OmsAdminFilePath, "r")
+        confFile.each_line do |line|
+          splitStrings = line.split("=")
+          adminConf[splitStrings[0]] = splitStrings[1]
+        end
+        workspaceDomain = adminConf["URL_TLD"]
+        workspaceCloud = "AzureCloud"
+        if workspaceDomain.casecmp("opinsights.azure.com") == 0
+          workspaceCloud = "AzureCloud"
+        elsif wokrspaceDomain.casecmp("opinsights.azure.cn") == 0
+          workspaceCloud = "AzureChinaCloud"
+        elsif wokrspaceDomain.casecmp("opinsights.azure.us") == 0
+          workspaceCloud = "AzureUSGovernment"
+        elsif wokrspaceDomain.casecmp("opinsights.azure.de") == 0
+          workspaceCloud = "AzureGermanCloud"
+        else
+          workspaceCloud = "Unknown"
+        end
+        return workspaceCloud
+      rescue => errorStr
+        $log.warn("Exception in AppInsightsUtility: getWorkspaceCloud - error: #{errorStr}")
       end
     end
   end

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -87,12 +87,12 @@ module Fluent
 
               if !items["spec"]["providerID"].nil? && !items["spec"]["providerID"].empty?
                 if File.file?(@@AzStackCloudFileName) # existence of this file indicates agent running on azstack
-                  record["ProviderID"] = "azurestack"
+                  record["KubernetesProviderID"] = "azurestack"
                 else
-                  record["ProviderID"] = items["spec"]["providerID"]
+                  record["KubernetesProviderID"] = items["spec"]["providerID"]
                 end
               else
-                record["ProviderID"] = "onprem"
+                record["KubernetesProviderID"] = "onprem"
               end
 
 
@@ -151,7 +151,7 @@ module Fluent
                 properties["KubeletVersion"] = record["KubeletVersion"]
                 properties["OperatingSystem"] = nodeInfo["operatingSystem"]
                 properties["DockerVersion"] = dockerVersion
-                properties["ProviderID"] = record["ProviderID"]
+                properties["KubernetesProviderID"] = record["KubernetesProviderID"]
                 properties["KernelVersion"] = nodeInfo["kernelVersion"]
                 properties["OSImage"] = nodeInfo["osImage"]
 

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -83,7 +83,13 @@ module Fluent
               record["CreationTimeStamp"] = items["metadata"]["creationTimestamp"]
               record["Labels"] = [items["metadata"]["labels"]]
               record["Status"] = ""
-              record["ProviderID"] = items["spec"]["providerID"]
+
+              if !items["spec"]["providerID"].nil? && !items["spec"]["providerID"].empty?
+                record["ProviderID"] = items["spec"]["providerID"]
+              else
+                record["ProviderID"] = "onprem"
+              end
+
 
               # Refer to https://kubernetes.io/docs/concepts/architecture/nodes/#condition for possible node conditions.
               # We check the status of each condition e.g. {"type": "OutOfDisk","status": "False"} . Based on this we

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -8,6 +8,7 @@ module Fluent
     @@ContainerNodeInventoryTag = "oms.containerinsights.ContainerNodeInventory"
     @@MDMKubeNodeInventoryTag = "mdm.kubenodeinventory"
     @@promConfigMountPath = "/etc/config/settings/prometheus-data-collection-settings"
+    @@AzStackCloudFileName = "/etc/kubernetes/host/azurestackcloud.json"
 
     @@rsPromInterval = ENV["TELEMETRY_RS_PROM_INTERVAL"]
     @@rsPromFieldPassCount = ENV["TELEMETRY_RS_PROM_FIELDPASS_LENGTH"]
@@ -85,7 +86,11 @@ module Fluent
               record["Status"] = ""
 
               if !items["spec"]["providerID"].nil? && !items["spec"]["providerID"].empty?
-                record["ProviderID"] = items["spec"]["providerID"]
+                if File.file?(@@AzStackCloudFileName) # existence of this file indicates agent running on azstack
+                  record["ProviderID"] = "azurestack"
+                else
+                  record["ProviderID"] = items["spec"]["providerID"]
+                end
               else
                 record["ProviderID"] = "onprem"
               end

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -83,6 +83,7 @@ module Fluent
               record["CreationTimeStamp"] = items["metadata"]["creationTimestamp"]
               record["Labels"] = [items["metadata"]["labels"]]
               record["Status"] = ""
+              record["ProviderID"] = items["spec"]["providerID"]
 
               # Refer to https://kubernetes.io/docs/concepts/architecture/nodes/#condition for possible node conditions.
               # We check the status of each condition e.g. {"type": "OutOfDisk","status": "False"} . Based on this we
@@ -139,6 +140,9 @@ module Fluent
                 properties["KubeletVersion"] = record["KubeletVersion"]
                 properties["OperatingSystem"] = nodeInfo["operatingSystem"]
                 properties["DockerVersion"] = dockerVersion
+                properties["ProviderID"] = record["ProviderID"]
+                properties["KernelVersion"] = nodeInfo["kernelVersion"]
+                properties["OSImage"] = nodeInfo["osImage"]
 
                 capacityInfo = items["status"]["capacity"]
                 ApplicationInsightsUtility.sendMetricTelemetry("NodeMemory", capacityInfo["memory"], properties)


### PR DESCRIPTION
This PR has the following changes 
 
   -  Added the ProviderID, KernelVersion and osImage as dimensions to node telemetry
   -  ProviderID field to Kube Node Inventory Table which will be used to show the cloud type in Ux

Note: 
1. ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>
2. still I am discussing with Azure stack team about detecting Azure stack since both Azure and Azurestack same cloud provider name (i.e.azure).
3. OnPrem K8s doesnt have the ProviderID so in the code ProviderID is hardcoded as "onprem".


