### PR TITLE
For ARO, stop collecting inventory of master and infra

### DIFF
--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -255,7 +255,7 @@ class KubernetesApiClient
     def getWindowsNodes
       winNodes = []
       begin
-        resourceUri = isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"
+        resourceUri = isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
         nodeInventory = JSON.parse(getKubeResourceInfo(resourceUri).body)
         @Log.info "KubernetesAPIClient::getWindowsNodes : Got nodes from kube api"
         # Resetting the windows node cache

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -374,9 +374,9 @@ class KubernetesApiClient
           end
 
           # For ARO, skip the pods scheduled on to master or infra nodes
-          if KubernetesApiClient.isAROCluster && !pods["spec"]["nodeName"].nil? &&
-            ( pods["spec"]["nodeName"].downcase.include?("infra-") ||
-             pods["spec"]["nodeName"].downcase.include?("master-") )
+          if isAROCluster && !pod["spec"]["nodeName"].nil? &&
+            ( pod["spec"]["nodeName"].downcase.include?("infra-") ||
+            pod["spec"]["nodeName"].downcase.include?("master-") )
             next
           end
 

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -158,7 +158,8 @@ class KubernetesApiClient
       @@IsAROCluster = false
       begin
         cluster = getClusterId
-        if cluster && !cluster.nil? && !cluster.empty? && cluster.downcase.include?("/microsoft.containerservice/openshiftmanagedclusters")
+        if cluster && !cluster.nil? && !cluster.empty? && 
+          cluster.downcase.include?("/microsoft.containerservice/openshiftmanagedclusters")
           @@IsAROCluster = true
         end
       rescue => error
@@ -373,7 +374,7 @@ class KubernetesApiClient
             podUid = pod["metadata"]["uid"]
           end
 
-          # For ARO, skip the pods scheduled on to master or infra nodes
+          # For ARO, skip the pods scheduled on to master or infra nodes to ingest
           if isAROCluster && !pod["spec"]["nodeName"].nil? &&
             ( pod["spec"]["nodeName"].downcase.include?("infra-") ||
             pod["spec"]["nodeName"].downcase.include?("master-") )

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -159,7 +159,7 @@ class KubernetesApiClient
       begin
         cluster = getClusterId
         if cluster && !cluster.nil? && !cluster.empty? && cluster.downcase.include?("/microsoft.containerservice/openshiftmanagedclusters")
-          @@IsAROCluster = true        
+          @@IsAROCluster = true
         end
       rescue => error
         @Log.warn("KubernetesApiClient::isAROCluster : isAROCluster failed #{error}")
@@ -255,7 +255,7 @@ class KubernetesApiClient
     def getWindowsNodes
       winNodes = []
       begin
-        resourceUri = isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
+        resourceUri = isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"
         nodeInventory = JSON.parse(getKubeResourceInfo(resourceUri).body)
         @Log.info "KubernetesAPIClient::getWindowsNodes : Got nodes from kube api"
         # Resetting the windows node cache
@@ -374,9 +374,11 @@ class KubernetesApiClient
           end
 
           # For ARO, skip the pods scheduled on to master or infra nodes
-          if KubernetesApiClient.isAROCluster && !pods["spec"]["nodeName"].nil? && ( pods["spec"]["nodeName"].downcase.include?("infra-") || pods["spec"]["nodeName"].downcase.include?("master-") )
+          if KubernetesApiClient.isAROCluster && !pods["spec"]["nodeName"].nil? &&
+            ( pods["spec"]["nodeName"].downcase.include?("infra-") ||
+             pods["spec"]["nodeName"].downcase.include?("master-") )
             next
-          end  
+          end
 
 
           podContainers = []

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -158,8 +158,7 @@ class KubernetesApiClient
       @@IsAROCluster = false
       begin
         cluster = getClusterId
-        if cluster && !cluster.nil? && !cluster.empty? && 
-          cluster.downcase.include?("/microsoft.containerservice/openshiftmanagedclusters")
+        if !cluster.nil? && !cluster.empty? && cluster.downcase.include?("/microsoft.containerservice/openshiftmanagedclusters")
           @@IsAROCluster = true
         end
       rescue => error
