### PR TITLE
grwehner/mdm custom metric regions

### DIFF
--- a/build/linux/installer/conf/container.conf
+++ b/build/linux/installer/conf/container.conf
@@ -45,14 +45,12 @@
 #custom_metrics_mdm filter plugin
 <filter mdm.cadvisorperf**>
   type filter_cadvisor2mdm
-  custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
   metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,memoryRssBytes,pvUsedBytes
   log_level info
 </filter>
 
 <filter oms.mdm.container.perf.telegraf**>
   type filter_telegraf2mdm
-  custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
   log_level debug
 </filter>
 

--- a/build/linux/installer/conf/kube.conf
+++ b/build/linux/installer/conf/kube.conf
@@ -13,7 +13,6 @@
      tag oms.containerinsights.KubePodInventory
      run_interval 60
      log_level debug
-     custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
     </source>
 
     #Kubernetes events
@@ -66,14 +65,12 @@
 
     <filter mdm.kubenodeinventory**>
      type filter_inventory2mdm
-     custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
      log_level info
     </filter>
 
     #custom_metrics_mdm filter plugin for perf data from windows nodes
     <filter mdm.cadvisorperf**>
      type filter_cadvisor2mdm
-     custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
      metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
      log_level info
     </filter>

--- a/charts/azuremonitor-containers/templates/omsagent-rs-configmap.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-rs-configmap.yaml
@@ -18,7 +18,6 @@ data:
       tag oms.containerinsights.KubePodInventory
       run_interval 60
       log_level debug
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
      </source>
 
      #Kubernetes events
@@ -70,14 +69,12 @@ data:
      </source>
      <filter mdm.kubenodeinventory**>
       type filter_inventory2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
       log_level info
      </filter>
 
      # custom_metrics_mdm filter plugin for perf data from windows nodes
      <filter mdm.cadvisorperf**>
       type filter_cadvisor2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
       metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes
       log_level info
      </filter>

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -150,6 +150,17 @@ else
       echo "LA Onboarding:Workspace Id not mounted, skipping the telemetry check"
 fi
 
+# Set environment variable for if public cloud by checking the workspace domain.
+if [-z $DOMAIN]; then
+  $ClOUD_ENVIRONMENT = "unknown"
+elif [$DOMAIN == "opinsights.azure.com"]; then
+  $CLOUD_ENVIRONMENT = "public"
+else
+  $CLOUD_ENVIRONMENT = "national"
+fi
+export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
+echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
+
 #Parse the configmap to set the right environment variables.
 /opt/microsoft/omsagent/ruby/bin/ruby tomlparser.rb
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -152,11 +152,11 @@ fi
 
 # Set environment variable for if public cloud by checking the workspace domain.
 if [-z $DOMAIN]; then
-  $ClOUD_ENVIRONMENT = "unknown"
+  $ClOUD_ENVIRONMENT="unknown"
 elif [$DOMAIN == "opinsights.azure.com"]; then
-  $CLOUD_ENVIRONMENT = "public"
+  $CLOUD_ENVIRONMENT="public"
 else
-  $CLOUD_ENVIRONMENT = "national"
+  $CLOUD_ENVIRONMENT="national"
 fi
 
 #Parse the configmap to set the right environment variables.

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -158,8 +158,6 @@ elif [$DOMAIN == "opinsights.azure.com"]; then
 else
   $CLOUD_ENVIRONMENT = "national"
 fi
-export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
-echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
 
 #Parse the configmap to set the right environment variables.
 /opt/microsoft/omsagent/ruby/bin/ruby tomlparser.rb
@@ -549,6 +547,8 @@ else
       telemetry_cluster_type="AKS"
 fi
 
+export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
+echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
 export TELEMETRY_AKS_RESOURCE_ID=$telemetry_aks_resource_id
 echo "export TELEMETRY_AKS_RESOURCE_ID=$telemetry_aks_resource_id" >> ~/.bashrc
 export TELEMETRY_AKS_REGION=$telemetry_aks_region

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -151,13 +151,15 @@ else
 fi
 
 # Set environment variable for if public cloud by checking the workspace domain.
