### PR TITLE
Gangams/add fbsettings configurable via configmap

### DIFF
--- a/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
@@ -18,12 +18,17 @@ def substituteFluentBitPlaceHolders
     bufferChunkSize = ENV["FBIT_TAIL_BUFFER_CHUNK_SIZE"]
     bufferMaxSize = ENV["FBIT_TAIL_BUFFER_MAX_SIZE"]
 
-    serviceInterval = (!interval.nil? && is_number?(interval)) ? interval : @default_service_interval
+    serviceInterval = (!interval.nil? && is_number?(interval) && interval.to_i > 0 ) ? interval : @default_service_interval
     serviceIntervalSetting = "Flush         " + serviceInterval
 
-    tailBufferChunkSize = (!bufferChunkSize.nil? && is_number?(bufferChunkSize)) ? bufferChunkSize : nil
+    tailBufferChunkSize = (!bufferChunkSize.nil? && is_number?(bufferChunkSize) && bufferChunkSize.to_i > 0) ? bufferChunkSize : nil
 
-    tailBufferMaxSize = (!bufferMaxSize.nil? && is_number?(bufferMaxSize)) ? bufferMaxSize : nil
+    tailBufferMaxSize = (!bufferMaxSize.nil? && is_number?(bufferMaxSize) && bufferMaxSize.to_i > 0) ? bufferMaxSize : nil
+
+    if ((!tailBufferChunkSize.nil? && tailBufferMaxSize.nil) ||  (!tailBufferChunkSize.nil? && !tailBufferMaxSize.nil? && tailBufferChunkSize.to_i > tailBufferMaxSize.to_i))
+      puts "config:warn buffer max size must be greater or equal to chunk size"
+      tailBufferMaxSize = tailBufferChunkSize
+    end
 
     text = File.read(@td_agent_bit_conf_path)
     new_contents = text.gsub("${SERVICE_FLUSH_INTERVAL}", serviceIntervalSetting)

--- a/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
@@ -25,7 +25,7 @@ def substituteFluentBitPlaceHolders
 
     tailBufferMaxSize = (!bufferMaxSize.nil? && is_number?(bufferMaxSize) && bufferMaxSize.to_i > 0) ? bufferMaxSize : nil
 
-    if ((!tailBufferChunkSize.nil? && tailBufferMaxSize.nil) ||  (!tailBufferChunkSize.nil? && !tailBufferMaxSize.nil? && tailBufferChunkSize.to_i > tailBufferMaxSize.to_i))
+    if ((!tailBufferChunkSize.nil? && tailBufferMaxSize.nil?) ||  (!tailBufferChunkSize.nil? && !tailBufferMaxSize.nil? && tailBufferChunkSize.to_i > tailBufferMaxSize.to_i))
       puts "config:warn buffer max size must be greater or equal to chunk size"
       tailBufferMaxSize = tailBufferChunkSize
     end

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -153,20 +153,18 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         end
 
         fbitTailBufferMaxSizeMBs = fbit_config[:tail_buf_maxsize_megabytes]
-        if !fbitTailBufferMaxSizeMBs.nil? && is_number?(fbitTailBufferMaxSizeMBs) && fbitTailBufferMaxSizeMBs.to_i > 0 
+        if !fbitTailBufferMaxSizeMBs.nil? && is_number?(fbitTailBufferMaxSizeMBs) && fbitTailBufferMaxSizeMBs.to_i > 0           
           if fbitTailBufferMaxSizeMBs.to_i >= @fbitTailBufferChunkSizeMBs
             @fbitTailBufferMaxSizeMBs = fbitTailBufferMaxSizeMBs.to_i
             puts "Using config map value: tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs}"
           else
+            # tail_buf_maxsize_megabytes has to be greater or equal to tail_buf_chunksize_megabytes
             @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
