### PR TITLE
grwehner/jan agent tasks

### DIFF
--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -228,7 +228,7 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
     file.write(commands)
     commands = get_command_windows('AZMON_LOG_TAIL_PATH', @logTailPath)
     file.write(commands)
-    commands = get_command_windows('AZMON_LOG_EXCLUSION_REGEX_PATTERN', @stdoutExcludeNamespaces)
+    commands = get_command_windows('AZMON_LOG_EXCLUSION_REGEX_PATTERN', @logExclusionRegexPattern)
     file.write(commands)
     commands = get_command_windows('AZMON_STDOUT_EXCLUDED_NAMESPACES', @stdoutExcludeNamespaces)
     file.write(commands)

--- a/build/windows/installer/certificategenerator/Program.cs
+++ b/build/windows/installer/certificategenerator/Program.cs
@@ -364,7 +364,7 @@ namespace certificategenerator
 
             try
             {
-              agentCert = CreateSelfSignedCertificate(agentGuid, logAnalyticsWorkspaceId);
+                agentCert = CreateSelfSignedCertificate(agentGuid, logAnalyticsWorkspaceId);
 
                 if (agentCert == null)
                 {

--- a/build/windows/installer/certificategenerator/Program.cs
+++ b/build/windows/installer/certificategenerator/Program.cs
@@ -414,10 +414,11 @@ namespace certificategenerator
 
             try
             {
-                if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("WSKEY")))
-                {
-                    logAnalyticsWorkspaceSharedKey = Environment.GetEnvironmentVariable("WSKEY");
-                }
+              logAnalyticsWorkspaceSharedKey = File.ReadAllText("C:/etc/omsagent-secret/KEY");
+                //if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("WSKEY")))
+                //{
+                    //logAnalyticsWorkspaceSharedKey = Environment.GetEnvironmentVariable("WSKEY");
+                //}
             }
             catch (Exception ex)
             {

--- a/build/windows/installer/certificategenerator/Program.cs
+++ b/build/windows/installer/certificategenerator/Program.cs
@@ -364,7 +364,7 @@ namespace certificategenerator
 
             try
             {
-                agentCert = CreateSelfSignedCertificate(agentGuid, logAnalyticsWorkspaceId);
+              agentCert = CreateSelfSignedCertificate(agentGuid, logAnalyticsWorkspaceId);
 
                 if (agentCert == null)
                 {
@@ -414,15 +414,12 @@ namespace certificategenerator
 
             try
             {
-              logAnalyticsWorkspaceSharedKey = File.ReadAllText("C:/etc/omsagent-secret/KEY");
-                //if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("WSKEY")))
-                //{
-                    //logAnalyticsWorkspaceSharedKey = Environment.GetEnvironmentVariable("WSKEY");
-                //}
+              // WSKEY isn't stored as an environment variable
+              logAnalyticsWorkspaceSharedKey = File.ReadAllText("C:/etc/omsagent-secret/KEY").Trim();
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Failed to read env variables (WSKEY)" + ex.Message);
+                Console.WriteLine("Failed to read secret (WSKEY)" + ex.Message);
             }
 
             try

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -29,15 +29,6 @@
   @include fluent-docker-parser.conf
 </source>
 
-<filter  oms.container.**>
-  @type record_transformer
-  # fluent-plugin-record-modifier more light-weight but needs to be installed (dependency worth it?)
-  remove_keys tailed_path
-  <record>
-    filepath ${record["tailed_path"]}
-  </record>
-</filter>
-
 <filter oms.container.log.la>
   @type grep
   <exclude>
@@ -46,6 +37,14 @@
   </exclude>
 </filter>
 
+<filter  oms.container.**>
+  @type record_transformer
+  # fluent-plugin-record-modifier more light-weight but needs to be installed (dependency worth it?)
+  remove_keys tailed_path
+  <record>
+    filepath ${record["tailed_path"]}
+  </record>
+</filter>
 
 <match oms.container.**>
   @type forward

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -7,6 +7,7 @@
 <source>
   @type tail
   path "#{ENV['AZMON_LOG_TAIL_PATH']}"
+  exclude_path "#{ENV['AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH']}"
   pos_file /var/opt/microsoft/fluent/fluentd-containers.log.pos
   tag oms.container.log.la
   @log_level trace
@@ -35,6 +36,14 @@
   <record>
     filepath ${record["tailed_path"]}
   </record>
+</filter>
+
+<filter oms.container.log.la>
+  @type grep
+  <exclude>
+    key stream
+    pattern "#{ENV['AZMON_LOG_EXCLUSION_REGEX_PATTERN']}"
+  </exclude>
 </filter>
 
 

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -6,7 +6,7 @@
 
 <source>
   @type tail
-  path /var/log/containers/*.log
+  path "#{ENV['AZMON_LOG_TAIL_PATH']}"
   pos_file /var/opt/microsoft/fluent/fluentd-containers.log.pos
   tag oms.container.log.la
   @log_level trace

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -64,19 +64,11 @@ function Set-EnvironmentVariables {
         $wsID = Get-Content /etc/omsagent-secret/WSID
     }
 
-    # Set DOMAIN
+    # Set WSID
     [System.Environment]::SetEnvironmentVariable("WSID", $wsID, "Process")
     [System.Environment]::SetEnvironmentVariable("WSID", $wsID, "Machine")
 
-    $wsKey = ""
-    if (Test-Path /etc/omsagent-secret/KEY) {
-        # TODO: Change to omsagent-secret before merging
-        $wsKey = Get-Content /etc/omsagent-secret/KEY
-    }
-
-    # Set KEY
-    #[System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Process")
-    #[System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Machine")
+    # Don't store WSKEY as environment variable
 
     $proxy = ""
     if (Test-Path /etc/omsagent-secret/PROXY) {

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -75,8 +75,8 @@ function Set-EnvironmentVariables {
     }
 
     # Set KEY
-    [System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Process")
-    [System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Machine")
+    #[System.Environment]::SetEnvironmentVariable("", $wsKey, "Process")
+    #[System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Machine")
 
     $proxy = ""
     if (Test-Path /etc/omsagent-secret/PROXY) {

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -75,7 +75,7 @@ function Set-EnvironmentVariables {
     }
 
     # Set KEY
-    #[System.Environment]::SetEnvironmentVariable("", $wsKey, "Process")
+    #[System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Process")
     #[System.Environment]::SetEnvironmentVariable("WSKEY", $wsKey, "Machine")
 
     $proxy = ""

--- a/source/plugins/ruby/filter_cadvisor2mdm.rb
+++ b/source/plugins/ruby/filter_cadvisor2mdm.rb
@@ -309,12 +309,15 @@ module Fluent
       elsif controller_type.downcase == "daemonset"
         capacity_from_kubelet = KubeletUtils.get_node_capacity
 
+        # Error handling in case /metrics/cadvsior endpoint fails
         if !capacity_from_kubelet.nil? && capacity_from_kubelet.length > 1
           @cpu_capacity = capacity_from_kubelet[0]
           @memory_capacity = capacity_from_kubelet[1]
         else
+          # cpu_capacity and memory_capacity keep initialized value of 0.0
           @log.info "Error getting capacity_from_kubelet: cpu_capacity and memory_capacity"
         end
+
       end
     end
 

--- a/source/plugins/ruby/filter_cadvisor2mdm.rb
+++ b/source/plugins/ruby/filter_cadvisor2mdm.rb
@@ -315,7 +315,7 @@ module Fluent
           @memory_capacity = capacity_from_kubelet[1]
         else
           # cpu_capacity and memory_capacity keep initialized value of 0.0
-          @log.info "Error getting capacity_from_kubelet: cpu_capacity and memory_capacity"
+          @log.error "Error getting capacity_from_kubelet: cpu_capacity and memory_capacity"
         end
 
       end

--- a/source/plugins/ruby/filter_cadvisor2mdm.rb
+++ b/source/plugins/ruby/filter_cadvisor2mdm.rb
@@ -308,8 +308,13 @@ module Fluent
         end
       elsif controller_type.downcase == "daemonset"
         capacity_from_kubelet = KubeletUtils.get_node_capacity
-        @cpu_capacity = capacity_from_kubelet[0]
-        @memory_capacity = capacity_from_kubelet[1]
+
+        if !capacity_from_kubelet.nil? && capacity_from_kubelet.length > 1
+          @cpu_capacity = capacity_from_kubelet[0]
+          @memory_capacity = capacity_from_kubelet[1]
+        else
+          @log.info "Error getting capacity_from_kubelet: cpu_capacity and memory_capacity"
+        end
       end
     end
 


### PR DESCRIPTION
Tasks:
- Windows agent fix to use log filtering settings in config map.
- Error handling for kubelet_utils get_node_capacity in case /metrics/cadvsior endpoint fails.
- Look into not using environment var for workspace key: Looks like it's only used as an env var for windows agent and only by the certificate generator. Made a change to remove the env var and for the certificate generator to read directly from the file that the secret is mounted to instead. This change would affect customers if they are using this environment variable to get the workspace key.