### PR TITLE
Gangams/fix container state failed

### DIFF
--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -86,6 +86,10 @@ class KubernetesContainerInventory
                 containerInventoryRecord["StartedTime"] = containerState["terminated"]["startedAt"]
                 containerInventoryRecord["FinishedTime"] = containerState["terminated"]["finishedAt"]
                 containerInventoryRecord["ExitCode"] = containerState["terminated"]["exitCode"]
+                # exit code non-zero indicates the container in failed state
+                if containerInventoryRecord["ExitCode"] != 0
+                  containerInventoryRecord["State"] = "Failed"
+                end
                 isContainerTerminated = true
               elsif containerState.key?("waiting")
                 containerInventoryRecord["State"] = "Waiting"

--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -76,6 +76,7 @@ class KubernetesContainerInventory
             end
             containerInventoryRecord["ExitCode"] = 0
             isContainerTerminated = false
+            isContainerWaiting = false
             if !containerStatus["state"].nil? && !containerStatus["state"].empty?
               containerState = containerStatus["state"]
               if containerState.key?("running")
@@ -96,6 +97,7 @@ class KubernetesContainerInventory
                 isContainerTerminated = true
               elsif containerState.key?("waiting")
                 containerInventoryRecord["State"] = "Waiting"
+                isContainerWaiting = true
               end
             end
 
@@ -118,8 +120,8 @@ class KubernetesContainerInventory
             containerInventoryRecord["Command"] = containerInfoMap["Command"]
             if !clusterCollectEnvironmentVar.nil? && !clusterCollectEnvironmentVar.empty? && clusterCollectEnvironmentVar.casecmp("false") == 0
               containerInventoryRecord["EnvironmentVar"] = ["AZMON_CLUSTER_COLLECT_ENV_VAR=FALSE"]
-            elsif isWindows || isContainerTerminated
-              # for terminated containers, since the cproc gone we lost the env and we can only get this
+            elsif isWindows || isContainerTerminated || isContainerWaiting
+              # for terminated and waiting containers, since the cproc doesnt exist we lost the env and we can only get this
               containerInventoryRecord["EnvironmentVar"] = containerInfoMap["EnvironmentVar"]
             else
               if containerId.nil? || containerId.empty? || containerRuntime.nil? || containerRuntime.empty?

--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -171,10 +171,7 @@ class KubernetesContainerInventory
               cmdValue = container["command"]
               cmdValueString = (cmdValue.nil?) ? "" : cmdValue.to_s
               containerInfoMap["Command"] = cmdValueString
-              containerInfoMap["EnvironmentVar"] = ""
-              if isWindows
-                containerInfoMap["EnvironmentVar"] = obtainWindowsContainerEnvironmentVars(podItem, container)
-              end
+              containerInfoMap["EnvironmentVar"] = obtainContainerEnvironmentVarsFromPodsResponse(podItem, container)
               containersInfoMap[containerName] = containerInfoMap
             end
           end
@@ -249,7 +246,7 @@ class KubernetesContainerInventory
       return envValueString
     end
 
-    def obtainWindowsContainerEnvironmentVars(pod, container)
+    def obtainContainerEnvironmentVarsFromPodsResponse(pod, container)
       envValueString = ""
       begin
         envVars = []
@@ -321,7 +318,7 @@ class KubernetesContainerInventory
           end
         end
       rescue => error
-        $log.warn("KubernetesContainerInventory::obtainWindowsContainerEnvironmentVars: parsing of EnvVars failed: #{error}")
+        $log.warn("KubernetesContainerInventory::obtainContainerEnvironmentVarsFromPodsResponse: parsing of EnvVars failed: #{error}")
         $log.debug_backtrace(error.backtrace)
         ApplicationInsightsUtility.sendExceptionTelemetry(error)
       end

--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -85,9 +85,12 @@ class KubernetesContainerInventory
                 containerInventoryRecord["State"] = "Terminated"
                 containerInventoryRecord["StartedTime"] = containerState["terminated"]["startedAt"]
                 containerInventoryRecord["FinishedTime"] = containerState["terminated"]["finishedAt"]
-                containerInventoryRecord["ExitCode"] = containerState["terminated"]["exitCode"]
-                # exit code non-zero indicates the container in failed state
-                if containerInventoryRecord["ExitCode"] != 0
+                exitCodeValue = containerState["terminated"]["exitCode"]
+                if exitCodeValue < 0
+                  exitCodeValue = 128
+                end
+                containerInventoryRecord["ExitCode"] = exitCodeValue
+                if exitCodeValue > 0
                   containerInventoryRecord["State"] = "Failed"
                 end
                 isContainerTerminated = true

--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -115,10 +115,11 @@ class KubernetesContainerInventory
             containerInventoryRecord["Command"] = containerInfoMap["Command"]
             if !clusterCollectEnvironmentVar.nil? && !clusterCollectEnvironmentVar.empty? && clusterCollectEnvironmentVar.casecmp("false") == 0
               containerInventoryRecord["EnvironmentVar"] = ["AZMON_CLUSTER_COLLECT_ENV_VAR=FALSE"]
-            elsif isWindows
+            elsif isWindows || isContainerTerminated
+              # for terminated containers, since the cproc gone we lost the env and we can only get this
               containerInventoryRecord["EnvironmentVar"] = containerInfoMap["EnvironmentVar"]
             else
-              if containerId.nil? || containerId.empty? || isContainerTerminated || containerRuntime.nil? || containerRuntime.empty?
+              if containerId.nil? || containerId.empty? || containerRuntime.nil? || containerRuntime.empty?
                 containerInventoryRecord["EnvironmentVar"] = ""
               else
                 if containerRuntime.casecmp("cri-o") == 0


### PR DESCRIPTION
This PR addresses following regressions 
  1.  Mark ContainerState as failed if  exit code is non zero
   2. Use the environment variables from pods response for terminated and failed containers since cproc process gone in these scenarios