-            puts "config::warn: tail_buf_maxsize_megabytes should be greater or equal to value of tail_buf_chunksize_megabytes. Using tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs} since provided config value not valid"
+            puts "config::warn: tail_buf_maxsize_megabytes must be greater or equal to value of tail_buf_chunksize_megabytes. Using tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs} since provided config value not valid"
           end
         end
-         # in scenario - tail_buf_maxsize_megabytes provided but not tail_buf_chunksize_megabytes and vice versa
-        if @fbitTailBufferMaxSizeMBs > 0 && @fbitTailBufferChunkSizeMBs == 0
-          @fbitTailBufferChunkSizeMBs = @fbitTailBufferMaxSizeMBs
-          puts "config::warn: since tail_buf_chunksize_megabytes not provided hence using tail_buf_chunksize_megabytes=#{@fbitTailBufferChunkSizeMBs} which is same as the value of tail_buf_maxsize_megabytes"
-        elsif  @fbitTailBufferChunkSizeMBs > 0  && @fbitTailBufferMaxSizeMBs == 0
+        # in scenario - tail_buf_chunksize_megabytes provided but not tail_buf_maxsize_megabytes to prevent fbit crash
+        if  @fbitTailBufferChunkSizeMBs > 0  && @fbitTailBufferMaxSizeMBs == 0
           @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
           puts "config::warn: since tail_buf_maxsize_megabytes not provided hence using tail_buf_maxsize_megabytes=#{@fbitTailBufferMaxSizeMBs} which is same as the value of tail_buf_chunksize_megabytes"
         end 

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -162,10 +162,13 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             puts "config::warn: FBIT_TAIL_BUFFER_MAX_SIZE should be greater or equal to value of FBIT_TAIL_BUFFER_CHUNK_SIZE. Using FBIT_TAIL_BUFFER_MAX_SIZE = #{@fbitTailBufferMaxSize} since provodided config value not valid"
           end
         end
-         # in scenario - FBIT_TAIL_BUFFER_MAX_SIZE provided but not FBIT_TAIL_BUFFER_CHUNK_SIZE
+         # in scenario - FBIT_TAIL_BUFFER_MAX_SIZE provided but not FBIT_TAIL_BUFFER_CHUNK_SIZE and vice versa
         if @fbitTailBufferMaxSize > 0 && @fbitTailBufferChunkSize == 0
           @fbitTailBufferChunkSize = @fbitTailBufferMaxSize
           puts "config::warn: since FBIT_TAIL_BUFFER_CHUNK_SIZE not provided hence using FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSize} which is same as the value of FBIT_TAIL_BUFFER_MAX_SIZE"
+        elsif  @fbitTailBufferChunkSize > 0  && @fbitTailBufferMaxSize == 0
+          @fbitTailBufferMaxSize = @fbitTailBufferChunkSize
+          puts "config::warn: since FBIT_TAIL_BUFFER_MAX_SIZE not provided hence using FBIT_TAIL_BUFFER_MAX_SIZE=#{@fbitTailBufferMaxSize} which is same as the value of FBIT_TAIL_BUFFER_CHUNK_SIZE"
         end 
       end
     end

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -56,9 +56,9 @@ require_relative "ConfigParseErrorLogger"
 @nodesEmitStreamBatchSizeMin = 50
 
 # configmap settings related fbit config
-@fbitFlushInterval = 0
-@fbitTailBufferChunkSize = 0
-@fbitTailBufferMaxSize = 0
+@fbitFlushIntervalSecsSecs = 0
+@fbitTailBufferChunkSizeMBs = 0
+@fbitTailBufferMaxSizeMBs = 0
 
 
 def is_number?(value)
@@ -140,35 +140,35 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       # fbit config settings
       fbit_config = parsedConfig[:agent_settings][:fbit_config]
       if !fbit_config.nil?
