### PR TITLE
Gangams/enable proxy support (for non-AKS) remote endpoints

### DIFF
--- a/installer/conf/out_oms.conf
+++ b/installer/conf/out_oms.conf
@@ -1,4 +1,5 @@
 omsadmin_conf_path=/etc/opt/microsoft/omsagent/conf/omsadmin.conf
+omsproxy_conf_path=/etc/opt/microsoft/omsagent/proxy.conf
 cert_file_path=/etc/opt/microsoft/omsagent/certs/oms.crt
 key_file_path=/etc/opt/microsoft/omsagent/certs/oms.key
 container_host_file_path=/var/opt/microsoft/docker-cimprov/state/containerhostname

--- a/installer/conf/out_oms.conf
+++ b/installer/conf/out_oms.conf
@@ -1,5 +1,5 @@
 omsadmin_conf_path=/etc/opt/microsoft/omsagent/conf/omsadmin.conf
-omsproxy_conf_path=/etc/opt/microsoft/omsagent/proxy.conf
+omsproxy_secret_path=/etc/omsagent-secret/PROXY
 cert_file_path=/etc/opt/microsoft/omsagent/certs/oms.crt
 key_file_path=/etc/opt/microsoft/omsagent/certs/oms.key
 container_host_file_path=/var/opt/microsoft/docker-cimprov/state/containerhostname

--- a/installer/datafiles/base_container.data
+++ b/installer/datafiles/base_container.data
@@ -46,6 +46,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/DockerApiRestHelper.rb;											source/code/plugin/DockerApiRestHelper.rb;			644; root; root
 /opt/microsoft/omsagent/plugin/in_containerinventory.rb;										source/code/plugin/in_containerinventory.rb;		644; root; root
 /opt/microsoft/omsagent/plugin/kubernetes_container_inventory.rb;							source/code/plugin/kubernetes_container_inventory.rb;		644; root; root
+/opt/microsoft/omsagent/plugin/proxy_utils.rb;						                  	source/code/plugin/proxy_utils.rb;		644; root; root
 
 
 /opt/microsoft/omsagent/plugin/out_mdm.rb;                                                  source/code/plugin/out_mdm.rb; 644; root; root

--- a/source/code/go/src/plugins/oms.go
+++ b/source/code/go/src/plugins/oms.go
@@ -1001,11 +1001,11 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 			if err != nil {
 				message := fmt.Sprintf("Error Reading omsproxy configuration %s\n", err.Error())
 				Log(message)
+				// if we fail to read proxy configuration, then everything will be fall apart including sending  exceptions to AI
 				SendException(message)
-				time.Sleep(30 * time.Second)
 				log.Fatalln(message)
 			} else {
-				ProxyEndpoint = strings.TrimSpace(string(proxyConfig))		
+				ProxyEndpoint = strings.TrimSpace(string(proxyConfig))
 			}
 		}
 	} else {

--- a/source/code/go/src/plugins/oms.go
+++ b/source/code/go/src/plugins/oms.go
@@ -994,16 +994,15 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		}
 		// read proxyendpoint if proxy configured
 		ProxyEndpoint = ""