@@ -375,7 +374,7 @@ class KubernetesApiClient
           end
 
           # For ARO, skip the pods scheduled on to master or infra nodes to ingest
-          if isAROCluster && !pod["spec"]["nodeName"].nil? &&
+          if isAROCluster && !pod["spec"].nil? && !pod["spec"]["nodeName"].nil? &&
             ( pod["spec"]["nodeName"].downcase.include?("infra-") ||
             pod["spec"]["nodeName"].downcase.include?("master-") )
             next

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -373,6 +373,12 @@ class KubernetesApiClient
             podUid = pod["metadata"]["uid"]
           end
 
+          # For ARO, skip the pods scheduled on to master or infra nodes
+          if KubernetesApiClient.isAROCluster && !pods["spec"]["nodeName"].nil? && ( pods["spec"]["nodeName"].downcase.include?("infra-") || pods["spec"]["nodeName"].downcase.include?("master-") )
+            next
+          end  
+
+
           podContainers = []
           if !pod["spec"]["containers"].nil? && !pod["spec"]["containers"].empty?
             podContainers = podContainers + pod["spec"]["containers"]

--- a/source/code/plugin/KubernetesApiClient.rb
+++ b/source/code/plugin/KubernetesApiClient.rb
@@ -375,8 +375,8 @@ class KubernetesApiClient
 
           # For ARO, skip the pods scheduled on to master or infra nodes to ingest
           if isAROCluster && !pod["spec"].nil? && !pod["spec"]["nodeName"].nil? &&
-            ( pod["spec"]["nodeName"].downcase.include?("infra-") ||
-            pod["spec"]["nodeName"].downcase.include?("master-") )
+            ( pod["spec"]["nodeName"].downcase.start_with?("infra-") ||
+            pod["spec"]["nodeName"].downcase.start_with?("master-") )
             next
           end
 

--- a/source/code/plugin/filter_cadvisor2mdm.rb
+++ b/source/code/plugin/filter_cadvisor2mdm.rb
@@ -145,7 +145,12 @@ module Fluent
             end
 
             begin
-                nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("nodes?fieldSelector=metadata.name%3D#{@@hostName}").body)
+                resourceUri = "nodes?fieldSelector=metadata.name%3D#{@@hostName}"
+                if KubernetesApiClient.isAROCluster 
+                    # only get the compute nodes for ARO cluster
+                    resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
+                end
+                nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
             rescue Exception => e
                 @log.info "Error when getting nodeInventory from kube API. Exception: #{e.class} Message: #{e.message} "
                 ApplicationInsightsUtility.sendExceptionTelemetry(e.backtrace)

--- a/source/code/plugin/filter_cadvisor2mdm.rb
+++ b/source/code/plugin/filter_cadvisor2mdm.rb
@@ -148,7 +148,7 @@ module Fluent
                 resourceUri = "nodes?fieldSelector=metadata.name%3D#{@@hostName}"
                 # For ARO, filter out all other node roles other than compute
                 if KubernetesApiClient.isAROCluster
-                    resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
+                    resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue"
                 end
                 nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
             rescue Exception => e

--- a/source/code/plugin/filter_cadvisor2mdm.rb
+++ b/source/code/plugin/filter_cadvisor2mdm.rb
@@ -145,11 +145,7 @@ module Fluent
             end
 
             begin
-                resourceUri = "nodes?fieldSelector=metadata.name%3D#{@@hostName}"
-                # For ARO, filter out all other node roles other than compute
-                if KubernetesApiClient.isAROCluster
-                    resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue"
-                end
+                resourceUri = KubernetesApiClient.getNodesResourceUri("nodes?fieldSelector=metadata.name%3D#{@@hostName}")
                 nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
             rescue Exception => e
                 @log.info "Error when getting nodeInventory from kube API. Exception: #{e.class} Message: #{e.message} "

