### PR TITLE
update onboarding scripts to use latest version of chat :2.7.7

### DIFF
--- a/scripts/onboarding/managed/enable-monitoring.ps1
+++ b/scripts/onboarding/managed/enable-monitoring.ps1
@@ -60,7 +60,7 @@ $isUsingServicePrincipal = $false
 
 # released chart version in mcr
 $mcr = "mcr.microsoft.com"
-$mcrChartVersion = "2.7.6"
+$mcrChartVersion = "2.7.7"
 $mcrChartRepoPath = "azuremonitor/containerinsights/preview/azuremonitor-containers"
 $helmLocalRepoName = "."
 

--- a/scripts/onboarding/managed/enable-monitoring.sh
+++ b/scripts/onboarding/managed/enable-monitoring.sh
@@ -42,7 +42,7 @@ set -o pipefail
 defaultAzureCloud="AzureCloud"
 
 # released chart version in mcr
-mcrChartVersion="2.7.6"
+mcrChartVersion="2.7.7"
 mcr="mcr.microsoft.com"
 mcrChartRepoPath="azuremonitor/containerinsights/preview/azuremonitor-containers"
 helmLocalRepoName="."


### PR DESCRIPTION
update the onboarding scripts to use latest version of chart i.e. 2.7.7 which uses sept 2020 agent image. 