### PR TITLE
config changes

### DIFF
--- a/otelcollector/configmapparser/tomlparser-default-scrape-settings.rb
+++ b/otelcollector/configmapparser/tomlparser-default-scrape-settings.rb
@@ -1,0 +1,78 @@
+#!/usr/local/bin/ruby
+# frozen_string_literal: true
+
+require "tomlrb"
+require_relative "ConfigParseErrorLogger"
+#require_relative "microsoft/omsagent/plugin/constants"
+
+@configMapMountPath = "/etc/config/settings/default-scrape-settings"
+@configVersion = ""
+@configSchemaVersion = ""
+
+@kubeletEnabled = true
+@corednsEnabled = true
+
+# Use parser to parse the configmap toml file to a ruby structure
+def parseConfigMap
+  begin
+    # Check to see if config map is created
+    puts "config::configmap prometheus-collector-configmap for prometheus collector file: #{@configMapMountPath}"
+    if (File.file?(@configMapMountPath))
+      puts "config::configmap prometheus-collector-configmap for default scrape settings mounted, parsing values"
+      parsedConfig = Tomlrb.load_file(@configMapMountPath, symbolize_keys: true)
+      puts "config::Successfully parsed mounted config map"
+      return parsedConfig
+    else
+      puts "config::configmapprometheus-collector-configmap for default scrape settings not mounted, using defaults"
+      return nil
+    end
+  rescue => errorStr
+    ConfigParseErrorLogger.logError("Exception while parsing config map for default scrape settings: #{errorStr}, using defaults, please check config map for errors")
+    return nil
+  end
+end
+
+# Use the ruby structure created after config parsing to set the right values to be used for otel collector settings
+def populateSettingValuesFromConfigMap(parsedConfig)
+  begin
+    if !parsedConfig.nil? && !parsedConfig[:default_scrape_settings].nil?
+      if !parsedConfig[:default_scrape_settings][:kubelet_enabled].nil?
+        @kubeletEnabled = parsedConfig[:default_scrape_settings][:kubelet_enabled]
+        puts "config::Using configmap settings for kubelet_enabled"
+      end
+      if !parsedConfig[:default_scrape_settings][:coredns_enabled].nil?
+        @corednsEnabled = parsedConfig[:default_scrape_settings][:coredns_enabled]
+        puts "config::Using configmap settings for coredns_enabled"
+      end
+    end
+  rescue => errorStr
+    ConfigParseErrorLogger.logError("Exception while reading config map settings for default scrape settings - #{errorStr}, using defaults, please check config map for errors")
+  end
+end
+
+@configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
+puts "****************Start default-scrape-settings Processing********************"
+if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version, so hardcoding it
+  configMapSettings = parseConfigMap
+  if !configMapSettings.nil?
+    populateSettingValuesFromConfigMap(configMapSettings)
+  end
+else
+  if (File.file?(@configMapMountPath))
+    ConfigParseErrorLogger.logError("config::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
+  end
+end
+
+# Write the settings to file, so that they can be set as environment variables
+file = File.open("/opt/microsoft/configmapparser/config_default_scrape_settings_env_var", "w")
+
+if !file.nil?
+  file.write("export AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED=#{@kubeletEnabled}\n")
+  file.write("export AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED=#{@corednsEnabled}\n")
+  # Close file after writing all metric collection setting environment variables
+  file.close
+  puts "****************End default-scrape-settings Processing********************"
+else
+  puts "Exception while opening file for writing default-scrape-settings config environment variables"
+  puts "****************End default-scrape-settings Processing********************"
+end

--- a/otelcollector/configmapparser/tomlparser-prometheus-config.rb
+++ b/otelcollector/configmapparser/tomlparser-prometheus-config.rb
@@ -5,7 +5,7 @@ require "tomlrb"
 require_relative "ConfigParseErrorLogger"
 #require_relative "microsoft/omsagent/plugin/constants"
 
-@configMapMountPath = "/etc/config/settings/prometheus-config"
+@configMapMountPath = "/etc/config/settings/prometheus/prometheus-config"
 @collectorConfigTemplatePath = "/opt/microsoft/otelcollector/collector-config-template.yml"
 @collectorConfigPath = "/opt/microsoft/otelcollector/collector-config.yml"
 @configVersion = ""
@@ -14,6 +14,9 @@ require_relative "ConfigParseErrorLogger"
 # Setting default values which will be used in case they are not set in the configmap or if configmap doesnt exist
 @indentedConfig = ""
 @useDefaultConfig = true
+
+@kubeletDefaultString = "job_name: 'kubernetes-nodes'\nscheme: https\ntls_config:\n  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  insecure_skip_verify: true\nauthorization:\n  credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token\nkubernetes_sd_configs:\n- role: node\nrelabel_configs:\n- action: labelmap\n  regex: __meta_kubernetes_node_label_(.+)"
+@corednsDefaultString = "job_name: kube-dns\nhonor_labels: true\nkubernetes_sd_configs:\n- role: pod\nrelabel_configs:\n- action: keep\n  source_labels:\n  - __meta_kubernetes_namespace\n  - __meta_kubernetes_pod_name\n  separator: '/'\n  regex: 'kube-system/coredns.+'\n- source_labels:\n  - __meta_kubernetes_pod_container_port_name\n  action: keep\n  regex: metrics\n- source_labels:\n  - __meta_kubernetes_pod_name\n  action: replace\n  target_label: instance\n- action: labelmap\n  regex: __meta_kubernetes_pod_label_(.+)"
 
 # Use parser to parse the configmap toml file to a ruby structure
 def parseConfigMap
@@ -40,20 +43,61 @@ def populateSettingValuesFromConfigMap(configString)
   begin
     # Indent for the otelcollector config
     @indentedConfig = configString.gsub(/\R+/, "\n        ")
+    if !ENV["AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED"].downcase == "true"
+      @indentedConfig = addDefaultScrapeConfig(@indentedConfig, @kubeletDefaultString)
+    end
+    if !ENV["AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED"].downcase == "true"
+      @indentedConfig = addDefaultScrapeConfig(@indentedConfig, @corednsDefaultString)
+    end
     puts "config::Using config map setting for prometheus config"
+    puts @indentedConfig
   rescue => errorStr
-    ConfigParseErrorLogger.logError("Exception while reading prometheus config - #{errorStr}, using defaults, please check config map for errors")
+    ConfigParseErrorLogger.logError("Exception while substituting the prometheus config in the otelcollector config - #{errorStr}, using defaults, please check config map for errors")
     @indentedConfig = ""
   end
+end
+
+def addDefaultScrapeConfig(indentedConfig, defaultScrapeConfig)
+
+  # Check where to put the extra scrape config
+  scrapeConfigString = "scrape_configs:"
+  scrapeConfigIndex = indentedConfig.index(scrapeConfigString)
+  if !scrapeConfigIndex.nil?
+    indexToAddAt = scrapeConfigIndex + scrapeConfigString.length
+
+    # Get how far indented the existing scrape configs are and add the scrape config at the same indentation
+    matched = indentedConfig.match("scrape_configs\s*:\s*\n(\s*)-(\s+).*")
+    if !matched.nil? && !matched.captures.nil? && matched.captures.length > 1
+      whitespaceBeforeDash = matched.captures[0]
+      whiteSpaceAfterDash = matched.captures[1]
+
+      # Match indentation for everything underneath "- job_name:" (Include an extra space for -)
+      indentedDefaultConfig = defaultScrapeConfig.gsub(/\R+/, sprintf("\n%s %s", whitespaceBeforeDash, whiteSpaceAfterDash))
+
+      # Match indentation and add dash for the starting line "- job_name:"
+      indentedDefaultConfig = sprintf("\n%s-%s%s\n", whitespaceBeforeDash, whiteSpaceAfterDash, indentedDefaultConfig)
+
+      # Add the indented scrape config to the existing config
+      indentedConfig = indentedConfig.insert(indexToAddAt, indentedDefaultConfig)
+    end
+
+  # The section "scrape_configs:" isn't in config, so add it at the beginning and the extra scrape config underneath
+  # Don't need to match indentation since there aren't any other scrape configs
+  else
+    indentedDefaultConfig = defaultScrapeConfig.gsub(/\R+/, "\n          ")
+    stringToAdd = sprintf("scrape_configs:\n        - %s\n        ", indentedDefaultConfig)
+    indentedConfig = indentedConfig.insert(0, stringToAdd)
+  end
+
+  return indentedConfig
 end
 
 @configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
 puts "****************Start Prometheus Config Processing********************"
 if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version, so hardcoding it
   prometheusConfigString = parseConfigMap
-  if prometheusConfigString != ""
-    populateSettingValuesFromConfigMap(prometheusConfigString)
-  end
+  # Need to populate default configs even if specfied config is empty
+  populateSettingValuesFromConfigMap(prometheusConfigString)
 else
   if (File.file?(@configMapMountPath))
     ConfigParseErrorLogger.logError("config::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")

--- a/otelcollector/deploy/README.md
+++ b/otelcollector/deploy/README.md
@@ -2,7 +2,7 @@
 
 #### Step 0 : Create a kubernetes cluster (AKS would be the quickest & easiest)
 
-#### Step 1 : You would need to create a MDM account and have name of the MDM account along with its cert & key file(s)
+#### Step 1 : You will need to create a MDM account and have name of the MDM account along with its cert & key file(s)
 
 #### Step 2 : In your Kubernetes cluster where you want to collect prometheus metrics from, create kubernetes secret (called ```metricstore-secret``` [see below for example] ) for MDM account to which you want to ship metrics to, from your kubernetes cluster
 
@@ -11,16 +11,47 @@
 Example :
 ```kubectl create secret tls metricstore-secret --cert=/mnt/e/prometheusmetricswork/genevacert/CIGenevaCert.pem  --key=/mnt/e/prometheusmetricswork/genevacert/CIGenevaCert.pem -n=kube-system```
 
-#### Step 3 : Provide the default MDM account name in the config map (prometheus-collector-configmap.yaml), and apply the configmap to your kubernetes cluster (see below). Also provide scrape config as needed in the config map [By default, configmap has scrape config to scrape our reference service (weather service), which is scrapping our reference app in the ['app'](../app/prometheus-reference-app.yaml) folder - which you need to deploy in case you want to use default scrape config (```kubectl apply -f prometheus-reference-app.yml``` from 'app' folder )]
+#### Step 3 : Provide the default MDM account name in the config map (prometheus-collector-configmap.yaml), optionally configure if you'd like scrape settings for kubelet, coredns, etc. included, and apply the configmap to your kubernetes cluster (see below).
+Below are the sub-steps for this -
 
-Below are the 3 sub-steps to do for this step -
+- 3.1) Ensure the line below in the configmap has your MDM account name (which will be used as the default MDM account to send metrics to)
+  ``` 
+  prometheus-collector-settings: |-
+    [prometheus_collector_settings.default_metric_account]
+      account_name = "mymetricaccountname"
+  ```
+- 3.2) Specify if you'd like default kubelet or coredns scrape configs added to the prometheus yaml for you. Set to false if you don't want these targets scraped or if you already include them in your prometheus yaml. Job names 'kubernetes-nodes' and 'kube-dns' are reserved if these are enabled.
+  ```
+  default-scrape-settings: |-
+    [default_scrape_settings]
+      kubelet_enabled = true
+      coredns_enabled = true
+  ```
+- 3.3) Apply the configmap to the cluster
+  ```
+  kubectl apply -f prometheus-collector-configmap.yaml
+  ```
 