--- a/source/code/plugin/filter_cadvisor2mdm.rb
+++ b/source/code/plugin/filter_cadvisor2mdm.rb
@@ -147,7 +147,7 @@ module Fluent
             begin
                 resourceUri = "nodes?fieldSelector=metadata.name%3D#{@@hostName}"
                 # For ARO, filter out all other node roles other than compute
-                if KubernetesApiClient.isAROCluster                    
+                if KubernetesApiClient.isAROCluster
                     resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
                 end
                 nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)

--- a/source/code/plugin/filter_cadvisor2mdm.rb
+++ b/source/code/plugin/filter_cadvisor2mdm.rb
@@ -146,8 +146,8 @@ module Fluent
 
             begin
                 resourceUri = "nodes?fieldSelector=metadata.name%3D#{@@hostName}"
-                if KubernetesApiClient.isAROCluster 
-                    # only get the compute nodes for ARO cluster
+                # For ARO, filter out all other node roles other than compute
+                if KubernetesApiClient.isAROCluster                    
                     resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
                 end
                 nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)

--- a/source/code/plugin/health/health_monitor_utils.rb
+++ b/source/code/plugin/health/health_monitor_utils.rb
@@ -161,6 +161,7 @@ module HealthModel
             def get_cluster_cpu_memory_capacity(log, node_inventory: nil)
                 begin
                     if node_inventory.nil?
+                        # For ARO, filter out all other node roles other than compute
                         resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
                         node_inventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     end
@@ -208,6 +209,7 @@ module HealthModel
                 end
 
                 begin
+                    # For ARO, filter out all other node roles other than compute
                     resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     if !hostName.nil?
@@ -274,7 +276,7 @@ module HealthModel
 
                 log.info "CPU and Memory Capacity Not set"
                 begin
-                    # only get for compute nodes for ARO cluster
+                    # For ARO, filter out all other node roles other than compute
                     resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue" : "nodes"                   
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                 rescue Exception => e

--- a/source/code/plugin/health/health_monitor_utils.rb
+++ b/source/code/plugin/health/health_monitor_utils.rb
@@ -161,8 +161,7 @@ module HealthModel
             def get_cluster_cpu_memory_capacity(log, node_inventory: nil)
                 begin
                     if node_inventory.nil?
-                        # For ARO, filter out all other node roles other than compute
-                        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
+                        resourceUri = KubernetesApiClient.getNodesResourceUri("nodes")
                         node_inventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     end
                     cluster_cpu_capacity = 0.0
@@ -209,8 +208,7 @@ module HealthModel
                 end
 
                 begin
-                    # For ARO, filter out all other node roles other than compute
-                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
+                    resourceUri = KubernetesApiClient.getNodesResourceUri("nodes")
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     if !hostName.nil?
                         podInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=spec.nodeName%3D#{hostName}").body)
@@ -276,8 +274,7 @@ module HealthModel
 
                 log.info "CPU and Memory Capacity Not set"
                 begin
-                    # For ARO, filter out all other node roles other than compute
-                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue" : "nodes"
+                    resourceUri = KubernetesApiClient.getNodesResourceUri("nodes")
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                 rescue Exception => e
                     log.info "Error when getting nodeInventory from kube API. Exception: #{e.class} Message: #{e.message} "

--- a/source/code/plugin/health/health_monitor_utils.rb
+++ b/source/code/plugin/health/health_monitor_utils.rb
@@ -162,7 +162,7 @@ module HealthModel
                 begin
                     if node_inventory.nil?
                         # For ARO, filter out all other node roles other than compute
-                        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
+                        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
                         node_inventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     end
                     cluster_cpu_capacity = 0.0
@@ -210,7 +210,7 @@ module HealthModel
 
                 begin
                     # For ARO, filter out all other node roles other than compute
-                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
+                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     if !hostName.nil?
                         podInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=spec.nodeName%3D#{hostName}").body)
