### PR TITLE
* Fix oomkilled in rs with high prometheus load

### DIFF
--- a/installer/conf/td-agent-bit-rs.conf
+++ b/installer/conf/td-agent-bit-rs.conf
@@ -1,5 +1,11 @@
 [SERVICE]
-    Flush         30
+    HTTP_Server   Off
+    Daemon        Off
+    Flush         15
+    storage.path  /var/opt/microsoft/docker-cimprov/state/flbstore/
+    storage.sync  normal
+    storage.checksum off
+    storage.backlog.mem_limit 10M
     Log_Level     info
     Parsers_File  /etc/opt/microsoft/docker-cimprov/azm-containers-parser.conf
     Log_File      /var/opt/microsoft/docker-cimprov/log/fluent-bit.log
@@ -11,6 +17,7 @@
     Port        25226
     Chunk_Size  32
     Buffer_Size 64
+    Mem_Buf_Limit 10m
 
 [OUTPUT]
     Name                            oms

--- a/installer/conf/td-agent-bit.conf
+++ b/installer/conf/td-agent-bit.conf
@@ -1,6 +1,12 @@
 [SERVICE]
     #Default service flush interval is 15 seconds
     ${SERVICE_FLUSH_INTERVAL}
+    HTTP_Server   Off
+    Daemon        Off
+    storage.path  /var/opt/microsoft/docker-cimprov/state/flbstore/
+    storage.sync  normal
+    storage.checksum off
+    storage.backlog.mem_limit 10M
     Log_Level     info
     Parsers_File  /etc/opt/microsoft/docker-cimprov/azm-containers-parser.conf
     Log_File      /var/opt/microsoft/docker-cimprov/log/fluent-bit.log
@@ -41,6 +47,7 @@
     Port        25226
     Chunk_Size  32
     Buffer_Size 64
+    Mem_Buf_Limit 5m
 
 [FILTER]
     Name grep

--- a/installer/conf/telegraf-rs.conf
+++ b/installer/conf/telegraf-rs.conf
@@ -147,7 +147,9 @@
 ###############################################################################
 #                            PROCESSOR PLUGINS                                #
 ###############################################################################
-
+[[processors.converter]]
+  [processors.converter.fields]
+    float = ["*"]
 # # Perform string processing on tags, fields, and measurements
 #[[processors.rename]]
   #[[processors.rename.replace]]

--- a/installer/conf/telegraf.conf
+++ b/installer/conf/telegraf.conf
@@ -182,6 +182,9 @@
 #                            PROCESSOR PLUGINS                                #
 ###############################################################################
 
+[[processors.converter]]
+  [processors.converter.fields]
+    float = ["*"]
 # # Perform string processing on tags, fields, and measurements
 #[[processors.rename]]
   #[[processors.rename.replace]]

--- a/installer/datafiles/base_container.data
+++ b/installer/datafiles/base_container.data
@@ -197,6 +197,7 @@ MAINTAINER:              'Microsoft Corporation'
 /var/opt/microsoft;                                     755; root; root; sysdir
 /var/opt/microsoft/docker-cimprov;                      755; root; root
 /var/opt/microsoft/docker-cimprov/state;                755; root; root
+/var/opt/microsoft/docker-cimprov/state/flbstore;       755; root; root
 /var/opt/microsoft/docker-cimprov/state/ContainerInventory; 755; root; root
 /var/opt/microsoft/docker-cimprov/log;                  755; root; root
 


### PR DESCRIPTION
* Fix oomkilled in rs with high prometheus load (prudential)
* Fix non-numeric value issue for metrics (NaN & +-Inf)
* Update fluentbit to 1.4.2 (from 0.14.4) [This will also fix json serialization encoding issue reported by a customer]
* Make deafult as file buffer