-		proxyConfigPath := pluginConfig["omsproxy_conf_path"]
-		if _, err := os.Stat(proxyConfigPath); err == nil {
-			Log("Reading proxy configuration for Linux from %s", proxyConfigPath)
-			proxyConfig, err := ioutil.ReadFile(proxyConfigPath)
+		proxySecretPath := pluginConfig["omsproxy_secret_path"]
+		if _, err := os.Stat(proxySecretPath); err == nil {
+			Log("Reading proxy configuration for Linux from %s", proxySecretPath)
+			proxyConfig, err := ioutil.ReadFile(proxySecretPath)
 			if err != nil {
 				message := fmt.Sprintf("Error Reading omsproxy configuration %s\n", err.Error())
 				Log(message)
-				// if we fail to read proxy configuration, then everything will be fall apart including sending  exceptions to AI
+				// if we fail to read proxy secret, AI telemetry might not be working as well
 				SendException(message)
-				log.Fatalln(message)
 			} else {
 				ProxyEndpoint = strings.TrimSpace(string(proxyConfig))
 			}

--- a/source/code/go/src/plugins/oms.go
+++ b/source/code/go/src/plugins/oms.go
@@ -1005,7 +1005,7 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 				time.Sleep(30 * time.Second)
 				log.Fatalln(message)
 			} else {
-				ProxyEndpoint = strings.TrimSpace(proxyConfig)		
+				ProxyEndpoint = strings.TrimSpace(string(proxyConfig))		
 			}
 		}
 	} else {

--- a/source/code/go/src/plugins/oms.go
+++ b/source/code/go/src/plugins/oms.go
@@ -101,6 +101,8 @@ var (
 	enrichContainerLogs bool
 	// container runtime engine configured on the kubelet
 	containerRuntime string
+	// Proxy endpoint in format http(s)://<user>:<pwd>@<proxyserver>:<port>
+	ProxyEndpoint string
 )
 
 var (
@@ -990,11 +992,28 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		} else {
 			Computer = strings.TrimSuffix(ToString(containerHostName), "\n")
 		}
+		// read proxyendpoint if proxy configured
+		ProxyEndpoint = ""
+		proxyConfigPath := pluginConfig["omsproxy_conf_path"]
+		if _, err := os.Stat(proxyConfigPath); err == nil {
+			Log("Reading proxy configuration for Linux from %s", proxyConfigPath)
+			proxyConfig, err := ioutil.ReadFile(proxyConfigPath)
+			if err != nil {
+				message := fmt.Sprintf("Error Reading omsproxy configuration %s\n", err.Error())
+				Log(message)
+				SendException(message)
+				time.Sleep(30 * time.Second)
+				log.Fatalln(message)
+			} else {
+				ProxyEndpoint = strings.TrimSpace(proxyConfig)		
+			}
+		}
 	} else {
 		// windows
 		Computer = os.Getenv("HOSTNAME")
 		WorkspaceID = os.Getenv("WSID")
 		logAnalyticsDomain := os.Getenv("DOMAIN")
+		ProxyEndpoint = os.Getenv("PROXY")
 		OMSEndpoint = "https://" + WorkspaceID + ".ods." + logAnalyticsDomain + "/OperationalData.svc/PostJsonDataItems"
 	}
 

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -159,6 +159,22 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		Log("Overriding the default AppInsights EndpointUrl with %s", appInsightsEndpoint)
 		telemetryClientConfig.EndpointUrl = envAppInsightsEndpoint
 	}
+	// if the proxy configured set the customized httpclient with proxy
+	if ProxyEndpoint != "" {
+		proxyConfig, err := http.ProxyURL(ProxyEndpoint)
+		if err != nil {
+			Log("Failed Parsing of Proxy endpoint %s", err.Error())			
+			return -1, err
+		}
+		//adding the proxy settings to the Transport object
+		transport := &http.Transport{
+			Proxy: proxyConfig,
+		}
+		httpClient := &http.Client{
+			Transport: transport,
+		}
+		telemetryClientConfig.Client = httpClient
+	}
 	TelemetryClient = appinsights.NewTelemetryClientFromConfig(telemetryClientConfig)
 
 	telemetryOffSwitch := os.Getenv("DISABLE_TELEMETRY")

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Microsoft/ApplicationInsights-Go/appinsights"
-	"github.com/Microsoft/ApplicationInsights-Go/appinsights/contracts"
+	"github.com/microsoft/ApplicationInsights-Go/appinsights"
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/fluent/fluent-bit-go/output"
 )
 

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -162,12 +162,14 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		telemetryClientConfig.EndpointUrl = envAppInsightsEndpoint
 	}
 	// if the proxy configured set the customized httpclient with proxy