-- 3.1) Ensure below line in the configmap has your MDM account name (which will be used as default MDM account to send metrics to)
-```account_name = "mymetricsacountname"```
-- 3.2) Change the scrape config as needed in the default configmap, save the file, and apply the configmap to the cluster
-```kubectl apply -f prometheus-collector-configmap.yaml```
-- 3.3) Deploy the sample/reference app (weather app), if you are using default scrape config, which will scraoe the reference (weather) app in the [app](../app/prometheus-reference-app.yaml) folder
-```kubectl apply -f prometheus-reference-app.yaml```
+#### Step 4 : Provide the prometheus scrape config as needed in the prometheus configmap. See [configuration.md](../configuration.md) for more info on the prometheus config. There are two ways of doing so:
+- Make changes as needed to the prometheus-config.yaml configmap and apply:
+  ```
+  kubectl apply -f prometheus-collector-configmap.yaml
+  ```
+  -  By default and for testing purposes, the configmap has a scrape config to scrape our reference service (weather service), which is located in the [app](../app/prometheus-reference-app.yaml) folder. If you'd like to use the default, you need to deploy by running the folowing command while in the [app](../app/prometheus-reference-app.yaml) folder:
+      ```
+      kubectl apply -f prometheus-reference-app.yaml
+      ```
+- If you have your own prometheus yaml and want to use that without having to paste into the configmap, rename the file to ```prometheus-config``` and run:
+  ```
+  kubectl create configmap prometheus-config --from-file=prometheus-config -n kube-system
+  ```
+  - We will validate configurations using [promtool](https://github.com/prometheus/prometheus/tree/main/cmd/promtool), an official commandline prometheus tool, with the command:
+    ```
+    promtool check config <config name>
+    ```
+    You can also download to this tool and run this command for your prometheus config before adding to the configmap.
 
 #### Step 4 : Deploy the prometheus collector (prometheuscollector.yaml) [Prometheus-collector will run in kube-system namespace as a singleton replica]
-```kubectl apply -f prometheuscollector.yaml```
+```
+kubectl apply -f prometheuscollector.yaml
+```

--- a/otelcollector/deploy/prometheus-collector-configmap.yaml
+++ b/otelcollector/deploy/prometheus-collector-configmap.yaml
@@ -10,19 +10,10 @@ data:
   prometheus-collector-settings: |-
     [prometheus_collector_settings.default_metric_account]
       account_name = "mymetricaccountname"
-  prometheus-config: |-
-    global:
-      evaluation_interval: 60s
-      scrape_interval: 60s
-    scrape_configs:
-    - job_name: prometheus_ref_app
-      scheme: http
-      kubernetes_sd_configs:
-        - role: service
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          action: keep
-          regex: "prometheus-reference-service"
+  default-scrape-settings: |-
+    [default_scrape_settings]
+      kubelet_enabled = true
+      coredns_enabled = true
 metadata:
   name: prometheus-collector-configmap
   namespace: kube-system

--- a/otelcollector/deploy/prometheus-config
+++ b/otelcollector/deploy/prometheus-config
@@ -1,0 +1,12 @@
+global:
+  evaluation_interval: 60s
+  scrape_interval: 60s
+scrape_configs:
+- job_name: prometheus_ref_app
+  scheme: http
+  kubernetes_sd_configs:
+    - role: service
+  relabel_configs:
+    - source_labels: [__meta_kubernetes_service_name]
+      action: keep
+      regex: "prometheus-reference-service"

--- a/otelcollector/deploy/prometheus-config.yaml
+++ b/otelcollector/deploy/prometheus-config.yaml
@@ -1,0 +1,19 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  prometheus-config: |-
+    global:
+      evaluation_interval: 60s
+      scrape_interval: 60s
+    scrape_configs:
+    - job_name: prometheus_ref_app
+      scheme: http
+      kubernetes_sd_configs:
+        - role: service
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          action: keep
+          regex: "prometheus-reference-service"
+metadata:
+  name: prometheus-config
+  namespace: kube-system

--- a/otelcollector/deploy/prometheuscollector.yaml
+++ b/otelcollector/deploy/prometheuscollector.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: prometheus-collector
       containers:
         - name: prometheus-collector
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/cidev:prometheuscollector0404-1"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/cidev:myprometheuscollector-040721-2"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -119,6 +119,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/config/settings
               name: settings-vol-config
+              readOnly: true
+            - mountPath: /etc/config/settings/prometheus
+              name: prometheus-config-vol
               readOnly: true
             - mountPath: /etc/config/settings/metricstore
               name: metricstore-secret
@@ -176,4 +179,8 @@ spec:
         - name: metricstore-secret
           secret:
             secretName: metricstore-secret
+            optional: true
+        - name: prometheus-config-vol
+          configMap:
+            name: prometheus-config
             optional: true

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -68,37 +68,39 @@ if [ ${#APPLICATIONINSIGHTS_AUTH_URL} -ge 1 ]; then  # (check if APPLICATIONINSI
       fi
 fi
 
-
 aikey=$(echo $APPLICATIONINSIGHTS_AUTH | base64 --decode)	
 export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey	
 echo "export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey" >> ~/.bashrc	
 
 source ~/.bashrc
 
-
-
-
-#Parse the configmap to set the right environment variables for prometheus collector settings
-
+# Parse the configmap to set the right environment variables for prometheus collector settings
 ruby /opt/microsoft/configmapparser/tomlparser-prometheus-collector-settings.rb
-
-
 cat /opt/microsoft/configmapparser/config_prometheus_collector_settings_env_var | while read line; do
       echo $line >> ~/.bashrc
 done
 source /opt/microsoft/configmapparser/config_prometheus_collector_settings_env_var
 source ~/.bashrc
 
+# Parse the settings for default scrape configs
+ruby /opt/microsoft/configmapparser/tomlparser-default-scrape-settings.rb
+if [ -e "/opt/microsoft/configmapparser/config_default_scrape_settings_env_var" ]; then
+      cat /opt/microsoft/configmapparser/config_default_scrape_settings_env_var | while read line; do
+            echo $line >> ~/.bashrc
+      done
+      source /opt/microsoft/configmapparser/config_default_scrape_settings_env_var
+      source ~/.bashrc
+fi
 
-if [ -e "/etc/config/settings/prometheus-config" ]; then
+if [ -e "/etc/config/settings/prometheus/prometheus-config" ]; then
       # Currently only logs the success or failure
-      /opt/promtool check config /etc/config/settings/prometheus-config
+      /opt/promtool check config /etc/config/settings/prometheus/prometheus-config
 
       # Use default config if specified config is invalid
       if [ $? -ne 0 ]; then
             echo "export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true" >> ~/.bashrc
             export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true
-            # Get prometheus config and replace in otelcollector config
+      # Get prometheus config and replace in otelcollector config
       else 
             ruby /opt/microsoft/configmapparser/tomlparser-prometheus-config.rb
 
@@ -120,9 +122,9 @@ source ~/.bashrc
 service cron start
 
 #start otelcollector
-if [ -e "/etc/config/settings/prometheus-config" ]; then
+if [ -e "/etc/config/settings/prometheus/prometheus-config" ]; then
       echo "prometheus config specified for otel collector:"
-      cat /etc/config/settings/prometheus-config
+      cat /etc/config/settings/prometheus/prometheus-config
 fi
 echo "Use default prometheus config: ${AZMON_USE_DEFAULT_PROMETHEUS_CONFIG}"
 


### PR DESCRIPTION
- Easier to use existing prometheus yaml:
  - Added instructions to use `kubectl create configmap --from-file` so that there's no indenting needed when pasting prometheus yaml in configmap
  - Separated prometheus yaml into another configmap so that no other keys are needed for the above command
- Added infrastructure for options to have common scrape configs like kubelet and coredns to be added into the prometheus yaml without the user needing to specify them