-        fbitFlushInterval = fbit_config[:FBIT_SERVICE_FLUSH_INTERVAL]
-        if !fbitFlushInterval.nil? && is_number?(fbitFlushInterval) && fbitFlushInterval.to_i > 0
-          @fbitFlushInterval = fbitFlushInterval.to_i
-          puts "Using config map value: FBIT_SERVICE_FLUSH_INTERVAL = #{@fbitFlushInterval}"
+        fbitFlushIntervalSecs = fbit_config[:logflushintervalsecs]
+        if !fbitFlushIntervalSecs.nil? && is_number?(fbitFlushIntervalSecs) && fbitFlushIntervalSecs.to_i > 0
+          @fbitFlushIntervalSecs = fbitFlushIntervalSecs.to_i
+          puts "Using config map value: logflushintervalsecs = #{@fbitFlushIntervalSecs}"
         end
 
-        fbitTailBufferChunkSize = fbit_config[:FBIT_TAIL_BUFFER_CHUNK_SIZE]
-        if !fbitTailBufferChunkSize.nil? && is_number?(fbitTailBufferChunkSize) && fbitTailBufferChunkSize.to_i > 0
-          @fbitTailBufferChunkSize = fbitTailBufferChunkSize.to_i
-          puts "Using config map value: FBIT_TAIL_BUFFER_CHUNK_SIZE = #{@fbitTailBufferChunkSize}"
+        fbitTailBufferChunkSizeMBs = fbit_config[:tailbufchunksizemegabytes ]
+        if !fbitTailBufferChunkSizeMBs.nil? && is_number?(fbitTailBufferChunkSizeMBs) && fbitTailBufferChunkSizeMBs.to_i > 0
+          @fbitTailBufferChunkSizeMBs = fbitTailBufferChunkSizeMBs.to_i
+          puts "Using config map value: tailbufchunksizemegabytes  = #{@fbitTailBufferChunkSizeMBs}"
         end
 
-        fbitTailBufferMaxSize = fbit_config[:FBIT_TAIL_BUFFER_MAX_SIZE]
-        if !fbitTailBufferMaxSize.nil? && is_number?(fbitTailBufferMaxSize) && fbitTailBufferMaxSize.to_i > 0 
-          if fbitTailBufferMaxSize.to_i >= @fbitTailBufferChunkSize
-            @fbitTailBufferMaxSize = fbitTailBufferMaxSize.to_i
-            puts "Using config map value: FBIT_TAIL_BUFFER_MAX_SIZE = #{@fbitTailBufferMaxSize}"
+        fbitTailBufferMaxSizeMBs = fbit_config[:tailbufmaxsizemegabytes ]
+        if !fbitTailBufferMaxSizeMBs.nil? && is_number?(fbitTailBufferMaxSizeMBs) && fbitTailBufferMaxSizeMBs.to_i > 0 
+          if fbitTailBufferMaxSizeMBs.to_i >= @fbitTailBufferChunkSizeMBs
+            @fbitTailBufferMaxSizeMBs = fbitTailBufferMaxSizeMBs.to_i
+            puts "Using config map value: tailbufmaxsizemegabytes = #{@fbitTailBufferMaxSizeMBs}"
           else
-            @fbitTailBufferMaxSize = @fbitTailBufferChunkSize
-            puts "config::warn: FBIT_TAIL_BUFFER_MAX_SIZE should be greater or equal to value of FBIT_TAIL_BUFFER_CHUNK_SIZE. Using FBIT_TAIL_BUFFER_MAX_SIZE = #{@fbitTailBufferMaxSize} since provodided config value not valid"
+            @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
+            puts "config::warn: tailbufmaxsizemegabytes should be greater or equal to value of tailbufchunksizemegabytes. Using tailbufmaxsizemegabytes = #{@fbitTailBufferMaxSizeMBs} since provodided config value not valid"
           end
         end
