### PR TITLE
Gangams/defer new kubelet metrics for next agent release

### DIFF
--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -625,13 +625,14 @@
 #    ControllerType = "$CONTROLLER_TYPE"
 #    AKS_RESOURCE_ID = "$TELEMETRY_AKS_RESOURCE_ID"
 #    ACSResourceName = "$TELEMETRY_ACS_RESOURCE_NAME"
-#    Region = "$TELEMETRY_AKS_REGION"  
+#    Region = "$TELEMETRY_AKS_REGION"
 
 [[inputs.prometheus]]
   name_prefix="container.azm.ms/"
   ## An array of urls to scrape metrics from.
   urls = ["$CADVISOR_METRICS_URL"]
-  fieldpass = ["$KUBELET_RUNTIME_OPERATIONS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC"]
+  ## Include "$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC" when we add for support for 1.18
+  fieldpass = ["$KUBELET_RUNTIME_OPERATIONS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_METRIC"]
 
   metric_version = 2
   url_tag = "scrapeUrl"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -283,7 +283,7 @@ fi
 echo "configured container runtime on kubelet is : "$CONTAINER_RUNTIME
 echo "export CONTAINER_RUNTIME="$CONTAINER_RUNTIME >> ~/.bashrc
 
-# these metrics available from k8s 1.18 or up
+# enable these metrics in next agent release
 # export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="kubelet_runtime_operations_total"
 # echo "export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC >> ~/.bashrc
 # export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="kubelet_runtime_operations_errors_total"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -284,10 +284,10 @@ echo "configured container runtime on kubelet is : "$CONTAINER_RUNTIME
 echo "export CONTAINER_RUNTIME="$CONTAINER_RUNTIME >> ~/.bashrc
 
 # these metrics available from k8s 1.18 or up
-export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="kubelet_runtime_operations_total"
-echo "export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC >> ~/.bashrc
-export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="kubelet_runtime_operations_errors_total"
-echo "export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC >> ~/.bashrc
+# export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="kubelet_runtime_operations_total"
+# echo "export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC >> ~/.bashrc
+# export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="kubelet_runtime_operations_errors_total"
+# echo "export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC >> ~/.bashrc
 
 # default to docker metrics
 export KUBELET_RUNTIME_OPERATIONS_METRIC="kubelet_docker_operations"


### PR DESCRIPTION
As we discussed and agreed, deferring the new kubelet metrics to next agent release so that doesn't incur additional cost to the customer.