### PR TITLE
Trailing spaces for azureCloudName and identitytype is causing script failure in certain scenarios

### DIFF
--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -675,7 +675,9 @@
   ## An array of urls to scrape metrics from.
   urls = ["$CADVISOR_METRICS_URL"]
 
-  fieldpass = ["kubelet_running_pod_count","volume_manager_total_volumes", "kubelet_node_config_error", "process_resident_memory_bytes", "process_cpu_seconds_total"]
+  # <= 1.18: metric name is kubelet_running_pod_count
+  # >= 1.19: metric name changed to kubelet_running_pods
+  fieldpass = ["kubelet_running_pod_count","kubelet_running_pods","volume_manager_total_volumes", "kubelet_node_config_error", "process_resident_memory_bytes", "process_cpu_seconds_total"]
 
   metric_version = 2
   url_tag = "scrapeUrl"


### PR DESCRIPTION
Trailing spaces for azureCloudName and identitytype is causing script failure in certain scenarios