-         # in scenario - FBIT_TAIL_BUFFER_MAX_SIZE provided but not FBIT_TAIL_BUFFER_CHUNK_SIZE and vice versa
-        if @fbitTailBufferMaxSize > 0 && @fbitTailBufferChunkSize == 0
-          @fbitTailBufferChunkSize = @fbitTailBufferMaxSize
-          puts "config::warn: since FBIT_TAIL_BUFFER_CHUNK_SIZE not provided hence using FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSize} which is same as the value of FBIT_TAIL_BUFFER_MAX_SIZE"
-        elsif  @fbitTailBufferChunkSize > 0  && @fbitTailBufferMaxSize == 0
-          @fbitTailBufferMaxSize = @fbitTailBufferChunkSize
-          puts "config::warn: since FBIT_TAIL_BUFFER_MAX_SIZE not provided hence using FBIT_TAIL_BUFFER_MAX_SIZE=#{@fbitTailBufferMaxSize} which is same as the value of FBIT_TAIL_BUFFER_CHUNK_SIZE"
+         # in scenario - tailbufmaxsizemegabytes provided but not tailbufchunksizemegabytes and vice versa
+        if @fbitTailBufferMaxSizeMBs > 0 && @fbitTailBufferChunkSizeMBs == 0
+          @fbitTailBufferChunkSizeMBs = @fbitTailBufferMaxSizeMBs
+          puts "config::warn: since tailbufchunksizemegabytes not provided hence using tailbufchunksizemegabytes=#{@fbitTailBufferChunkSizeMBs} which is same as the value of tailbufmaxsizemegabytes"
+        elsif  @fbitTailBufferChunkSizeMBs > 0  && @fbitTailBufferMaxSizeMBs == 0
+          @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
+          puts "config::warn: since tailbufmaxsizemegabytes not provided hence using tailbufmaxsizemegabytes=#{@fbitTailBufferMaxSizeMBs} which is same as the value of tailbufchunksizemegabytes"
         end 
       end
     end
@@ -205,14 +205,14 @@ if !file.nil?
   file.write("export PODS_EMIT_STREAM_BATCH_SIZE=#{@podsEmitStreamBatchSize}\n")
   file.write("export NODES_EMIT_STREAM_BATCH_SIZE=#{@nodesEmitStreamBatchSize}\n")
   # fbit settings
-  if @fbitFlushInterval > 0
-    file.write("export FBIT_SERVICE_FLUSH_INTERVAL=#{@fbitFlushInterval}\n")
+  if @fbitFlushIntervalSecs > 0
+    file.write("export FBIT_SERVICE_FLUSH_INTERVAL=#{@fbitFlushIntervalSecs}\n")
   end
-  if @fbitTailBufferChunkSize > 0
-    file.write("export FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSize}\n")
+  if @fbitTailBufferChunkSizeMBs > 0
+    file.write("export FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSizeMBs}\n")
   end
-  if @fbitTailBufferMaxSize > 0
-    file.write("export FBIT_TAIL_BUFFER_MAX_SIZE=#{@fbitTailBufferMaxSize}\n")
+  if @fbitTailBufferMaxSizeMBs > 0
+    file.write("export FBIT_TAIL_BUFFER_MAX_SIZE=#{@fbitTailBufferMaxSizeMBs}\n")
   end 
   # Close file after writing all environment variables
   file.close

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -137,6 +137,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           puts "Using config map value: NODES_EMIT_STREAM_BATCH_SIZE = #{@nodesEmitStreamBatchSize}"
         end
       end
+      # fbit config settings
       fbit_config = parsedConfig[:agent_settings][:fbit_config]
       if !fbit_config.nil?
         fbitFlushInterval = fbit_config[:FBIT_SERVICE_FLUSH_INTERVAL]
@@ -165,7 +166,6 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @fbitTailBufferMaxSize > 0 && @fbitTailBufferChunkSize == 0
           @fbitTailBufferChunkSize = @fbitTailBufferMaxSize
         end 
-
       end
     end
   rescue => errorStr
