### PR TITLE
The metric kubelet_running_pods_count was renamed in 1.19

### DIFF
--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -675,7 +675,9 @@
   ## An array of urls to scrape metrics from.
   urls = ["$CADVISOR_METRICS_URL"]
 
-  fieldpass = ["kubelet_running_pod_count","volume_manager_total_volumes", "kubelet_node_config_error", "process_resident_memory_bytes", "process_cpu_seconds_total"]
+  # <= 1.18: metric name is kubelet_running_pod_count
+  # >= 1.19: metric name changed to kubelet_running_pods
+  fieldpass = ["kubelet_running_pod_count","kubelet_running_pods","volume_manager_total_volumes", "kubelet_node_config_error", "process_resident_memory_bytes", "process_cpu_seconds_total"]
 
   metric_version = 2
   url_tag = "scrapeUrl"


### PR DESCRIPTION
Fix for the kubelet workbook issue found by Ganga where kubelet_running_pods_count metrics were missing (ICM: https://portal.microsofticm.com/imp/v3/incidents/details/229404590/home)

The metric `kubelet_running_pods_count` was renamed to` kubelet_running_pods` starting with kubernetes 1.19 (https://github.com/kubernetes/kubernetes/pull/92407). We will need to scrape both names to support all kubernetes versions.