### PR TITLE
[Draft]Gangams/add proxy support

### DIFF
--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/Microsoft/ApplicationInsights-Go/appinsights"
+	"github.com/Microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/fluent/fluent-bit-go/output"
-	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 )
 
 var (

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -210,6 +210,7 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		CommonProperties["IsProxyConfigured"] = "false"
 	} else {
 		CommonProperties["IsProxyConfigured"] = "true"
+		Log("Proxy configured")
 	}
 
 	TelemetryClient.Context().CommonProperties = CommonProperties

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/ApplicationInsights-Go/appinsights"
-	"github.com/Microsoft/ApplicationInsights-Go/appinsights/contracts"
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/fluent/fluent-bit-go/output"
 )
 

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/Microsoft/ApplicationInsights-Go/appinsights"
-	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/fluent/fluent-bit-go/output"
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 )
 
 var (
@@ -198,6 +198,16 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 
 		region := os.Getenv("AKS_REGION")
 		CommonProperties["Region"] = region
+	}
+
+	agentProxy := os.Getenv("HTTP_PROXY")
+	if agentProxy == "" {
+		agentProxy = os.Getenv("HTTPS_PROXY")
+	}
+	if agentProxy == "" {
+		CommonProperties["IsProxyConfigured"] = "false"
+	} else {
+		CommonProperties["IsProxyConfigured"] = "true"
 	}
 
 	TelemetryClient.Context().CommonProperties = CommonProperties

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -45,6 +45,8 @@ const (
 	envACSResourceName                                = "ACS_RESOURCE_NAME"
 	envAppInsightsAuth                                = "APPLICATIONINSIGHTS_AUTH"
 	envAppInsightsEndpoint                            = "APPLICATIONINSIGHTS_ENDPOINT"
+	envHTTPProxy                                      = "HTTP_PROXY"
+	envHTTPsProxy                                     = "HTTPS_PROXY"
 	metricNameAvgFlushRate                            = "ContainerLogAvgRecordsFlushedPerSec"
 	metricNameAvgLogGenerationRate                    = "ContainerLogsGeneratedPerSec"
 	metricNameLogSize                                 = "ContainerLogsSize"
@@ -200,9 +202,9 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		CommonProperties["Region"] = region
 	}
 