-	if ProxyEndpoint != "" {		
-		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)		
+	isProxyConfigured := false
+	if ProxyEndpoint != "" {
+		Log("Using proxy endpoint for telemetry client since proxy configured")
+		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)
 		if err != nil {
-			Log("Failed Parsing of Proxy endpoint %s", err.Error())			
+			Log("Failed Parsing of Proxy endpoint %s", err.Error())
 			return -1, err
-		}		
+		}
 		//adding the proxy settings to the Transport object
 		transport := &http.Transport{
 			Proxy: http.ProxyURL(proxyEndpointUrl),
@@ -176,6 +178,7 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 			Transport: transport,
 		}
 		telemetryClientConfig.Client = httpClient
+		isProxyConfigured = true
 	}
 	TelemetryClient = appinsights.NewTelemetryClientFromConfig(telemetryClientConfig)
 
@@ -217,6 +220,12 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		region := os.Getenv("AKS_REGION")
 		CommonProperties["Region"] = region
 	}
+
+	if isProxyConfigured == true {
+	  CommonProperties["IsProxyConfigured"] = "true"
+	} else {
+  	   CommonProperties["IsProxyConfigured"] = "false"
+    }
 
 	TelemetryClient.Context().CommonProperties = CommonProperties
 	return 0, nil

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -161,15 +161,15 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 		telemetryClientConfig.EndpointUrl = envAppInsightsEndpoint
 	}
 	// if the proxy configured set the customized httpclient with proxy
-	if ProxyEndpoint != "" {
-		proxyConfig, err := http.ProxyURL(ProxyEndpoint)
+	if ProxyEndpoint != "" {		
+		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)		
 		if err != nil {
 			Log("Failed Parsing of Proxy endpoint %s", err.Error())			
 			return -1, err
-		}
+		}		
 		//adding the proxy settings to the Transport object
 		transport := &http.Transport{
-			Proxy: proxyConfig,
+			Proxy: http.ProxyURL(proxyEndpointUrl),
 		}
 		httpClient := &http.Client{
 			Transport: transport,

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/microsoft/ApplicationInsights-Go/appinsights"
+	"github.com/Microsoft/ApplicationInsights-Go/appinsights"
 	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/fluent/fluent-bit-go/output"
 )

--- a/source/code/go/src/plugins/telemetry.go
+++ b/source/code/go/src/plugins/telemetry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"errors"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -69,8 +69,8 @@ func CreateHTTPClient() {
 	}
 
 	tlsConfig.BuildNameToCertificate()
-		
-	var proxyConfig *url.URL
+	transport := &http.Transport{TLSClientConfig: tlsConfig}	
+	// set the proxy if the proxy configured
 	if ProxyEndpoint != "" {
 		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)		
 		if err != nil {
@@ -80,10 +80,9 @@ func CreateHTTPClient() {
 			Log(message)
 			log.Fatalf("Error parsing Proxy endpoint %s", err.Error())
 		} else {
-			proxyConfig = http.ProxyURL(proxyEndpointUrl)
+			transport.Proxy = http.ProxyURL(proxyEndpointUrl)
 		}
 	}
