### PR TITLE
separate build yamls for ci_prod branch

### DIFF
--- a/.pipelines/pipeline.user.linux.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.linux.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -1,0 +1,44 @@
+environment:
+  host:
+    os: 'linux'
+    flavor: 'ubuntu'
+    version: '16.04'
+  runtime:
+    provider: 'appcontainer'
+    image: 'cdpxlinux.azurecr.io/user/azure-monitor/container-insights:1.0'
+
+version:
+  name: 'DockerProvider'
+  major: 10
+  minor: 0
+  tag: 'beta'
+  system: 'custom'
+  exclude_commit: true
+
+restore:
+  commands:
+    - !!defaultcommand
+      name: 'get go modules'
+      command: '.pipelines/restore-linux.sh'
+      fail_on_stderr: false
+
+build:
+  commands:
+    - !!defaultcommand
+      name: 'Build Docker Provider Shell Bundle'
+      command: '.pipelines/build-linux.sh'
+      fail_on_stderr: false
+
+package:
+  commands:
+    - !!dockerbuildcommand                               # REQUIRED: This maps the command data to a concrete type in the CDPX orchestrator.
+      name: 'Build Docker Image'                          # REQUIRED: All commands have a name field. All console output captured when
+                                                          #           this command runs is tagged with the value of this field.
+      context_folder: 'kubernetes/linux'                  # REQUIRED: The repository root relative path of the folder containing the Dockerfile to build.
+                                                          # In effect, the context folder will be repository_checkout_folder/src/DockerFinal.
+      dockerfile_name: 'Dockerfile'                       # OPTIONAL: The name of the dockerfile. Docker client does allow the Dockerfile
+                                                          # to be named differently. Defaults to Dockerfile.
+                                                          # In effect, the -f option value passed to docker build will be repository_checkout_folder/src/DockerFinal/Foo.dockerfile.
+      repository_name: 'cdpxlinux'                        # only supported ones are cdpx acr repos
+      tag: 'ciprod'                                        # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
+      latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.

--- a/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -1,0 +1,55 @@
+environment:
+  host:
+    os: 'windows'
+    flavor: 'server'
+    version: '2019'
+  runtime:
+    provider: 'appcontainer'
+    image: 'cdpxwin1809.azurecr.io/user/azure-monitor/container-insights:6.0'
+    source_mode: 'map'
+
+version:
+  name: 'Certificate Generator and Out OMS plugin'
+  major: 10
+  minor: 0
+  tag: 'beta'
+  system: 'custom'
+  exclude_commit: true
+
+signing_options:
+  profile: 'azure'
+  codesign_validation_glob_pattern: 'regex|.+(?:dll|exe|sys|ps1|psm1|ps1xml|psc1|psd1|cdxml|vbs|js|wsf)$;-:file|**\linux\**' #CSV does not currently support binaries built for linux, so we exclude this folder
+
+static_analysis_options:
+  binskim_options:
+    files_to_scan:
+      - from: 'build\windows\installer\certificategenerator\bin\'
+        exclude: # exclude binaries which are referenced via dotnet packages and not built by us
+          - '**/**/**/BouncyCastle.Crypto.dll'
+          - '**/**/**/**/BouncyCastle.Crypto.dll'
+restore:
+  commands:
+    - !!defaultcommand
+       name: 'Restore dotnet packages'
+       command: '.pipelines/restore-windows.cmd'
+
+build:
+  commands:
+    - !!defaultcommand
+      name: 'Build Certificate Generator Source code and Out OMS Go plugin code'
+      command: '.pipelines/build-windows.cmd'
+      fail_on_stderr: false
+
+package:
+  commands:
+    - !!dockerbuildcommand                                # REQUIRED: This maps the command data to a concrete type in the CDPX orchestrator.
+      name: 'Build Docker Image'                          # REQUIRED: All commands have a name field. All console output captured when
+                                                          #           this command runs is tagged with the value of this field.
+      context_folder: 'kubernetes/windows'                # REQUIRED: The repository root relative path of the folder containing the Dockerfile to build.
+                                                          # In effect, the context folder will be repository_checkout_folder/src/DockerFinal.
+      dockerfile_name: 'Dockerfile'                       # OPTIONAL: The name of the dockerfile. Docker client does allow the Dockerfile
+                                                          # to be named differently. Defaults to Dockerfile.
+                                                          # In effect, the -f option value passed to docker build will be repository_checkout_folder/src/DockerFinal/Foo.dockerfile.
+      repository_name: 'cdpxwin1809'                      # only supported ones are cdpx acr repos
+      tag: 'win-ciprod'                                    # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
+      latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.


### PR DESCRIPTION
separate build yamls for the official prod branch with separate image tags. per discussion with cdpx team, there is not easy alternative to avoid conflict with dev and prod image tags without messing up build definition. 