@@ -277,7 +277,7 @@ module HealthModel
                 log.info "CPU and Memory Capacity Not set"
                 begin
                     # For ARO, filter out all other node roles other than compute
-                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue" : "nodes"                   
+                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue" : "nodes"
                     @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                 rescue Exception => e
                     log.info "Error when getting nodeInventory from kube API. Exception: #{e.class} Message: #{e.message} "

--- a/source/code/plugin/health/health_monitor_utils.rb
+++ b/source/code/plugin/health/health_monitor_utils.rb
@@ -161,7 +161,8 @@ module HealthModel
             def get_cluster_cpu_memory_capacity(log, node_inventory: nil)
                 begin
                     if node_inventory.nil?
-                        node_inventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("nodes").body)
+                        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
+                        node_inventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     end
                     cluster_cpu_capacity = 0.0
                     cluster_memory_capacity = 0.0
@@ -207,7 +208,8 @@ module HealthModel
                 end
 
                 begin
-                    @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("nodes").body)
+                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"                       
+                    @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                     if !hostName.nil?
                         podInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=spec.nodeName%3D#{hostName}").body)
                     else
@@ -272,7 +274,9 @@ module HealthModel
 
                 log.info "CPU and Memory Capacity Not set"
                 begin
-                    @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo("nodes").body)
+                    # only get for compute nodes for ARO cluster
+                    resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue" : "nodes"                   
+                    @@nodeInventory = JSON.parse(KubernetesApiClient.getKubeResourceInfo(resourceUri).body)
                 rescue Exception => e
                     log.info "Error when getting nodeInventory from kube API. Exception: #{e.class} Message: #{e.message} "
                     ApplicationInsightsUtility.sendExceptionTelemetry(e.backtrace)

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -103,8 +103,8 @@ module Fluent
           end
 
           nodeName = items["source"].key?("host") ? items["source"]["host"] : (OMS::Common.get_hostname)
-          # For ARO, drop the master and infra node sourced events to ingest
-          if KubernetesApiClient.isAROCluster && !nodeName.nil? && !nodeName.empty? &&
+          # For ARO v3 cluster, drop the master and infra node sourced events to ingest
+          if KubernetesApiClient.isAROV3Cluster && !nodeName.nil? && !nodeName.empty? &&
              ( nodeName.downcase.start_with?("infra-") || nodeName.downcase.start_with?("master-") )
             next
           end

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -104,9 +104,8 @@ module Fluent
 
           nodeName = items["source"].key?("host") ? items["source"]["host"] : (OMS::Common.get_hostname)
           # For ARO, drop the master and infra node sourced events to ingest
-          if KubernetesApiClient.isAROCluster && (
-             nodeName.downcase.include?("infra-") ||
-             nodeName.downcase.include?("master-") )
+          if KubernetesApiClient.isAROCluster && !nodeName.nil? && !nodeName.empty? &&
+             ( nodeName.downcase.include?("infra-") || nodeName.downcase.include?("master-") )
             next
           end
 

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -105,7 +105,7 @@ module Fluent
           nodeName = items["source"].key?("host") ? items["source"]["host"] : (OMS::Common.get_hostname)
           # For ARO, drop the master and infra node sourced events to ingest
           if KubernetesApiClient.isAROCluster && !nodeName.nil? && !nodeName.empty? &&
-             ( nodeName.downcase.include?("infra-") || nodeName.downcase.include?("master-") )
+             ( nodeName.downcase.start_with?("infra-") || nodeName.downcase.start_with?("master-") )
             next
           end
 

--- a/source/code/plugin/in_kube_events.rb
+++ b/source/code/plugin/in_kube_events.rb
@@ -103,7 +103,7 @@ module Fluent
           end
 
           nodeName = items["source"].key?("host") ? items["source"]["host"] : (OMS::Common.get_hostname)
-          # For ARO, drop the master and infra node sourced events
+          # For ARO, drop the master and infra node sourced events to ingest
           if KubernetesApiClient.isAROCluster && (
              nodeName.downcase.include?("infra-") ||
              nodeName.downcase.include?("master-") )