-	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: proxyConfig}
 
 	HTTPClient = http.Client{
 		Transport: transport,

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -68,7 +68,18 @@ func CreateHTTPClient() {
 	}
 
 	tlsConfig.BuildNameToCertificate()
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	proxyConfig := nil
+	if ProxyEndpoint != "" {
+		proxyConfig, err := http.ProxyURL(ProxyEndpoint)
+		if err != nil {
+			message := fmt.Sprintf("Error parsing Proxy endpoint %s", err.Error())
+			SendException(message)
+			time.Sleep(30 * time.Second)
+			Log(message)
+			log.Fatalf("Error parsing Proxy endpoint %s", err.Error())
+		}
+	}
+	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: proxyConfig}
 
 	HTTPClient = http.Client{
 		Transport: transport,

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -76,9 +76,8 @@ func CreateHTTPClient() {
 		if err != nil {
 			message := fmt.Sprintf("Error parsing Proxy endpoint %s", err.Error())
 			SendException(message)
-			// if we fail to read proxy configuration, then everything will be fall apart including sending  exceptions to AI
+			// if we fail to read proxy secret, AI telemetry might not be working as well
 			Log(message)
-			log.Fatalf("Error parsing Proxy endpoint %s", err.Error())
 		} else {
 			transport.Proxy = http.ProxyURL(proxyEndpointUrl)
 		}

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -69,14 +69,14 @@ func CreateHTTPClient() {
 	}
 
 	tlsConfig.BuildNameToCertificate()
-	transport := &http.Transport{TLSClientConfig: tlsConfig}	
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	// set the proxy if the proxy configured
 	if ProxyEndpoint != "" {
-		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)		
+		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)
 		if err != nil {
 			message := fmt.Sprintf("Error parsing Proxy endpoint %s", err.Error())
 			SendException(message)
-			time.Sleep(30 * time.Second)
+			// if we fail to read proxy configuration, then everything will be fall apart including sending  exceptions to AI
 			Log(message)
 			log.Fatalf("Error parsing Proxy endpoint %s", err.Error())
 		} else {

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -70,13 +71,15 @@ func CreateHTTPClient() {
 	tlsConfig.BuildNameToCertificate()
 	proxyConfig := nil
 	if ProxyEndpoint != "" {
-		proxyConfig, err := http.ProxyURL(ProxyEndpoint)
+		proxyEndpointUrl, err := url.Parse(proxyEndpoint)		
 		if err != nil {
 			message := fmt.Sprintf("Error parsing Proxy endpoint %s", err.Error())
 			SendException(message)
 			time.Sleep(30 * time.Second)
 			Log(message)
 			log.Fatalf("Error parsing Proxy endpoint %s", err.Error())
+		} else {
+			proxyConfig = http.ProxyURL(proxyEndpointUrl)
 		}
 	}
 	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: proxyConfig}

--- a/source/code/go/src/plugins/utils.go
+++ b/source/code/go/src/plugins/utils.go
@@ -69,9 +69,10 @@ func CreateHTTPClient() {
 	}
 
 	tlsConfig.BuildNameToCertificate()
-	proxyConfig := nil
+		
+	var proxyConfig *url.URL
 	if ProxyEndpoint != "" {
-		proxyEndpointUrl, err := url.Parse(proxyEndpoint)		
+		proxyEndpointUrl, err := url.Parse(ProxyEndpoint)		
 		if err != nil {
 			message := fmt.Sprintf("Error parsing Proxy endpoint %s", err.Error())
 			SendException(message)

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -6,7 +6,7 @@ class ApplicationInsightsUtility
   require_relative "omslog"
   require_relative "DockerApiClient"
   require_relative "oms_common"
-  require_relative 'proxy_utils'
+  require_relative "proxy_utils"
   require "yajl/json_gem"
   require "base64"
 
@@ -69,14 +69,14 @@ class ApplicationInsightsUtility
         encodedAppInsightsKey = ENV[@@EnvApplicationInsightsKey]
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
         @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud
-        if !@@proxy.nil? && !@@proxy.empty?        
-          $log.info("proxy configured")	      
-          @@CustomProperties["IsProxyConfigured"] =  "true"	         
-          isProxyConfigured = true	          
+        if !@@proxy.nil? && !@@proxy.empty?
+          $log.info("proxy configured")
+          @@CustomProperties["IsProxyConfigured"] = "true"
+          isProxyConfigured = true
         else
-          @@CustomProperties["IsProxyConfigured"] =  "false"	         
-          isProxyConfigured = false	         
-          $log.info("proxy is not configured")	
+          @@CustomProperties["IsProxyConfigured"] = "false"
+          isProxyConfigured = false
+          $log.info("proxy is not configured")
         end
 
         #Check if telemetry is turned off
@@ -97,7 +97,7 @@ class ApplicationInsightsUtility
               sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
-              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, @@proxy           
+              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, @@proxy
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -107,7 +107,7 @@ class ApplicationInsightsUtility
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
-              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, @@proxy              
+              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, @@proxy
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
@@ -141,7 +141,7 @@ class ApplicationInsightsUtility
         if containerRuntime.casecmp("docker") == 0
           dockerInfo = DockerApiClient.dockerInfo
           if (!dockerInfo.nil? && !dockerInfo.empty?)
-            @@CustomProperties["DockerVersion"] = dockerInfo["Version"]          
+            @@CustomProperties["DockerVersion"] = dockerInfo["Version"]
           end
         end
       end

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -22,8 +22,7 @@ class ApplicationInsightsUtility
   @@EnvApplicationInsightsEndpoint = "APPLICATIONINSIGHTS_ENDPOINT"
   @@EnvControllerType = "CONTROLLER_TYPE"
   @@EnvContainerRuntime = "CONTAINER_RUNTIME"
-  @DefaultAppInsightsEndpoint = "https://dc.services.visualstudio.com/v2/track"
-
+  
   @@CustomProperties = {}
   @@Tc = nil
   @@hostName = (OMS::Common.get_hostname)
@@ -107,7 +106,7 @@ class ApplicationInsightsUtility
               sender = ApplicationInsights::Channel::AsynchronousSender.new
             else
               $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
-              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, @@proxy
+              sender = ApplicationInsights::Channel::AsynchronousSender.new nil, @@proxy
             end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue

--- a/source/code/plugin/ApplicationInsightsUtility.rb
+++ b/source/code/plugin/ApplicationInsightsUtility.rb
@@ -6,6 +6,7 @@ class ApplicationInsightsUtility
   require_relative "omslog"
   require_relative "DockerApiClient"
   require_relative "oms_common"
+  require_relative 'proxy_utils'
   require "yajl/json_gem"
   require "base64"
 
@@ -21,10 +22,12 @@ class ApplicationInsightsUtility
   @@EnvApplicationInsightsEndpoint = "APPLICATIONINSIGHTS_ENDPOINT"
   @@EnvControllerType = "CONTROLLER_TYPE"
   @@EnvContainerRuntime = "CONTAINER_RUNTIME"
+  @DefaultAppInsightsEndpoint = "https://dc.services.visualstudio.com/v2/track"
 
   @@CustomProperties = {}
   @@Tc = nil
   @@hostName = (OMS::Common.get_hostname)
+  @@proxy = (ProxyUtils.getProxyConfiguration)
 
   def initialize
   end
@@ -66,6 +69,15 @@ class ApplicationInsightsUtility
         encodedAppInsightsKey = ENV[@@EnvApplicationInsightsKey]
         appInsightsEndpoint = ENV[@@EnvApplicationInsightsEndpoint]
         @@CustomProperties["WorkspaceCloud"] = getWorkspaceCloud
+        if !@@proxy.nil? && !@@proxy.empty?        
+          $log.info("proxy configured")	      
+          @@CustomProperties["IsProxyConfigured"] =  "true"	         
+          isProxyConfigured = true	          
+        else
+          @@CustomProperties["IsProxyConfigured"] =  "false"	         
+          isProxyConfigured = false	         
+          $log.info("proxy is not configured")	
+        end
 
         #Check if telemetry is turned off
         telemetryOffSwitch = ENV["DISABLE_TELEMETRY"]
@@ -81,12 +93,22 @@ class ApplicationInsightsUtility
             #telemetrySynchronousSender = ApplicationInsights::Channel::SynchronousSender.new appInsightsEndpoint
             #telemetrySynchronousQueue = ApplicationInsights::Channel::SynchronousQueue.new(telemetrySynchronousSender)
             #telemetryChannel = ApplicationInsights::Channel::TelemetryChannel.new nil, telemetrySynchronousQueue
-            sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
+            if !isProxyConfigured
+              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint
+            else
+              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
+              sender = ApplicationInsights::Channel::AsynchronousSender.new appInsightsEndpoint, @@proxy           
+            end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
             @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey, telemetryChannel
           else
-            sender = ApplicationInsights::Channel::AsynchronousSender.new
+            if !isProxyConfigured
+              sender = ApplicationInsights::Channel::AsynchronousSender.new
+            else
+              $log.info("AppInsightsUtility: Telemetry client uses provided proxy configuration since proxy configured")
+              sender = ApplicationInsights::Channel::AsynchronousSender.new @DefaultAppInsightsEndpoint, @@proxy              
+            end
             queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
             channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
             @@Tc = ApplicationInsights::TelemetryClient.new decodedAppInsightsKey, channel

--- a/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
@@ -20,15 +20,16 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
         @send_interval = 1.0
         @send_remaining_time = 0
         @send_time = 3.0
         @lock_work_thread = Mutex.new
         @work_thread = nil
         @start_notification_processed = true
-        super service_endpoint_uri
+        super service_endpoint_uri, proxy
       end
 
       # The time span in seconds at which the the worker thread will check the

--- a/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/asynchronous_sender.rb
@@ -23,6 +23,10 @@ module ApplicationInsights
       # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
       def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        # callers which requires proxy dont require to maintain service endpoint uri which potentially can change
+        if service_endpoint_uri.nil? || service_endpoint_uri.empty?
+          service_endpoint_uri = SERVICE_ENDPOINT_URI
+        end
         @send_interval = 1.0
         @send_remaining_time = 0
         @send_time = 3.0

--- a/source/code/plugin/lib/application_insights/channel/sender_base.rb
+++ b/source/code/plugin/lib/application_insights/channel/sender_base.rb
@@ -16,12 +16,14 @@ module ApplicationInsights
     class SenderBase
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri)
+      def initialize(service_endpoint_uri, proxy = {})
         @service_endpoint_uri = service_endpoint_uri
         @queue = nil
         @send_buffer_size = 100
         @logger = Logger.new(STDOUT)
+        @proxy = proxy
       end
 
       # The service endpoint URI where this sender will send data to.
@@ -41,6 +43,9 @@ module ApplicationInsights
       # The logger for the sender.
       attr_accessor :logger
 
+      # The proxy for the sender.
+      attr_accessor :proxy
+
       # Immediately sends the data passed in to {#service_endpoint_uri}. If the
       # service request fails, the passed in items are pushed back to the {#queue}.
       # @param [Array<Contracts::Envelope>] data_to_send an array of
@@ -59,8 +64,11 @@ module ApplicationInsights
         json = JSON.generate(data_to_send)
         compressed_data = compress(json)
         request.body = compressed_data
-
-        http = Net::HTTP.new uri.hostname, uri.port
+        if @proxy.nil? || @proxy.empty?
+          http = Net::HTTP.new uri.hostname, uri.port
+        else 
+          http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
+        end
         if uri.scheme.downcase == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
@@ -8,9 +8,10 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       # telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
-        super service_endpoint_uri
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        super service_endpoint_uri, proxy
       end
     end
   end

--- a/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
+++ b/source/code/plugin/lib/application_insights/channel/synchronous_sender.rb
@@ -1,16 +1,20 @@
-require_relative 'sender_base'
+require_relative "sender_base"
 
 module ApplicationInsights
   module Channel
     # A synchronous sender that works in conjunction with the {SynchronousQueue}.
     # The queue will call {#send} on the current instance with the data to send.
     class SynchronousSender < SenderBase
-      SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
+      SERVICE_ENDPOINT_URI = "https://dc.services.visualstudio.com/v2/track"
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
       # @param [Hash] proxy server configuration to send (optional)
       # telemetry data to.
       def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        # callers which requires proxy dont require to maintain service endpoint uri which potentially can change
+        if service_endpoint_uri.nil? || service_endpoint_uri.empty?
+          service_endpoint_uri = SERVICE_ENDPOINT_URI
+        end
         super service_endpoint_uri, proxy
       end
     end

--- a/source/code/plugin/out_mdm.rb
+++ b/source/code/plugin/out_mdm.rb
@@ -76,7 +76,7 @@ module Fluent
         if @can_send_data_to_mdm
           @log.info "MDM Metrics supported in #{aks_region} region"
 
-          @@post_request_url = @@post_request_url_template % {aks_region: aks_region, aks_resource_id: aks_resource_id}
+          @@post_request_url = @@post_request_url_template % { aks_region: aks_region, aks_resource_id: aks_resource_id }
           @post_request_uri = URI.parse(@@post_request_url)
           if @proxy.nil? || @proxy.empty?
             @http_client = Net::HTTP.new(@post_request_uri.host, @post_request_uri.port)
@@ -93,11 +93,11 @@ module Fluent
 
           if (!sp_client_id.nil? && !sp_client_id.empty? && sp_client_id.downcase != "msi")
             @useMsi = false
-            aad_token_url = @@aad_token_url_template % {tenant_id: @data_hash["tenantId"]}
+            aad_token_url = @@aad_token_url_template % { tenant_id: @data_hash["tenantId"] }
             @parsed_token_uri = URI.parse(aad_token_url)
           else
             @useMsi = true
-            msi_endpoint = @@msi_endpoint_template % {user_assigned_client_id: @@userAssignedClientId, resource: @@token_resource_url}
+            msi_endpoint = @@msi_endpoint_template % { user_assigned_client_id: @@userAssignedClientId, resource: @@token_resource_url }
             @parsed_token_uri = URI.parse(msi_endpoint)
           end
 
@@ -105,7 +105,7 @@ module Fluent
         end
       rescue => e
         @log.info "exception when initializing out_mdm #{e}"
-        ApplicationInsightsUtility.sendExceptionTelemetry(e, {"FeatureArea" => "MDM"})
+        ApplicationInsightsUtility.sendExceptionTelemetry(e, { "FeatureArea" => "MDM" })
         return
       end
     end
@@ -131,12 +131,11 @@ module Fluent
               @log.info "Using SP to get the token to post MDM data"
               ApplicationInsightsUtility.sendCustomEvent("AKSCustomMetricsMDMToken-SP", {})
               @log.info "Opening TCP connection"
-              if @proxy.nil? || @proxy.empty?                  
+              if @proxy.nil? || @proxy.empty?
                 http_access_token = Net::HTTP.start(@parsed_token_uri.host, @parsed_token_uri.port, :use_ssl => true)
               else
-                http_access_token = Net::HTTP.start(@parsed_token_uri.host, @parsed_token_uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass]), :use_ssl => true)
+                http_access_token = Net::HTTP.start(@parsed_token_uri.host, @parsed_token_uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass], :use_ssl => true)
               end
