### PR TITLE
fix quote issue for the region in arc onboarding issue

### DIFF
--- a/scripts/onboarding/managed/enable-monitoring.sh
+++ b/scripts/onboarding/managed/enable-monitoring.sh
@@ -499,7 +499,7 @@ install_helm_chart()
  fi
 
  echo "getting the region of the cluster"
- clusterRegion=$(az resource show --ids ${clusterResourceId} --query location)
+ clusterRegion=$(az resource show --ids ${clusterResourceId} --query location -o tsv)
  echo "cluster region is : ${clusterRegion}"
 
  echo "adding helm repo:" $helmRepoName


### PR DESCRIPTION
az resource show --ids ${clusterResourceId} --query location returns the region with quotes for example "eastus" instead of eastus which causing invalid mdm endpoint so using the -o tsv option to get rid off quotes.