-if [-z $DOMAIN]; then
-  $ClOUD_ENVIRONMENT="unknown"
-elif [$DOMAIN == "opinsights.azure.com"]; then
-  $CLOUD_ENVIRONMENT="public"
+if [ -z $domain ]; then
+  ClOUD_ENVIRONMENT="unknown"
+elif [ $domain == "opinsights.azure.com" ]; then
+  CLOUD_ENVIRONMENT="public"
 else
-  $CLOUD_ENVIRONMENT="national"
+  CLOUD_ENVIRONMENT="national"
 fi
+export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
+echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
 
 #Parse the configmap to set the right environment variables.
 /opt/microsoft/omsagent/ruby/bin/ruby tomlparser.rb
@@ -547,8 +549,6 @@ else
       telemetry_cluster_type="AKS"
 fi
 
-export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
-echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
 export TELEMETRY_AKS_RESOURCE_ID=$telemetry_aks_resource_id
 echo "export TELEMETRY_AKS_RESOURCE_ID=$telemetry_aks_resource_id" >> ~/.bashrc
 export TELEMETRY_AKS_REGION=$telemetry_aks_region

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -64,7 +64,6 @@ data:
       tag oms.containerinsights.KubePodInventory
       run_interval 60
       log_level debug
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
      </source>
 
      #Kubernetes events
