### PR TITLE
fix: Reverting back to ltsc2019 tag

### DIFF
--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore@sha256:921bed01c2a023310bdbaa288edebd82c4910e536ff206b87e9cbe703ca27505
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"


### PR DESCRIPTION
Pinning it to a tag can prove dangerous on machines where egress is not allowed and we only have cached images to work with.

Reverting it to ltsc2019 as the latest image for this has long term support and is going to be cached for all clusters.