@@ -200,6 +200,16 @@ if !file.nil?
   file.write("export HPA_CHUNK_SIZE=#{@hpaChunkSize}\n")
   file.write("export PODS_EMIT_STREAM_BATCH_SIZE=#{@podsEmitStreamBatchSize}\n")
   file.write("export NODES_EMIT_STREAM_BATCH_SIZE=#{@nodesEmitStreamBatchSize}\n")
+  # fbit settings
+  if @fbitFlushInterval > 0
+    file.write("export FBIT_SERVICE_FLUSH_INTERVAL=#{@fbitFlushInterval}\n")
+  end
+  if @fbitTailBufferChunkSize > 0
+    file.write("export FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSize}\n")
+  end
+  if @fbitTailBufferMaxSize > 0
+    file.write("export FBIT_TAIL_BUFFER_MAX_SIZE=#{@fbitTailBufferMaxSize}\n")
+  end 
   # Close file after writing all environment variables
   file.close
 else

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -159,7 +159,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             puts "Using config map value: tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs}"
           else
             @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
-            puts "config::warn: tail_buf_maxsize_megabytes should be greater or equal to value of tail_buf_chunksize_megabytes. Using tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs} since provodided config value not valid"
+            puts "config::warn: tail_buf_maxsize_megabytes should be greater or equal to value of tail_buf_chunksize_megabytes. Using tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs} since provided config value not valid"
           end
         end
          # in scenario - tail_buf_maxsize_megabytes provided but not tail_buf_chunksize_megabytes and vice versa

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -56,7 +56,7 @@ require_relative "ConfigParseErrorLogger"
 @nodesEmitStreamBatchSizeMin = 50
 
 # configmap settings related fbit config
-@fbitFlushIntervalSecsSecs = 0
+@fbitFlushIntervalSecs = 0
 @fbitTailBufferChunkSizeMBs = 0
 @fbitTailBufferMaxSizeMBs = 0
 

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -165,6 +165,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
          # in scenario - FBIT_TAIL_BUFFER_MAX_SIZE provided but not FBIT_TAIL_BUFFER_CHUNK_SIZE
         if @fbitTailBufferMaxSize > 0 && @fbitTailBufferChunkSize == 0
           @fbitTailBufferChunkSize = @fbitTailBufferMaxSize
+          puts "config::warn: since FBIT_TAIL_BUFFER_CHUNK_SIZE not provided hence using FBIT_TAIL_BUFFER_CHUNK_SIZE=#{@fbitTailBufferChunkSize} which is same as the value of FBIT_TAIL_BUFFER_MAX_SIZE"
         end 
       end
     end

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -140,35 +140,35 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       # fbit config settings
       fbit_config = parsedConfig[:agent_settings][:fbit_config]
       if !fbit_config.nil?
-        fbitFlushIntervalSecs = fbit_config[:logflushintervalsecs]
+        fbitFlushIntervalSecs = fbit_config[:log_flush_interval_secs]
         if !fbitFlushIntervalSecs.nil? && is_number?(fbitFlushIntervalSecs) && fbitFlushIntervalSecs.to_i > 0
           @fbitFlushIntervalSecs = fbitFlushIntervalSecs.to_i
-          puts "Using config map value: logflushintervalsecs = #{@fbitFlushIntervalSecs}"
+          puts "Using config map value: log_flush_interval_secs = #{@fbitFlushIntervalSecs}"
         end
 
-        fbitTailBufferChunkSizeMBs = fbit_config[:tailbufchunksizemegabytes ]
+        fbitTailBufferChunkSizeMBs = fbit_config[:tail_buf_chunksize_megabytes]
         if !fbitTailBufferChunkSizeMBs.nil? && is_number?(fbitTailBufferChunkSizeMBs) && fbitTailBufferChunkSizeMBs.to_i > 0
           @fbitTailBufferChunkSizeMBs = fbitTailBufferChunkSizeMBs.to_i
-          puts "Using config map value: tailbufchunksizemegabytes  = #{@fbitTailBufferChunkSizeMBs}"
+          puts "Using config map value: tail_buf_chunksize_megabytes  = #{@fbitTailBufferChunkSizeMBs}"
         end
 