--- a/source/code/plugin/in_kube_health.rb
+++ b/source/code/plugin/in_kube_health.rb
@@ -86,7 +86,7 @@ module Fluent
         #HealthMonitorUtils.refresh_kubernetes_api_data(@@hmlog, nil)
         # we do this so that if the call fails, we get a response code/header etc.
         # For ARO, filter out all other node roles other than compute
-        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
+        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")
@@ -302,7 +302,7 @@ module Fluent
     def initialize_inventory
         #this is required because there are other components, like the container cpu memory aggregator, that depends on the mapping being initialized
         # For ARO, filter out all other node roles other than compute
-        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
+        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")

--- a/source/code/plugin/in_kube_health.rb
+++ b/source/code/plugin/in_kube_health.rb
@@ -85,8 +85,7 @@ module Fluent
 
         #HealthMonitorUtils.refresh_kubernetes_api_data(@@hmlog, nil)
         # we do this so that if the call fails, we get a response code/header etc.
-        # For ARO, filter out all other node roles other than compute
-        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
+        resourceUri = KubernetesApiClient.getNodesResourceUri("nodes")
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")
@@ -301,8 +300,7 @@ module Fluent
 
     def initialize_inventory
         #this is required because there are other components, like the container cpu memory aggregator, that depends on the mapping being initialized
-        # For ARO, filter out all other node roles other than compute
-        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue": "nodes"
+        resourceUri = KubernetesApiClient.getNodesResourceUri("nodes")
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")

--- a/source/code/plugin/in_kube_health.rb
+++ b/source/code/plugin/in_kube_health.rb
@@ -85,6 +85,7 @@ module Fluent
 
         #HealthMonitorUtils.refresh_kubernetes_api_data(@@hmlog, nil)
         # we do this so that if the call fails, we get a response code/header etc.
+        # For ARO, filter out all other node roles other than compute
         resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
@@ -300,6 +301,7 @@ module Fluent
 
     def initialize_inventory
         #this is required because there are other components, like the container cpu memory aggregator, that depends on the mapping being initialized
+        # For ARO, filter out all other node roles other than compute
         resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
         node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))

--- a/source/code/plugin/in_kube_health.rb
+++ b/source/code/plugin/in_kube_health.rb
@@ -85,7 +85,8 @@ module Fluent
 
         #HealthMonitorUtils.refresh_kubernetes_api_data(@@hmlog, nil)
         # we do this so that if the call fails, we get a response code/header etc.
-        node_inventory_response = KubernetesApiClient.getKubeResourceInfo("nodes")
+        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
+        node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")
         pod_inventory = Yajl::Parser.parse(StringIO.new(pod_inventory_response.body))
@@ -299,7 +300,8 @@ module Fluent
 
     def initialize_inventory
         #this is required because there are other components, like the container cpu memory aggregator, that depends on the mapping being initialized
-        node_inventory_response = KubernetesApiClient.getKubeResourceInfo("nodes")
+        resourceUri = KubernetesApiClient.isAROCluster ? "nodes?labelSelector=node-role.kubernetes.io/compute%3Dtrue": "nodes"   
+        node_inventory_response = KubernetesApiClient.getKubeResourceInfo(resourceUri)
         node_inventory = Yajl::Parser.parse(StringIO.new(node_inventory_response.body))
         pod_inventory_response = KubernetesApiClient.getKubeResourceInfo("pods?fieldSelector=metadata.namespace%3D#{@@KubeInfraNamespace}")
         pod_inventory = Yajl::Parser.parse(StringIO.new(pod_inventory_response.body))

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -74,7 +74,7 @@ module Fluent
           # only get the compute nodes for ARO cluster
           resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
         end
