### PR TITLE
Gangams/sept agent release tasks

### DIFF
--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -632,8 +632,7 @@
   name_prefix="container.azm.ms/"
   ## An array of urls to scrape metrics from.
   urls = ["$CADVISOR_METRICS_URL"]
-  ## Include "$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC" when we add for support for 1.18
-  fieldpass = ["$KUBELET_RUNTIME_OPERATIONS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_METRIC"]
+  fieldpass = ["$KUBELET_RUNTIME_OPERATIONS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_METRIC", "$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC", "$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC"]
 
   metric_version = 2
   url_tag = "scrapeUrl"
@@ -675,7 +674,7 @@
   name_prefix="container.azm.ms/"
   ## An array of urls to scrape metrics from.
   urls = ["$CADVISOR_METRICS_URL"]
-  
+
   fieldpass = ["kubelet_running_pod_count","volume_manager_total_volumes", "kubelet_node_config_error", "process_resident_memory_bytes", "process_cpu_seconds_total"]
 
   metric_version = 2
@@ -690,7 +689,7 @@
   ## Optional TLS Config
   tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   insecure_skip_verify = true
-  
+
 
 ## prometheus custom metrics
 [[inputs.prometheus]]
@@ -731,7 +730,7 @@
   #name_prefix="container.azm.ms/"
   ## An array of urls to scrape metrics from.
   urls = $AZMON_INTEGRATION_NPM_METRICS_URL_LIST_NODE
-  
+
   metric_version = 2
   url_tag = "scrapeUrl"
 

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -25,12 +25,13 @@ spec:
     dockerProviderVersion: {{ .Values.omsagent.image.dockerProviderVersion }}
     schema-versions: "v1"
   spec:
