### PR TITLE
Changing fluent bit version to 1.6.8

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -71,7 +71,7 @@ chmod 777 /opt/telegraf
 wget -qO - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
 sudo echo "deb https://packages.fluentbit.io/ubuntu/xenial xenial main" >> /etc/apt/sources.list
 sudo apt-get update
-sudo apt-get install td-agent-bit=1.6.9 -y
+sudo apt-get install td-agent-bit=1.6.8 -y
 
 rm -rf $TMPDIR/omsbundle
 rm -f $TMPDIR/omsagent*.sh


### PR DESCRIPTION
1.6.8 seems to have better results than 1.6.9 and is well tested so going back to 1.6.8