### PR TITLE
Adding explicit json output to az commands #409

### DIFF
--- a/scripts/onboarding/managed/disable-monitoring.sh
+++ b/scripts/onboarding/managed/disable-monitoring.sh
@@ -127,7 +127,7 @@ remove_monitoring_tags()
 
   # validate cluster identity for Azure Arc enabled Kubernetes cluster
   if [ "$isArcK8sCluster" = true ] ; then
-   identitytype=$(az resource show -g ${clusterResourceGroup} -n ${clusterName} --resource-type $resourceProvider --query identity.type)
+   identitytype=$(az resource show -g ${clusterResourceGroup} -n ${clusterName} --resource-type $resourceProvider --query identity.type -o json)
    identitytype=$(echo $identitytype | tr "[:upper:]" "[:lower:]" | tr -d '"')
    echo "cluster identity type:" $identitytype
     if [[ "$identitytype" != "systemassigned" ]]; then

--- a/scripts/onboarding/managed/enable-monitoring.sh
+++ b/scripts/onboarding/managed/enable-monitoring.sh
@@ -339,7 +339,7 @@ validate_cluster_identity() {
   local rgName="$(echo ${1})"
   local clusterName="$(echo ${2})"
 
-  local identitytype=$(az resource show -g ${rgName} -n ${clusterName} --resource-type $resourceProvider --query identity.type)
+  local identitytype=$(az resource show -g ${rgName} -n ${clusterName} --resource-type $resourceProvider --query identity.type -o json)
   identitytype=$(echo $identitytype | tr "[:upper:]" "[:lower:]" | tr -d '"')
   echo "cluster identity type:" $identitytype
 
@@ -454,7 +454,7 @@ create_default_log_analytics_workspace() {
     echo "using existing default workspace:"$workspaceName
   fi
 
-  workspaceResourceId=$(az resource show -g $workspaceResourceGroup -n $workspaceName --resource-type $workspaceResourceProvider --query id)
+  workspaceResourceId=$(az resource show -g $workspaceResourceGroup -n $workspaceName --resource-type $workspaceResourceProvider --query id -o json)
   workspaceResourceId=$(echo $workspaceResourceId | tr -d '"')
   echo "workspace resource Id: ${workspaceResourceId}"
 }
@@ -477,12 +477,12 @@ get_workspace_guid_and_key() {
   local wsName="$(echo ${resourceId} | cut -d'/' -f9)"
 
   # get the workspace guid
-  workspaceGuid=$(az resource show -g $rgName -n $wsName --resource-type $workspaceResourceProvider --query properties.customerId)
+  workspaceGuid=$(az resource show -g $rgName -n $wsName --resource-type $workspaceResourceProvider --query properties.customerId -o json)
   workspaceGuid=$(echo $workspaceGuid | tr -d '"')
   echo "workspaceGuid:"$workspaceGuid
 
   echo "getting workspace primaryshared key"
-  workspaceKey=$(az rest --method post --uri $workspaceResourceId/sharedKeys?api-version=2015-11-01-preview --query primarySharedKey)
+  workspaceKey=$(az rest --method post --uri $workspaceResourceId/sharedKeys?api-version=2015-11-01-preview --query primarySharedKey -o json)
   workspaceKey=$(echo $workspaceKey | tr -d '"')
 }
 
@@ -621,7 +621,7 @@ else
     set_azure_subscription $workspaceSubscriptionId
   fi
 
-  workspaceRegion=$(az resource show --ids ${workspaceResourceId} --query location)
+  workspaceRegion=$(az resource show --ids ${workspaceResourceId} --query location -o json)
   workspaceRegion=$(echo $workspaceRegion | tr -d '"')
   echo "Workspace Region:"$workspaceRegion
 fi

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -202,7 +202,7 @@ validate_cluster_identity() {
   local rgName="$(echo ${1})"
   local clusterName="$(echo ${2})"
 
-  local identitytype=$(az resource show -g ${rgName} -n ${clusterName} --resource-type $resourceProvider --query identity.type)
+  local identitytype=$(az resource show -g ${rgName} -n ${clusterName} --resource-type $resourceProvider --query identity.type -o json)
   identitytype=$(echo $identitytype | tr "[:upper:]" "[:lower:]" | tr -d '"')
   echo "cluster identity type:" $identitytype
 
@@ -216,7 +216,7 @@ validate_cluster_identity() {
 
 validate_monitoring_tags() {
   echo "get loganalyticsworkspaceResourceId tag on to cluster resource"
-  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type $resourceProvider)
+  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type $resourceProvider -o json)
   echo "configured log analytics workspace: ${logAnalyticsWorkspaceResourceIdTag}"
   echo "successfully got logAnalyticsWorkspaceResourceId tag on the cluster resource"
   if [ -z "$logAnalyticsWorkspaceResourceIdTag" ]; then


### PR DESCRIPTION
Cluster onboarding fails if the AZ cli is not configured as json output. 
Adding explicit -o json parameter to az cli where no output format is specified #409