-	agentProxy := os.Getenv("HTTP_PROXY")
+	agentProxy := os.Getenv(envHTTPsProxy)
 	if agentProxy == "" {
-		agentProxy = os.Getenv("HTTPS_PROXY")
+		agentProxy = os.Getenv(envHTTPProxy)
 	}
 	if agentProxy == "" {
 		CommonProperties["IsProxyConfigured"] = "false"

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -68,7 +68,8 @@ func CreateHTTPClient() {
 	}
 
 	tlsConfig.BuildNameToCertificate()
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	// Refer: https://golang.org/pkg/net/http/#ProxyFromEnvironment
+	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: http.ProxyFromEnvironment}
 
 	HTTPClient = http.Client{
 		Transport: transport,

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -314,8 +314,10 @@ class ApplicationInsightsUtility
       proxyConfig = {}
       begin
         proxyEnvVar = ENV[@@EnvHTTPsProxy]
+        $log.info("HTTPS_PROXY environment var : #{proxyEnvVar}")      
         if proxyEnvVar.nil?  || proxyEnvVar.empty?
            proxyEnvVar = ENV[@@EnvHTTPProxy]
+           $log.info("HTTP_PROXY environment var : #{proxyEnvVar}")      
            if proxyEnvVar.nil?  || proxyEnvVar.empty?
               return proxyConfig
            end

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -68,17 +68,17 @@ class ApplicationInsightsUtility
         @@CustomProperties["ControllerType"] = ENV[@@EnvControllerType]
         encodedAppInsightsKey = ENV[@@EnvApplicationInsightsKey]
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
-        @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud   
-        @@CustomProperties["IsProxyConfigured"] =  "false"
-        IsProxyConfigured = false
+        @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud          
         # read the proxy configuration
         $log.info("calling getProxyConfiguration")
         proxy = getProxyConfiguration()
         if !proxy.nil? && !proxy.empty?        
           $log.info("proxy configured")
           @@CustomProperties["IsProxyConfigured"] =  "true"
-          IsProxyConfigured = true
+          isProxyConfigured = true
         else 
+          @@CustomProperties["IsProxyConfigured"] =  "false"
+          isProxyConfigured = false
           $log.info("proxy is not configured")
         end
         
@@ -95,7 +95,7 @@ class ApplicationInsightsUtility
             #telemetrySynchronousSender = ApplicationInsights::Channel::SynchronousSender.new appInsightsEndpoint
             #telemetrySynchronousQueue = ApplicationInsights::Channel::SynchronousQueue.new(telemetrySynchronousSender)
             #telemetryChannel = ApplicationInsights::Channel::TelemetryChannel.new nil, telemetrySynchronousQueue
-            if !IsProxyConfigured
+            if !isProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
@@ -105,7 +105,7 @@ class ApplicationInsightsUtility
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
             @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey, telemetryChannel
           else
-            if !IsProxyConfigured
+            if !isProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -70,16 +70,14 @@ class ApplicationInsightsUtility
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
         @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud          
         # read the proxy configuration
-        $log.info("calling getProxyConfiguration")
         proxy = getProxyConfiguration()
         if !proxy.nil? && !proxy.empty?        
           $log.info("proxy configured")
           @@CustomProperties["IsProxyConfigured"] =  "true"
           isProxyConfigured = true
-        else 
+        else
           @@CustomProperties["IsProxyConfigured"] =  "false"
           isProxyConfigured = false
-          $log.info("proxy is not configured")
         end
         
         #Check if telemetry is turned off
@@ -98,7 +96,7 @@ class ApplicationInsightsUtility
             if !isProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
             else
-              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
+              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, proxy              
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
@@ -108,7 +106,7 @@ class ApplicationInsightsUtility
             if !isProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
-              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
+              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
               sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, proxy              
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
@@ -197,11 +195,9 @@ class ApplicationInsightsUtility
 
     def sendExceptionTelemetry(errorStr, properties = nil)
       begin
-        if @@CustomProperties.empty? || @@CustomProperties.nil?
-          $log.info("initializing initializeUtility")
+        if @@CustomProperties.empty? || @@CustomProperties.nil?          
           initializeUtility()
-        elsif @@CustomProperties["DockerVersion"].nil?
-          $log.info("getContainerRuntimeInfo")
+        elsif @@CustomProperties["DockerVersion"].nil?          
           getContainerRuntimeInfo()
         end
         telemetryProps = {}
@@ -309,20 +305,15 @@ class ApplicationInsightsUtility
     end
 
     #Method to get the http or https proxy configuration if its configured.
-    def getProxyConfiguration()
-      $log.info("getProxyConfiguration : start")      
+    def getProxyConfiguration()    
       proxyConfig = {}
       begin
-        containerRuntime = ENV[@@EnvContainerRuntime]
-        $log.info("CONTAINER_RUNTIME environment var : #{containerRuntime}")      
-        proxyEnvVar = ENV[@@EnvHTTPsProxy]
-        $log.info("HTTPS_PROXY environment var : #{proxyEnvVar}")      
+        proxyEnvVar = ENV[@@EnvHTTPsProxy]   
         if proxyEnvVar.nil?  || proxyEnvVar.empty?
-           proxyEnvVar = ENV[@@EnvHTTPProxy]
-           $log.info("HTTP_PROXY environment var : #{proxyEnvVar}")      
-           if proxyEnvVar.nil?  || proxyEnvVar.empty?
-              return proxyConfig
-           end
+          proxyEnvVar = ENV[@@EnvHTTPProxy]           
+          if proxyEnvVar.nil?  || proxyEnvVar.empty?
+            return proxyConfig
+          end
         end     
         # Remove the http(s) protocol
         proxyConfigString = proxyEnvVar.gsub(/^(https?:\/\/)?/, "")
@@ -342,8 +333,7 @@ class ApplicationInsightsUtility
       rescue => errorStr        
         $log.warn("Exception in AppInsightsUtility: getProxyConfiguration - error: #{errorStr}")
         return {}
-      end
-      $log.info("getProxyConfiguration : end")      
+      end      
       return proxyConfig
     end
   end

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -313,6 +313,8 @@ class ApplicationInsightsUtility
       $log.info("getProxyConfiguration : start")      
       proxyConfig = {}
       begin
+        containerRuntime = ENV[@@EnvContainerRuntime]
+        $log.info("CONTAINER_RUNTIME environment var : #{containerRuntime}")      
         proxyEnvVar = ENV[@@EnvHTTPsProxy]
         $log.info("HTTPS_PROXY environment var : #{proxyEnvVar}")      
         if proxyEnvVar.nil?  || proxyEnvVar.empty?

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -90,7 +90,7 @@ class ApplicationInsightsUtility
             else 
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, proxy
-              @@CustomProperties["IsProxyConfigured"] =  true
+              @@CustomProperties["IsProxyConfigured"] =  "true"
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -101,7 +101,7 @@ class ApplicationInsightsUtility
             else       
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")        
               sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, proxy
-              @@CustomProperties["IsProxyConfigured"] = true
+              @@CustomProperties["IsProxyConfigured"] = "true"
             end         
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -72,6 +72,7 @@ class ApplicationInsightsUtility
         @@CustomProperties["IsProxyConfigured"] =  "false"
         IsProxyConfigured = false
         # read the proxy configuration
+        $log.info("calling getProxyConfiguration")
         proxy = getProxyConfiguration()
         if !proxy.nil? && !proxy.empty?        
           $log.info("proxy configured")
@@ -197,8 +198,10 @@ class ApplicationInsightsUtility
     def sendExceptionTelemetry(errorStr, properties = nil)
       begin
         if @@CustomProperties.empty? || @@CustomProperties.nil?
+          $log.info("initializing initializeUtility")
           initializeUtility()
         elsif @@CustomProperties["DockerVersion"].nil?
+          $log.info("getContainerRuntimeInfo")
           getContainerRuntimeInfo()
         end
         telemetryProps = {}
@@ -306,7 +309,8 @@ class ApplicationInsightsUtility
     end
 
     #Method to get the http or https proxy configuration if its configured.
-    def getProxyConfiguration()      
+    def getProxyConfiguration()
+      $log.info("getProxyConfiguration : start")      
       proxyConfig = {}
       begin
         proxyEnvVar = ENV[@@EnvHTTPsProxy]
@@ -335,6 +339,7 @@ class ApplicationInsightsUtility
         $log.warn("Exception in AppInsightsUtility: getProxyConfiguration - error: #{errorStr}")
         return {}
       end
+      $log.info("getProxyConfiguration : end")      
       return proxyConfig
     end
   end

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -311,11 +311,11 @@ class ApplicationInsightsUtility
       end
 
       if proxyConfig.nil?
-        $log.warn("Failed to parse the proxy configuration in '#{proxy_conf_path}'")
+        $log.warn("Failed to parse the proxy configuration in '#{proxyEnvVar}'")
         return {}
       end
 
-      return proxy_config
+      return proxyConfig
     end
 
     def parseProxyConfiguration(proxyConfigString)

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -70,10 +70,15 @@ class ApplicationInsightsUtility
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
         @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud   
         @@CustomProperties["IsProxyConfigured"] =  "false"
+        IsProxyConfigured = false
         # read the proxy configuration
         proxy = getProxyConfiguration()
         if !proxy.nil? && !proxy.empty?        
+          $log.info("proxy configured")
           @@CustomProperties["IsProxyConfigured"] =  "true"
+          IsProxyConfigured = true
+        else 
+          $log.info("proxy is not configured")
         end
         
         #Check if telemetry is turned off
@@ -89,7 +94,7 @@ class ApplicationInsightsUtility
             #telemetrySynchronousSender = ApplicationInsights::Channel::SynchronousSender.new appInsightsEndpoint
             #telemetrySynchronousQueue = ApplicationInsights::Channel::SynchronousQueue.new(telemetrySynchronousSender)
             #telemetryChannel = ApplicationInsights::Channel::TelemetryChannel.new nil, telemetrySynchronousQueue
-            if proxy.nil? || proxy.empty?
+            if !IsProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
@@ -99,7 +104,7 @@ class ApplicationInsightsUtility
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
             @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey, telemetryChannel
           else
-            if proxy.nil? || proxy.empty?
+            if !IsProxyConfigured
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
@@ -301,7 +306,7 @@ class ApplicationInsightsUtility
     end
 
     #Method to get the http or https proxy configuration if its configured.
-    def getProxyConfiguration()
+    def getProxyConfiguration()      
       proxyConfig = {}
       begin
         proxyEnvVar = ENV[@@EnvHTTPsProxy]

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -93,8 +93,7 @@ class ApplicationInsightsUtility
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
-              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, proxy
-              @@CustomProperties["IsProxyConfigured"] =  "true"
+              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, proxy              
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -104,8 +103,7 @@ class ApplicationInsightsUtility
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
-              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, proxy
-              @@CustomProperties["IsProxyConfigured"] = "true"
+              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, proxy              
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -322,14 +320,14 @@ class ApplicationInsightsUtility
         end
         re = /^(?:(?<user>[^:]+):(?<pass>[^@]+)@)?(?<addr>[^:@]+)(?::(?<port>\d+))?$/
         matches = re.match(proxyConfigString)
-        if matches.nil? or matches[:addr].nil?
+        if matches.nil? || matches[:addr].nil?
           $log.warn("invalid proxy configuration")
           return proxyConfig
         end
-        # Convert nammed matches to a hash
+        # Convert named matches to a hash
         proxyConfig = Hash[ matches.names.map{ |name| name.to_sym}.zip( matches.captures ) ]
-      rescue => errorStr
-        $log.warn("Failed to parse the proxy configuration in '#{errorStr}'")
+      rescue => errorStr        
+        $log.warn("Exception in AppInsightsUtility: getProxyConfiguration - error: #{errorStr}")
         return {}
       end
       return proxyConfig

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -90,7 +90,7 @@ class ApplicationInsightsUtility
             else 
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, proxy
-              @@CustomProperties["Proxy"] = "Configured"
+              @@CustomProperties["IsProxyConfigured"] =  true
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -101,7 +101,7 @@ class ApplicationInsightsUtility
             else       
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration")        
               sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, proxy
-              @@CustomProperties["Proxy"] = "Configured"
+              @@CustomProperties["IsProxyConfigured"] = true
             end         
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -326,16 +326,18 @@ class ApplicationInsightsUtility
 
         # Check for unsupported protocol
         if proxyConfigString[/^[a-z]+:\/\//]
+          $log.warn("unsupported protocol in proxy configuration")
           return nil
         end
 
         re = /^(?:(?<user>[^:]+):(?<pass>[^@]+)@)?(?<addr>[^:@]+)(?::(?<port>\d+))?$/
         matches = re.match(proxyConfigString)
         if matches.nil? or matches[:addr].nil?
+          $log.warn("invalid proxy configuration")
           return nil
         end
         # Convert nammed matches to a hash
-        return Hash[ matches.names.map{ |name| name.to_sym}.zip( matches.captures ) ]
+        Hash[ matches.names.map{ |name| name.to_sym}.zip( matches.captures ) ]
     end
 
   end

--- a/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
@@ -20,15 +20,16 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI,  proxy = {})
         @send_interval = 1.0
         @send_remaining_time = 0
         @send_time = 3.0
         @lock_work_thread = Mutex.new
         @work_thread = nil
         @start_notification_processed = true
-        super service_endpoint_uri
+        super service_endpoint_uri, proxy
       end
 
       # The time span in seconds at which the the worker thread will check the

--- a/source/code/plugin/lib/application_insights/channel/sender_base.rb
+++ b/source/code/plugin/lib/application_insights/channel/sender_base.rb
@@ -16,12 +16,14 @@ module ApplicationInsights
     class SenderBase
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri)
+      def initialize(service_endpoint_uri, proxy = {})
         @service_endpoint_uri = service_endpoint_uri
         @queue = nil
         @send_buffer_size = 100
         @logger = Logger.new(STDOUT)