-        fbitTailBufferMaxSizeMBs = fbit_config[:tailbufmaxsizemegabytes ]
+        fbitTailBufferMaxSizeMBs = fbit_config[:tail_buf_maxsize_megabytes]
         if !fbitTailBufferMaxSizeMBs.nil? && is_number?(fbitTailBufferMaxSizeMBs) && fbitTailBufferMaxSizeMBs.to_i > 0 
           if fbitTailBufferMaxSizeMBs.to_i >= @fbitTailBufferChunkSizeMBs
             @fbitTailBufferMaxSizeMBs = fbitTailBufferMaxSizeMBs.to_i
-            puts "Using config map value: tailbufmaxsizemegabytes = #{@fbitTailBufferMaxSizeMBs}"
+            puts "Using config map value: tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs}"
           else
             @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
-            puts "config::warn: tailbufmaxsizemegabytes should be greater or equal to value of tailbufchunksizemegabytes. Using tailbufmaxsizemegabytes = #{@fbitTailBufferMaxSizeMBs} since provodided config value not valid"
+            puts "config::warn: tail_buf_maxsize_megabytes should be greater or equal to value of tail_buf_chunksize_megabytes. Using tail_buf_maxsize_megabytes = #{@fbitTailBufferMaxSizeMBs} since provodided config value not valid"
           end
         end
-         # in scenario - tailbufmaxsizemegabytes provided but not tailbufchunksizemegabytes and vice versa
+         # in scenario - tail_buf_maxsize_megabytes provided but not tail_buf_chunksize_megabytes and vice versa
         if @fbitTailBufferMaxSizeMBs > 0 && @fbitTailBufferChunkSizeMBs == 0
           @fbitTailBufferChunkSizeMBs = @fbitTailBufferMaxSizeMBs
-          puts "config::warn: since tailbufchunksizemegabytes not provided hence using tailbufchunksizemegabytes=#{@fbitTailBufferChunkSizeMBs} which is same as the value of tailbufmaxsizemegabytes"
+          puts "config::warn: since tail_buf_chunksize_megabytes not provided hence using tail_buf_chunksize_megabytes=#{@fbitTailBufferChunkSizeMBs} which is same as the value of tail_buf_maxsize_megabytes"
         elsif  @fbitTailBufferChunkSizeMBs > 0  && @fbitTailBufferMaxSizeMBs == 0
           @fbitTailBufferMaxSizeMBs = @fbitTailBufferChunkSizeMBs
-          puts "config::warn: since tailbufmaxsizemegabytes not provided hence using tailbufmaxsizemegabytes=#{@fbitTailBufferMaxSizeMBs} which is same as the value of tailbufchunksizemegabytes"
+          puts "config::warn: since tail_buf_maxsize_megabytes not provided hence using tail_buf_maxsize_megabytes=#{@fbitTailBufferMaxSizeMBs} which is same as the value of tail_buf_chunksize_megabytes"
         end 
       end
     end

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -172,6 +172,7 @@ source config_env_var
 
 
 #Parse the configmap to set the right environment variables for agent config.
+#Note > tomlparser-agent-config.rb has to be parsed first before td-agent-bit-conf-customizer.rb for fbit agent settings
 /opt/microsoft/omsagent/ruby/bin/ruby tomlparser-agent-config.rb
 
 cat agent_config_env_var | while read line; do


### PR DESCRIPTION
adding fbit settings FBIT_SERVICE_FLUSH_INTERVAL, FBIT_TAIL_BUFFER_CHUNK_SIZE and FBIT_TAIL_BUFFER_MAX_SIZE configurable via configmap.  These config settings will be under 
Here is the final naming 
 agent-settings: |- 
    [agent_settings.fbit_config]   
      log_flush_interval_secs = "1"	
      tail_buf_chunksize_megabytes= "1"  
      tail_buf_maxsize_megabytes = "1"  	 