-    nodeSelector:
-    {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+   nodeSelector:
       kubernetes.io/os: windows
-    {{- else -}}
+{{- else }}
+   nodeSelector:
       beta.kubernetes.io/os: windows
-    {{- end }}
+{{- end }}
    {{- if .Values.omsagent.rbac }}
    serviceAccountName: omsagent
    {{- end }}

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -25,8 +25,12 @@ spec:
     dockerProviderVersion: {{ .Values.omsagent.image.dockerProviderVersion }}
     schema-versions: "v1"
   spec:
-   nodeSelector:
+    nodeSelector:
+    {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+      kubernetes.io/os: windows
+    {{- else -}}
       beta.kubernetes.io/os: windows
+    {{- end }}
    {{- if .Values.omsagent.rbac }}
    serviceAccountName: omsagent
    {{- end }}

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -59,11 +59,18 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
-              {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
                 - key: kubernetes.io/os
-              {{- else -}}
+                  operator: In
+                  values:
+                    - linux
+                - key: type
+                  operator: NotIn
+                  values:
+                    - virtual-kubelet
+          nodeSelectorTerms:
+            - labelSelector:
+              matchExpressions:
                 - key: beta.kubernetes.io/os
-              {{- end }}
                   operator: In
                   values:
                     - linux
@@ -78,11 +85,22 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
-              {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
                 - key: kubernetes.io/os
-              {{- else -}}
+                  operator: In
+                  values:
+                    - linux
+                - key: type
+                  operator: NotIn
+                  values:
+                    - virtual-kubelet
+                - key: kubernetes.io/role
+                  operator: NotIn
+                  values:
+                    - master
+          nodeSelectorTerms:
+            - labelSelector:
+              matchExpressions:
                 - key: beta.kubernetes.io/os
-              {{- end }}
                   operator: In
                   values:
                     - linux

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -59,7 +59,11 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
+              {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+                - key: kubernetes.io/os
+              {{- else -}}
                 - key: beta.kubernetes.io/os
+              {{- end }}
                   operator: In
                   values:
                     - linux
@@ -74,7 +78,11 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
+              {{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+                - key: kubernetes.io/os
+              {{- else -}}
                 - key: beta.kubernetes.io/os
+              {{- end }}
                   operator: In
                   values:
                     - linux

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -300,11 +300,10 @@ fi
 echo "configured container runtime on kubelet is : "$CONTAINER_RUNTIME
 echo "export CONTAINER_RUNTIME="$CONTAINER_RUNTIME >> ~/.bashrc
 
-# enable these metrics in next agent release
-# export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="kubelet_runtime_operations_total"
-# echo "export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC >> ~/.bashrc
-# export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="kubelet_runtime_operations_errors_total"
-# echo "export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC >> ~/.bashrc
+export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="kubelet_runtime_operations_total"
+echo "export KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_TOTAL_METRIC >> ~/.bashrc
+export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="kubelet_runtime_operations_errors_total"
+echo "export KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC="$KUBELET_RUNTIME_OPERATIONS_ERRORS_TOTAL_METRIC >> ~/.bashrc
 
 # default to docker metrics
 export KUBELET_RUNTIME_OPERATIONS_METRIC="kubelet_docker_operations"

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -419,7 +419,8 @@ spec:
             nodeSelectorTerms:
               - labelSelector:
                 matchExpressions:
-                  - key: beta.kubernetes.io/os
+      # kubernetes.io/os label doesnt exist in k8s versions < 1.14  so make sure to choose label based on k8s version in aks yaml
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                     - linux

--- a/source/plugins/ruby/lib/application_insights/channel/sender_base.rb
+++ b/source/plugins/ruby/lib/application_insights/channel/sender_base.rb
@@ -1,9 +1,9 @@
-require "yajl/json_gem"
-require "net/http"
-require "openssl"
-require "stringio"
-require "zlib"
-require "logger"
+require 'yajl/json_gem'
+require 'net/http'
+require 'openssl'
+require 'stringio'
+require 'zlib'
+require 'logger'
 
 module ApplicationInsights
   module Channel
@@ -53,9 +53,9 @@ module ApplicationInsights
       def send(data_to_send)
         uri = URI(@service_endpoint_uri)
         headers = {
-          "Accept" => "application/json",
-          "Content-Type" => "application/json; charset=utf-8",
-          "Content-Encoding" => "gzip",
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json; charset=utf-8',
+          'Content-Encoding' => 'gzip'
         }
         request = Net::HTTP::Post.new(uri.path, headers)
 
@@ -69,7 +69,7 @@ module ApplicationInsights
         else
           http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
         end
-        if uri.scheme.downcase == "https"
+        if uri.scheme.downcase == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
@@ -78,7 +78,7 @@ module ApplicationInsights
         http.finish if http.started?
 
         if !response.kind_of? Net::HTTPSuccess
-          @logger.warn("application_insights") { "Failed to send data: #{response.message}" }
+          @logger.warn('application_insights') { "Failed to send data: #{response.message}" }
         end
       end
 

--- a/source/plugins/ruby/lib/application_insights/channel/sender_base.rb
+++ b/source/plugins/ruby/lib/application_insights/channel/sender_base.rb
@@ -1,9 +1,9 @@
-require 'yajl/json_gem'
-require 'net/http'
-require 'openssl'
-require 'stringio'
-require 'zlib'
-require 'logger'
+require "yajl/json_gem"
+require "net/http"
+require "openssl"
+require "stringio"
+require "zlib"
+require "logger"
 
 module ApplicationInsights
   module Channel
@@ -53,9 +53,9 @@ module ApplicationInsights
       def send(data_to_send)
         uri = URI(@service_endpoint_uri)
         headers = {
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json; charset=utf-8',
-          'Content-Encoding' => 'gzip'
+          "Accept" => "application/json",
+          "Content-Type" => "application/json; charset=utf-8",
+          "Content-Encoding" => "gzip",
         }
         request = Net::HTTP::Post.new(uri.path, headers)
 
@@ -66,19 +66,19 @@ module ApplicationInsights
         request.body = compressed_data
         if @proxy.nil? || @proxy.empty?
           http = Net::HTTP.new uri.hostname, uri.port
-        else 
+        else
           http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
         end
-        if uri.scheme.downcase == 'https'
+        if uri.scheme.downcase == "https"
           http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 
         response = http.request(request)
         http.finish if http.started?
 
         if !response.kind_of? Net::HTTPSuccess
-          @logger.warn('application_insights') { "Failed to send data: #{response.message}" }
+          @logger.warn("application_insights") { "Failed to send data: #{response.message}" }
         end
       end
 

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -67,10 +67,11 @@ module Fluent
         if aks_resource_id.to_s.empty?
           @log.info "Environment Variable AKS_RESOURCE_ID is not set.. "
           @can_send_data_to_mdm = false
-        elsif !aks_resource_id.downcase.include?("/microsoft.kubernetes/connectedclusters/") && !aks_resource_id.downcase.include?("/microsoft.containerservice/managedclusters/")
+        elsif !aks_resource_id.downcase.include?("/microsoft.containerservice/managedclusters/") && !aks_resource_id.downcase.include?("/microsoft.kubernetes/connectedclusters/")
           @log.info "MDM Metris not supported for this cluster type resource: #{aks_resource_id}"
           @can_send_data_to_mdm = false
         end
+
         if aks_region.to_s.empty?
           @log.info "Environment Variable AKS_REGION is not set.. "
           @can_send_data_to_mdm = false
@@ -107,7 +108,7 @@ module Fluent
             @cluster_identity = ArcK8sClusterIdentity.new
             @cached_access_token = @cluster_identity.get_cluster_identity_token
           else
-            # azure json file only used for aks
+            # azure json file only used for aks and doesnt exist non-azure envs
             file = File.read(@@azure_json_path)
             @data_hash = JSON.parse(file)
             # Check to see if SP exists, if it does use SP. Else, use msi

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -67,18 +67,15 @@ module Fluent
         if aks_resource_id.to_s.empty?
           @log.info "Environment Variable AKS_RESOURCE_ID is not set.. "
           @can_send_data_to_mdm = false
+        elsif !aks_resource_id.downcase.include?("/microsoft.kubernetes/connectedclusters/") && !aks_resource_id.downcase.include?("/microsoft.containerservice/managedclusters/")
+          @log.info "MDM Metris not supported for this cluster type resource: #{aks_resource_id}"
+          @can_send_data_to_mdm = false
         end
         if aks_region.to_s.empty?
           @log.info "Environment Variable AKS_REGION is not set.. "
           @can_send_data_to_mdm = false
         else
           aks_region = aks_region.gsub(" ", "")
-        end
-
-        if !aks_resource_id.to_s.empty? && !aks_resource_id.downcase.include?("microsoft.kubernetes/connectedclusters")
-          && !aks_resource_id.downcase.include?("microsoft.containerservice/managedclusters")
-          @log.info "MDM Metris not supported for this cluster type resource: #{aks_resource_id}"
-          @can_send_data_to_mdm = false
         end
 
         if @can_send_data_to_mdm

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -108,7 +108,7 @@ module Fluent
             @cluster_identity = ArcK8sClusterIdentity.new
             @cached_access_token = @cluster_identity.get_cluster_identity_token
           else
-            # azure json file only used for aks and doesnt exist non-azure envs
+            # azure json file only used for aks and doesnt exist in non-azure envs
             file = File.read(@@azure_json_path)
             @data_hash = JSON.parse(file)
             # Check to see if SP exists, if it does use SP. Else, use msi


### PR DESCRIPTION
This PR has following changes

1. Turn off MDM Ingestion for non-supported clusters and only allow AKS and Arc K8s
2. Enable kubelet_runtime_operations_total and kubelet_runtime_operations_errors_total metrics
3. Enable OpenSSL::SSL::VERIFY_PEER for AI ruby client to prevent MTM attacks
4. handle both beta.kubernetes.io/os  and kubernetes.io/os label since beta one deprecated
5. Move reading of azure.json file for aks code path since this doesnt exist on-prem clusters of arc k8s