### PR TITLE
add 'Terminating' state

### DIFF
--- a/source/plugins/ruby/constants.rb
+++ b/source/plugins/ruby/constants.rb
@@ -74,4 +74,7 @@ class Constants
     TELEMETRY_FLUSH_INTERVAL_IN_MINUTES = 10
     KUBE_STATE_TELEMETRY_FLUSH_INTERVAL_IN_MINUTES = 15
     MDM_TIME_SERIES_FLUSHED_IN_LAST_HOUR = "MdmTimeSeriesFlushedInLastHour"
+
+    #Pod Statuses
+    POD_STATUS_TERMINATING = "Terminating"
 end

--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -194,6 +194,9 @@ module Fluent
 
           if podReadyCondition == false
             record["PodStatus"] = "Unknown"
+          # ICM - https://portal.microsofticm.com/imp/v3/incidents/details/187091803/home
+          elsif !items["metadata"]["deletionTimestamp"].nil? && !items["metadata"]["deletionTimestamp"].empty?
+            record["PodStatus"] = Constants::POD_STATUS_TERMINATING
           else
             record["PodStatus"] = items["status"]["phase"]
           end


### PR DESCRIPTION
This change is for ICM - https://portal.microsofticm.com/imp/v3/incidents/details/187091803/home.
To match with kubectl, we will now show 'Terminating' pods.

kubectl:
![image](https://user-images.githubusercontent.com/10353076/93953087-5750e200-fcff-11ea-9e60-4e88f7d7744d.png)



Ux:
![image](https://user-images.githubusercontent.com/10353076/93953124-6b94df00-fcff-11ea-83fc-25aca15e31a5.png)
