### PR TITLE
fix ci envvar collection in large pods

### DIFF
--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -193,25 +193,41 @@ class KubernetesContainerInventory
       $log.info("KubernetesContainerInventory::obtainContainerEnvironmentVars @ #{Time.now.utc.iso8601}")
       envValueString = ""
       begin
-        unless @@containerCGroupCache.has_key?(containerId)
+        isCGroupPidFetchRequired = false 
+        if !@@containerCGroupCache.has_key?(containerId)
+          isCGroupPidFetchRequired = true 
+        else
+          cGroupPid = @@containerCGroupCache[containerId]
+          if cGroupPid.nil? || cGroupPid.empty?            
+            isCGroupPidFetchRequired = true
+            @@containerCGroupCache.delete(containerId)
+          elsif !File.exist?("/hostfs/proc/#{cGroupPid}/environ")              
+            isCGroupPidFetchRequired = true
+            @@containerCGroupCache.delete(containerId)                       
+          end        
+        end
+
+        if isCGroupPidFetchRequired
           $log.info("KubernetesContainerInventory::obtainContainerEnvironmentVars fetching cGroup parent pid @ #{Time.now.utc.iso8601} for containerId: #{containerId}")
           Dir["/hostfs/proc/*/cgroup"].each do |filename|
             begin
-              if File.file?(filename) && File.foreach(filename).grep(/#{containerId}/).any?
+              if File.file?(filename) && File.exist?(filename) && File.foreach(filename).grep(/#{containerId}/).any?
                 # file full path is /hostfs/proc/<cGroupPid>/cgroup
-                cGroupPid = filename.split("/")[3]
-                if @@containerCGroupCache.has_key?(containerId)
-                  tempCGroupPid = @@containerCGroupCache[containerId]
-                  if tempCGroupPid > cGroupPid
+                cGroupPid = filename.split("/")[3]  
+                if is_number?(cGroupPid)                              
+                  if @@containerCGroupCache.has_key?(containerId)
+                    tempCGroupPid = @@containerCGroupCache[containerId]                  
+                    if tempCGroupPid.to_i > cGroupPid.to_i
+                      @@containerCGroupCache[containerId] = cGroupPid
+                    end
+                  else
                     @@containerCGroupCache[containerId] = cGroupPid
-                  end
-                else
-                  @@containerCGroupCache[containerId] = cGroupPid
+                  end                        
                 end
               end
-            rescue SystemCallError # ignore Error::ENOENT,Errno::ESRCH which is expected if any of the container gone while we read
-            end
-          end
+            rescue SystemCallError # ignore Error::ENOENT,Errno::ESRCH which is expected if any of the container gone while we read              
+            end          
+          end        
         end
         cGroupPid = @@containerCGroupCache[containerId]
         if !cGroupPid.nil? && !cGroupPid.empty?
@@ -340,6 +356,9 @@ class KubernetesContainerInventory
         $log.debug_backtrace(error.backtrace)
         ApplicationInsightsUtility.sendExceptionTelemetry(error)
       end
+    end
+    def is_number?(value)
+      true if Integer(value) rescue false
     end
   end
 end


### PR DESCRIPTION
This fix addresses inconsistency in collection of the environment variables if the pod has more than > 40 containers.  Because of this inconsistency ci_dev cluster has huge drop in the container inventory if ended up getting no envvars for the large pods where pod has high number of containers. For example, on dev cluster, "many-containers-in-pod" has more than 100 containers.