@@ -117,14 +116,12 @@ data:
 
      <filter mdm.kubenodeinventory**>
       type filter_inventory2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
       log_level info
      </filter>
 
      #custom_metrics_mdm filter plugin for perf data from windows nodes
      <filter mdm.cadvisorperf**>
       type filter_cadvisor2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westeurope,southafricanorth,centralus,northcentralus,eastus2,koreacentral,eastasia,centralindia,uksouth,canadacentral,francecentral,japaneast,australiaeast,eastus2,westus,australiasoutheast,brazilsouth,germanywestcentral,northcentralus,switzerlandnorth
       metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
       log_level info
      </filter>

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -43,14 +43,20 @@ function Start-FileSystemWatcher {
 
 function Set-EnvironmentVariables {
     $domain = "opinsights.azure.com"
+    $cloud_environment = "public"
     if (Test-Path /etc/omsagent-secret/DOMAIN) {
         # TODO: Change to omsagent-secret before merging
         $domain = Get-Content /etc/omsagent-secret/DOMAIN
+        $cloud_environment = "national"
     }
 
     # Set DOMAIN
     [System.Environment]::SetEnvironmentVariable("DOMAIN", $domain, "Process")
     [System.Environment]::SetEnvironmentVariable("DOMAIN", $domain, "Machine")
+
+    # Set CLOUD_ENVIRONMENT
+    [System.Environment]::SetEnvironmentVariable("CLOUD_ENVIRONMENT", $cloud_environment, "Process")
+    [System.Environment]::SetEnvironmentVariable("CLOUD_ENVIRONMENT", $cloud_environment, "Machine")
 
     $wsID = ""
     if (Test-Path /etc/omsagent-secret/WSID) {

--- a/scripts/preview/health/omsagent-template-aks-engine.yaml
+++ b/scripts/preview/health/omsagent-template-aks-engine.yaml
@@ -108,14 +108,12 @@ data:
 
     <filter mdm.kubepodinventory** mdm.kubenodeinventory**>
      type filter_inventory2mdm
-     custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westEurope
      log_level info
     </filter>
 
     # custom_metrics_mdm filter plugin for perf data from windows nodes
     <filter mdm.cadvisorperf**>
      type filter_cadvisor2mdm
-     custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westEurope
      metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes
      log_level info
     </filter>

--- a/scripts/preview/health/omsagent-template.yaml
+++ b/scripts/preview/health/omsagent-template.yaml
@@ -108,14 +108,12 @@ data:
 
      <filter mdm.kubepodinventory** mdm.kubenodeinventory**>
       type filter_inventory2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westEurope
       log_level info
      </filter>
 
      # custom_metrics_mdm filter plugin for perf data from windows nodes
      <filter mdm.cadvisorperf**>
       type filter_cadvisor2mdm
-      custom_metrics_azure_regions eastus,southcentralus,westcentralus,westus2,southeastasia,northeurope,westEurope
       metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes
       log_level info
      </filter>

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -9,12 +9,12 @@ class CustomMetricsUtils
         def check_custom_metrics_availability
             aks_region = ENV['AKS_REGION']
             aks_resource_id = ENV['AKS_RESOURCE_ID']
-            aks_cloud_environment = ENV['CLOUD_ENVIRONTMENT']
+            aks_cloud_environment = ENV['CLOUD_ENVIRONMENT']
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
             
-            return aks_cloud_environment.downcase == 'public'
+            return aks_cloud_environment.to_s.downcase == 'public'
         end
     end
 end

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -6,21 +6,15 @@ class CustomMetricsUtils
     end
 
     class << self
-        def check_custom_metrics_availability(custom_metric_regions)
+        def check_custom_metrics_availability
             aks_region = ENV['AKS_REGION']
             aks_resource_id = ENV['AKS_RESOURCE_ID']
+            aks_cloud_environment = ENV['CLOUD_ENVIRONTMENT']
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
             
-            custom_metrics_regions_arr = custom_metric_regions.split(',')
-            custom_metrics_regions_hash = custom_metrics_regions_arr.map {|x| [x.downcase,true]}.to_h
-
-            if custom_metrics_regions_hash.key?(aks_region.downcase)
-                true
-            else 
-                false
-            end
+            return aks_cloud_environment.downcase == 'public'
         end
     end
 end

--- a/source/plugins/ruby/filter_cadvisor2mdm.rb
+++ b/source/plugins/ruby/filter_cadvisor2mdm.rb
@@ -15,7 +15,6 @@ module Fluent
 
     config_param :enable_log, :integer, :default => 0
     config_param :log_path, :string, :default => "/var/opt/microsoft/docker-cimprov/log/filter_cadvisor2mdm.log"
-    config_param :custom_metrics_azure_regions, :string
     config_param :metrics_to_collect, :string, :default => "Constants::CPU_USAGE_NANO_CORES,Constants::MEMORY_WORKING_SET_BYTES,Constants::MEMORY_RSS_BYTES,Constants::PV_USED_BYTES"
 
     @@hostName = (OMS::Common.get_hostname)
@@ -42,7 +41,7 @@ module Fluent
     def start
       super
       begin
-        @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability(@custom_metrics_azure_regions)
+        @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability
         @metrics_to_collect_hash = build_metrics_hash
         @log.debug "After check_custom_metrics_availability process_incoming_stream #{@process_incoming_stream}"
         @@containerResourceUtilTelemetryTimeTracker = DateTime.now.to_time.to_i

--- a/source/plugins/ruby/filter_inventory2mdm.rb
+++ b/source/plugins/ruby/filter_inventory2mdm.rb
@@ -13,7 +13,6 @@ module Fluent
 
 		config_param :enable_log, :integer, :default => 0
         config_param :log_path, :string, :default => '/var/opt/microsoft/docker-cimprov/log/filter_inventory2mdm.log'
-        config_param :custom_metrics_azure_regions, :string
 
         @@node_count_metric_name = 'nodesCount'
         @@pod_count_metric_name = 'podCount'
@@ -98,7 +97,7 @@ module Fluent
 
         def start
             super
-            @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability(@custom_metrics_azure_regions)
+            @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability
             @log.debug "After check_custom_metrics_availability process_incoming_stream #{@process_incoming_stream}"
         end
 

--- a/source/plugins/ruby/filter_telegraf2mdm.rb
+++ b/source/plugins/ruby/filter_telegraf2mdm.rb
@@ -15,7 +15,6 @@ module Fluent
 
     config_param :enable_log, :integer, :default => 0
     config_param :log_path, :string, :default => "/var/opt/microsoft/docker-cimprov/log/filter_telegraf2mdm.log"
-    config_param :custom_metrics_azure_regions, :string
 
     @process_incoming_stream = true
 
@@ -36,7 +35,7 @@ module Fluent
     def start
       super
       begin
-        @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability(@custom_metrics_azure_regions)
+        @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability
         @log.debug "After check_custom_metrics_availability process_incoming_stream #{@process_incoming_stream}"
       rescue => errorStr
         @log.info "Error initializing plugin #{errorStr}"

--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -36,11 +36,10 @@ module Fluent
 
     config_param :run_interval, :time, :default => 60
     config_param :tag, :string, :default => "oms.containerinsights.KubePodInventory"
-    config_param :custom_metrics_azure_regions, :string
 
     def configure(conf)
       super
-      @inventoryToMdmConvertor = Inventory2MdmConvertor.new(@custom_metrics_azure_regions)
+      @inventoryToMdmConvertor = Inventory2MdmConvertor.new()
     end
 
     def start

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -268,7 +268,10 @@ module Fluent
       begin
         # Adding this before trying to flush out metrics, since adding after can lead to metrics never being sent
         flush_mdm_exception_telemetry
-        if (!@first_post_attempt_made || (Time.now > @last_post_attempt_time + retry_mdm_post_wait_minutes * 60)) && @can_send_data_to_mdm
+
+        # Always try to write if can send data to mdm and using MSI since the permissions can update without a token refresh.
+        # Still wait the specified timeframe if using SP and encountered a 403.
+        if (@useMsi || !@first_post_attempt_made || (Time.now > @last_post_attempt_time + retry_mdm_post_wait_minutes * 60)) && @can_send_data_to_mdm
           post_body = []
           chunk.msgpack_each { |(tag, record)|
             post_body.push(record.to_json)

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -271,7 +271,7 @@ module Fluent
 
         # Always try to write if can send data to mdm and using MSI since the permissions can update without a token refresh.
         # Still wait the specified timeframe if using SP and encountered a 403.
-        if (@useMsi || !@first_post_attempt_made || (Time.now > @last_post_attempt_time + retry_mdm_post_wait_minutes * 60)) && @can_send_data_to_mdm
+        if (!@first_post_attempt_made || (Time.now > @last_post_attempt_time + retry_mdm_post_wait_minutes * 60)) && @can_send_data_to_mdm
           post_body = []
           chunk.msgpack_each { |(tag, record)|
             post_body.push(record.to_json)

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -268,9 +268,6 @@ module Fluent
       begin
         # Adding this before trying to flush out metrics, since adding after can lead to metrics never being sent
         flush_mdm_exception_telemetry
-
-        # Always try to write if can send data to mdm and using MSI since the permissions can update without a token refresh.
-        # Still wait the specified timeframe if using SP and encountered a 403.
         if (!@first_post_attempt_made || (Time.now > @last_post_attempt_time + retry_mdm_post_wait_minutes * 60)) && @can_send_data_to_mdm
           post_body = []
           chunk.msgpack_each { |(tag, record)|

--- a/source/plugins/ruby/podinventory_to_mdm.rb
+++ b/source/plugins/ruby/podinventory_to_mdm.rb
@@ -80,14 +80,14 @@ class Inventory2MdmConvertor
   @@pod_phase_values = ["Running", "Pending", "Succeeded", "Failed", "Unknown"]
   @process_incoming_stream = false
 
-  def initialize(custom_metrics_azure_regions)
+  def initialize()
     @log_path = "/var/opt/microsoft/docker-cimprov/log/mdm_metrics_generator.log"
     @log = Logger.new(@log_path, 1, 5000000)
     @pod_count_hash = {}
     @no_phase_dim_values_hash = {}
     @pod_count_by_phase = {}
     @pod_uids = {}
-    @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability(custom_metrics_azure_regions)
+    @process_incoming_stream = CustomMetricsUtils.check_custom_metrics_availability
     @log.debug "After check_custom_metrics_availability process_incoming_stream #{@process_incoming_stream}"
     @log.debug { "Starting podinventory_to_mdm plugin" }
   end


### PR DESCRIPTION
- Remove custom metrics region check for public cloud by removing the custom_metrics_azure_regions variable for plugins and changing to only check the cloud environment. This is set as an environment variable using the workspace domain in the main.sh file so that it'll work with AKS and ARC.

My questions:
Should the check be more explicit by specifically checking if the workspace domain is indeed for a national cloud? Should custom metrics be available for any other cluster with a workspace domain that isn't opinsights.azure.com? What should the strategy be if the domain is not set?