### PR TITLE
Gangams/jan agent release tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.renderWhitespace": "all"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.renderWhitespace": "all"
+}

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -27,6 +27,10 @@ spec:
     checksum/secret: {{ include (print $.Template.BasePath "/omsagent-secret.yaml") . | sha256sum }}
     checksum/config: {{ toYaml .Values.omsagent.resources | sha256sum }}
   spec:
+   dnsConfig:    
+     options:
+       - name: ndots
+         value: "3"     
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
    nodeSelector:
       kubernetes.io/os: windows

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -28,6 +28,10 @@ spec:
     checksum/config: {{ toYaml .Values.omsagent.resources | sha256sum }}
     checksum/logsettings: {{ toYaml .Values.omsagent.logsettings | sha256sum }}
   spec:
+   dnsConfig:    
+     options:
+       - name: ndots
+         value: "3"     
    {{- if .Values.omsagent.rbac }}
    serviceAccountName: omsagent
    {{- end }}

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -58,7 +58,7 @@ omsagent:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - labelSelector:
-              matchExpressions:
+              matchExpressions:             
                 - key: kubernetes.io/os
                   operator: In
                   values:
@@ -67,6 +67,10 @@ omsagent:
                   operator: NotIn
                   values:
                     - virtual-kubelet
+                - key: kubernetes.io/arch 
+                  operator: In
+                  values:
+                    - amd64   
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
@@ -78,6 +82,10 @@ omsagent:
                   operator: NotIn
                   values:
                     - virtual-kubelet
+                - key: beta.kubernetes.io/arch 
+                  operator: In
+                  values:
+                    - amd64       
   deployment:
     affinity:
       nodeAffinity:
@@ -106,6 +114,10 @@ omsagent:
                   operator: NotIn
                   values:
                     - master
+                - key: kubernetes.io/arch 
+                  operator: In
+                  values:
+                    - amd64       
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
@@ -121,6 +133,10 @@ omsagent:
                   operator: NotIn
                   values:
                     - master
+                - key: beta.kubernetes.io/arch 
+                  operator: In
+                  values:
+                    - amd64           
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -58,7 +58,7 @@ omsagent:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - labelSelector:
-              matchExpressions:            
+              matchExpressions:           
                 - key: kubernetes.io/os
                   operator: In
                   values:

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -58,7 +58,7 @@ omsagent:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - labelSelector:
-              matchExpressions:             
+              matchExpressions:            
                 - key: kubernetes.io/os
                   operator: In
                   values:

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -362,6 +362,10 @@ spec:
         schema-versions: "v1"
     spec:
       serviceAccountName: omsagent
+      dnsConfig:    
+        options:
+          - name: ndots
+            value: "3"       
       containers:
         - name: omsagent
           image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod11092020"
@@ -675,6 +679,10 @@ spec:
         schema-versions: "v1"
     spec:
      serviceAccountName: omsagent
+     dnsConfig:    
+        options:
+          - name: ndots
+            value: "3"     
      containers:
        - name: omsagent-win
          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod11092020"


### PR DESCRIPTION
This PR has following changes 

1. Only for DS, ndots change to 3 to avoid internal serach there by reducing pressure on coredns. (see email for the results)
2. for hybrid workloads, add the explicit node selector with amd64 as affinity since hybrid clusters can have with arm64.