### PR TITLE
grwehner/pv-collect-volume-name

### DIFF
--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -359,6 +359,7 @@ class CAdvisorMetricsAPIClient
                   metricTags[Constants::INSIGHTSMETRICS_TAGS_POD_NAME] = podName
                   metricTags[Constants::INSIGHTSMETRICS_TAGS_PVC_NAME] = pvcName
                   metricTags[Constants::INSIGHTSMETRICS_TAGS_PVC_NAMESPACE] = pvcNamespace
+                  metricTags[Constants::INSIGHTSMETRICS_TAGS_VOLUME_NAME] = volume["name"]
                   metricTags[Constants::INSIGHTSMETRICS_TAGS_PV_CAPACITY_BYTES] = volume["capacityBytes"]
 
                   metricItem["Tags"] = metricTags

--- a/source/plugins/ruby/constants.rb
+++ b/source/plugins/ruby/constants.rb
@@ -19,6 +19,7 @@ class Constants
     INSIGHTSMETRICS_TAGS_PVC_NAMESPACE = "pvcNamespace"
     INSIGHTSMETRICS_TAGS_POD_NAME = "podName"
     INSIGHTSMETRICS_TAGS_PV_CAPACITY_BYTES = "pvCapacityBytes"
+    INSIGHTSMETRICS_TAGS_VOLUME_NAME = "volumeName"
     INSIGHTSMETRICS_FLUENT_TAG = "oms.api.InsightsMetrics"
     REASON_OOM_KILLED = "oomkilled"
     #Kubestate (common)


### PR DESCRIPTION
Collect and send the volume name as another tag for pvUsedBytes in InsightsMetrics, so that it can be displayed in the workload workbook