+        @proxy = proxy
       end
 
       # The service endpoint URI where this sender will send data to.
@@ -60,7 +62,11 @@ module ApplicationInsights
         compressed_data = compress(json)
         request.body = compressed_data
 
-        http = Net::HTTP.new uri.hostname, uri.port
+        if @proxy.nil? || @proxy.empty?
+          http = Net::HTTP.new(uri.hostname, uri.port)
+        else
+          http = Net::HTTP.new(uri.hostname, uri.port, proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
+        end
         if uri.scheme.downcase == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/source/code/plugin/lib/application_insights/channel/sender_base.rb
+++ b/source/code/plugin/lib/application_insights/channel/sender_base.rb
@@ -65,7 +65,7 @@ module ApplicationInsights
         if @proxy.nil? || @proxy.empty?
           http = Net::HTTP.new(uri.hostname, uri.port)
         else
-          http = Net::HTTP.new(uri.hostname, uri.port, proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
+          http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
         end
         if uri.scheme.downcase == 'https'
           http.use_ssl = true

--- a/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
@@ -8,9 +8,10 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       # telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
-        super service_endpoint_uri
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI,  proxy = {})
+        super service_endpoint_uri, proxy
       end
     end
   end


### PR DESCRIPTION
Adding proxy support for the agent so that on-prem customers can use the agent on the k8s clusters which are behind proxy. the same should work for AKS and other managed clusters as well.

For all outbound traffic, OMS, ODS and AI communications will be routed via Proxy if Proxy configured.