-        continuationToken, nodeInventory = KubernetesApiClient.KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)        
+        continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)        
         
         $log.info("in_kube_nodes::enumerate : Done getting nodes from Kube API @ #{Time.now.utc.iso8601}")
         if (!nodeInventory.nil? && !nodeInventory.empty? && nodeInventory.key?("items") && !nodeInventory["items"].nil? && !nodeInventory["items"].empty?)

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -69,11 +69,7 @@ module Fluent
         # Initializing continuation token to nil
         continuationToken = nil
         $log.info("in_kube_nodes::enumerate : Getting nodes from Kube API @ #{Time.now.utc.iso8601}")
-        resourceUri = "nodes?limit=#{@NODES_CHUNK_SIZE}"
-        # For ARO, filter out all other node roles other than compute
-        if KubernetesApiClient.isAROCluster
-          resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue"
-        end
+        resourceUri = KubernetesApiClient.getNodesResourceUri("nodes?limit=#{@NODES_CHUNK_SIZE}")
         continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)
 
         $log.info("in_kube_nodes::enumerate : Done getting nodes from Kube API @ #{Time.now.utc.iso8601}")

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -69,7 +69,13 @@ module Fluent
         # Initializing continuation token to nil
         continuationToken = nil
         $log.info("in_kube_nodes::enumerate : Getting nodes from Kube API @ #{Time.now.utc.iso8601}")
-        continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken("nodes?limit=#{@NODES_CHUNK_SIZE}")
+        resourceUri = "nodes?limit=#{@NODES_CHUNK_SIZE}"
+        if KubernetesApiClient.isAROCluster 
+          # only get the compute nodes for ARO cluster
+          resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
+        end
+        continuationToken, nodeInventory = KubernetesApiClient.KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)        
+        
         $log.info("in_kube_nodes::enumerate : Done getting nodes from Kube API @ #{Time.now.utc.iso8601}")
         if (!nodeInventory.nil? && !nodeInventory.empty? && nodeInventory.key?("items") && !nodeInventory["items"].nil? && !nodeInventory["items"].empty?)
           parse_and_emit_records(nodeInventory, batchTime)
@@ -78,8 +84,8 @@ module Fluent
         end
 
         #If we receive a continuation token, make calls, process and flush data until we have processed all data
-        while (!continuationToken.nil? && !continuationToken.empty?)
-          continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken("nodes?limit=#{@NODES_CHUNK_SIZE}&continue=#{continuationToken}")
+        while (!continuationToken.nil? && !continuationToken.empty?)         
+          continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken(resourceUri + "&continue=#{continuationToken}")
           if (!nodeInventory.nil? && !nodeInventory.empty? && nodeInventory.key?("items") && !nodeInventory["items"].nil? && !nodeInventory["items"].empty?)
             parse_and_emit_records(nodeInventory, batchTime)
           else

--- a/source/code/plugin/in_kube_nodes.rb
+++ b/source/code/plugin/in_kube_nodes.rb
@@ -71,11 +71,11 @@ module Fluent
         $log.info("in_kube_nodes::enumerate : Getting nodes from Kube API @ #{Time.now.utc.iso8601}")
         resourceUri = "nodes?limit=#{@NODES_CHUNK_SIZE}"
         # For ARO, filter out all other node roles other than compute
-        if KubernetesApiClient.isAROCluster         
-          resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io/compute%3Dtrue"
+        if KubernetesApiClient.isAROCluster
+          resourceUri = resourceUri + "&labelSelector=node-role.kubernetes.io%2Fcompute%3Dtrue"
         end
-        continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)        
-        
+        continuationToken, nodeInventory = KubernetesApiClient.getResourcesAndContinuationToken(resourceUri)
+
         $log.info("in_kube_nodes::enumerate : Done getting nodes from Kube API @ #{Time.now.utc.iso8601}")
         if (!nodeInventory.nil? && !nodeInventory.empty? && nodeInventory.key?("items") && !nodeInventory["items"].nil? && !nodeInventory["items"].empty?)
           parse_and_emit_records(nodeInventory, batchTime)

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -265,8 +265,8 @@ module Fluent
           record["Name"] = items["metadata"]["name"]
           podNameSpace = items["metadata"]["namespace"]
 