-              
               # http_access_token.use_ssl = true
               token_request = Net::HTTP::Post.new(@parsed_token_uri.request_uri)
               token_request.set_form_data(
@@ -155,7 +154,7 @@ module Fluent
             parsed_json = JSON.parse(token_response.body)
             @token_expiry_time = Time.now + @@tokenRefreshBackoffInterval * 60 # set the expiry time to be ~thirty minutes from current time
             @cached_access_token = parsed_json["access_token"]
-          @log.info "Successfully got access token"
+            @log.info "Successfully got access token"
           end
         rescue => err
           @log.info "Exception in get_access_token: #{err}"
@@ -165,9 +164,9 @@ module Fluent
             sleep(retries)
             retry
           else
-          @get_access_token_backoff_expiry = Time.now + @@tokenRefreshBackoffInterval * 60
-          @log.info "@get_access_token_backoff_expiry set to #{@get_access_token_backoff_expiry}"
-          ApplicationInsightsUtility.sendExceptionTelemetry(err, {"FeatureArea" => "MDM"})
+            @get_access_token_backoff_expiry = Time.now + @@tokenRefreshBackoffInterval * 60
+            @log.info "@get_access_token_backoff_expiry set to #{@get_access_token_backoff_expiry}"
+            ApplicationInsightsUtility.sendExceptionTelemetry(err, { "FeatureArea" => "MDM" })
           end
         ensure
           if http_access_token
@@ -241,7 +240,7 @@ module Fluent
         request["Authorization"] = "Bearer #{access_token}"
 
         request.body = post_body.join("\n")
-        @log.info "REQUEST BODY SIZE #{request.body.bytesize/1024}"
+        @log.info "REQUEST BODY SIZE #{request.body.bytesize / 1024}"
         response = @http_client.request(request)
         response.value # this throws for non 200 HTTP response code
         @log.info "HTTP Post Response Code : #{response.code}"

--- a/source/code/plugin/proxy_utils.rb
+++ b/source/code/plugin/proxy_utils.rb
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+#!/usr/local/bin/ruby
+# frozen_string_literal: true
+
+class ProxyUtils
+    class << self
+        def getProxyConfiguration()   
+            proxy_conf_path = "/etc/opt/microsoft/omsagent/proxy.conf"
+            if !File.exist?(proxy_conf_path) 
+              return {}
+            end
+      
+            begin      
+              proxy_config = parseProxyConfiguration(File.read(proxy_conf_path))
+            rescue SystemCallError # Error::ENOENT
+              return {}
+            end
+      
+            if proxy_config.nil?
+              $log.warn("Failed to parse the proxy configuration in '#{proxy_conf_path}'")
+              return {}
+            end
+      
+            return proxy_config
+        end
+        
+        def parseProxyConfiguration(proxy_conf_str)
+            # Remove the http(s) protocol
+            proxy_conf_str = proxy_conf_str.gsub(/^(https?:\/\/)?/, "")
+    
+            # Check for unsupported protocol
+            if proxy_conf_str[/^[a-z]+:\/\//]
+              return nil
+            end
+    
+            re = /^(?:(?<user>[^:]+):(?<pass>[^@]+)@)?(?<addr>[^:@]+)(?::(?<port>\d+))?$/ 
+            matches = re.match(proxy_conf_str)
+            if matches.nil? or matches[:addr].nil? 
+              return nil
+            end
+            # Convert nammed matches to a hash
+            Hash[ matches.names.map{ |name| name.to_sym}.zip( matches.captures ) ]
+        end
+    end
+end

--- a/source/code/plugin/proxy_utils.rb
+++ b/source/code/plugin/proxy_utils.rb
@@ -5,19 +5,19 @@
 class ProxyUtils
     class << self
         def getProxyConfiguration()   
-            proxy_conf_path = "/etc/opt/microsoft/omsagent/proxy.conf"
-            if !File.exist?(proxy_conf_path) 
+            omsproxy_secret_path = "/etc/omsagent-secret/PROXY"
+            if !File.exist?(omsproxy_secret_path) 
               return {}
             end
       
             begin      
-              proxy_config = parseProxyConfiguration(File.read(proxy_conf_path))
+              proxy_config = parseProxyConfiguration(File.read(omsproxy_secret_path))
             rescue SystemCallError # Error::ENOENT
               return {}
             end
       
             if proxy_config.nil?
-              $log.warn("Failed to parse the proxy configuration in '#{proxy_conf_path}'")
+              $log.warn("Failed to parse the proxy configuration in '#{omsproxy_secret_path}'")
               return {}
             end
       


### PR DESCRIPTION
This PR is enables proxy support for the agent  so that  Linux and Windows agent can be used behind proxy environment.

For external outbound traffic of Non-AKS, OMS, ODS, AI, and onboarding check communications will be routed via Proxy if Proxy configured.


Refer latest design doc https://microsoft.sharepoint.com/:w:/t/Operations_Management_Suite/EWITL1uDq6BPpgv8taRppd4BxKE5H9st5AgRT8nLIAiZsA?e=fIwOVV