-          # For ARO, skip the pods scheduled on to master or infra nodes
-          if KubernetesApiClient.isAROCluster && !items["spec"].nil? && !items["spec"]["nodeName"].nil? &&
+          # For ARO v3 cluster, skip the pods scheduled on to master or infra nodes
+          if KubernetesApiClient.isAROV3Cluster && !items["spec"].nil? && !items["spec"]["nodeName"].nil? &&
              ( items["spec"]["nodeName"].downcase.start_with?("infra-") ||
               items["spec"]["nodeName"].downcase.start_with?("master-") )
             next

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -265,6 +265,11 @@ module Fluent
           record["Name"] = items["metadata"]["name"]
           podNameSpace = items["metadata"]["namespace"]
 
+          # For ARO, skip the pods scheduled on to master or infra nodes
+          if KubernetesApiClient.isAROCluster && !items["spec"]["nodeName"].nil? && ( items["spec"]["nodeName"].downcase.include?("infra-") || items["spec"]["nodeName"].downcase.include?("master-") )
+            next
+          end  
+
           if podNameSpace.eql?("kube-system") && !items["metadata"].key?("ownerReferences")
             # The above case seems to be the only case where you have horizontal scaling of pods
             # but no controller, in which case cAdvisor picks up kubernetes.io/config.hash

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -266,7 +266,7 @@ module Fluent
           podNameSpace = items["metadata"]["namespace"]
 
           # For ARO, skip the pods scheduled on to master or infra nodes
-          if KubernetesApiClient.isAROCluster && !items["spec"]["nodeName"].nil? &&
+          if KubernetesApiClient.isAROCluster && !items["spec"].nil? && !items["spec"]["nodeName"].nil? &&
              ( items["spec"]["nodeName"].downcase.include?("infra-") ||
               items["spec"]["nodeName"].downcase.include?("master-") )
             next

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -266,9 +266,11 @@ module Fluent
           podNameSpace = items["metadata"]["namespace"]
 
           # For ARO, skip the pods scheduled on to master or infra nodes
-          if KubernetesApiClient.isAROCluster && !items["spec"]["nodeName"].nil? && ( items["spec"]["nodeName"].downcase.include?("infra-") || items["spec"]["nodeName"].downcase.include?("master-") )
+          if KubernetesApiClient.isAROCluster && !items["spec"]["nodeName"].nil? &&
+             ( items["spec"]["nodeName"].downcase.include?("infra-") ||
+              items["spec"]["nodeName"].downcase.include?("master-") )
             next
-          end  
+          end
 
           if podNameSpace.eql?("kube-system") && !items["metadata"].key?("ownerReferences")
             # The above case seems to be the only case where you have horizontal scaling of pods

--- a/source/code/plugin/in_kube_podinventory.rb
+++ b/source/code/plugin/in_kube_podinventory.rb
@@ -267,8 +267,8 @@ module Fluent
 
           # For ARO, skip the pods scheduled on to master or infra nodes
           if KubernetesApiClient.isAROCluster && !items["spec"].nil? && !items["spec"]["nodeName"].nil? &&
-             ( items["spec"]["nodeName"].downcase.include?("infra-") ||
-              items["spec"]["nodeName"].downcase.include?("master-") )
+             ( items["spec"]["nodeName"].downcase.start_with?("infra-") ||
+              items["spec"]["nodeName"].downcase.start_with?("master-") )
             next
           end
 


### PR DESCRIPTION
In ARO, in v3, monitoring agent (both replicaset and deamonset) deployed only to compute nodes. Since the replicaset gets the inventory such as nodes, pods and events etc .. from Kube API. The monitoring data collected by the replicaset agent has the inventory of all the nodes (master, infra and compute), but where as the monitoring data (such as perf and logs ) collected by the daemonset only for the compute nodes. So, this causing incomplete data in Azure Monitoring Ux, since Ux integrates the data from both daemonset and replicaset for the visualization.  And also this partial data related to master and infra nodes will cost the customer. This PR addresses this issue by stop collecting inventory of master and infra nodes.