### PR TITLE
Adding MDM metrics for threshold violation

### DIFF
--- a/source/plugins/ruby/MdmAlertTemplates.rb
+++ b/source/plugins/ruby/MdmAlertTemplates.rb
@@ -28,7 +28,7 @@ class MdmAlertTemplates
         }
     }'
 
-    Stable_job_metrics_template = '
+  Stable_job_metrics_template = '
     {
         "time": "%{timestamp}",
         "data": {
@@ -90,6 +90,39 @@ class MdmAlertTemplates
         }
     }'
 
+  Container_resource_threshold_violation_template = '
+    {
+        "time": "%{timestamp}",
+        "data": {
+            "baseData": {
+                "metric": "%{metricName}",
+                "namespace": "insights.container/containers",
+                "dimNames": [
+                    "containerName",
+                    "podName",
+                    "controllerName",
+                    "Kubernetes namespace",
+                    "thresholdPercentage"
+                ],
+                "series": [
+                {
+                    "dimValues": [
+                        "%{containerNameDimValue}",
+                        "%{podNameDimValue}",
+                        "%{controllerNameDimValue}",
+                        "%{namespaceDimValue}",
+                        "%{thresholdPercentageDimValue}"
+                    ],
+                    "min": %{containerResourceThresholdViolated},
+                    "max": %{containerResourceThresholdViolated},
+                    "sum": %{containerResourceThresholdViolated},
+                    "count": 1
+                }
+                ]
+            }
+        }
+    }'
+
   PV_resource_utilization_template = '
     {
         "time": "%{timestamp}",
@@ -123,6 +156,38 @@ class MdmAlertTemplates
         }
     }'
 
+  PV_resource_threshold_violation_template = '
+    {
+        "time": "%{timestamp}",
+        "data": {
+            "baseData": {
+                "metric": "%{metricName}",
+                "namespace": "insights.container/persistentvolumes",
+                "dimNames": [
+                    "podName",
+                    "node",
+                    "kubernetesNamespace",
+                    "volumeName",
+                    "thresholdPercentage"
+                ],
+                "series": [
+                {
+                    "dimValues": [
+                        "%{podNameDimValue}",
+                        "%{computerNameDimValue}",
+                        "%{namespaceDimValue}",
+                        "%{volumeNameDimValue}",
+                        "%{thresholdPercentageDimValue}"
+                    ],
+                    "min": %{pvResourceThresholdViolated},
+                    "max": %{pvResourceThresholdViolated},
+                    "sum": %{pvResourceThresholdViolated},
+                    "count": 1
+                }
+                ]
+            }
+        }
+    }'
 
   Node_resource_metrics_template = '
             {

--- a/source/plugins/ruby/MdmMetricsGenerator.rb
+++ b/source/plugins/ruby/MdmMetricsGenerator.rb
@@ -169,43 +169,59 @@ class MdmMetricsGenerator
 
         metric_threshold_hash = getContainerResourceUtilizationThresholds
         container_zero_fill_dims = [Constants::OMSAGENT_ZERO_FILL, Constants::OMSAGENT_ZERO_FILL, Constants::OMSAGENT_ZERO_FILL, Constants::KUBESYSTEM_NAMESPACE_ZERO_FILL].join("~~")
-        containerCpuRecord = getContainerResourceUtilMetricRecords(batch_time,
-                                                                   Constants::CPU_USAGE_NANO_CORES,
-                                                                   0,
-                                                                   container_zero_fill_dims,
-                                                                   metric_threshold_hash[Constants::CPU_USAGE_NANO_CORES])
-        if !containerCpuRecord.nil? && !containerCpuRecord.empty? && !containerCpuRecord[0].nil? && !containerCpuRecord[0].empty?
-          records.push(containerCpuRecord[0])
+        containerCpuRecords = getContainerResourceUtilMetricRecords(batch_time,
+                                                                    Constants::CPU_USAGE_NANO_CORES,
+                                                                    0,
+                                                                    container_zero_fill_dims,
+                                                                    metric_threshold_hash[Constants::CPU_USAGE_NANO_CORES])
+        if !containerCpuRecords.nil? && !containerCpuRecords.empty?
+          containerCpuRecords.each { |cpuRecord|
+            if !cpuRecord.nil? && !cpuRecord.empty?
+              records.push(cpuRecord)
+            end
+          }
         end
-        containerMemoryRssRecord = getContainerResourceUtilMetricRecords(batch_time,
-                                                                         Constants::MEMORY_RSS_BYTES,
-                                                                         0,
-                                                                         container_zero_fill_dims,
-                                                                         metric_threshold_hash[Constants::MEMORY_RSS_BYTES])
-        if !containerMemoryRssRecord.nil? && !containerMemoryRssRecord.empty? && !containerMemoryRssRecord[0].nil? && !containerMemoryRssRecord[0].empty?
-          records.push(containerMemoryRssRecord[0])
+        containerMemoryRssRecords = getContainerResourceUtilMetricRecords(batch_time,
+                                                                          Constants::MEMORY_RSS_BYTES,
+                                                                          0,
+                                                                          container_zero_fill_dims,
+                                                                          metric_threshold_hash[Constants::MEMORY_RSS_BYTES])
+        if !containerMemoryRssRecords.nil? && !containerMemoryRssRecords.empty?
+          containerMemoryRssRecords.each { |memoryRssRecord|
+            if !memoryRssRecord.nil? && !memoryRssRecord.empty?
+              records.push(memoryRssRecord)
+            end
+          }
         end
-        containerMemoryWorkingSetRecord = getContainerResourceUtilMetricRecords(batch_time,
-                                                                                Constants::MEMORY_WORKING_SET_BYTES,
-                                                                                0,
-                                                                                container_zero_fill_dims,
-                                                                                metric_threshold_hash[Constants::MEMORY_WORKING_SET_BYTES])
-        if !containerMemoryWorkingSetRecord.nil? && !containerMemoryWorkingSetRecord.empty? && !containerMemoryWorkingSetRecord[0].nil? && !containerMemoryWorkingSetRecord[0].empty?
-          records.push(containerMemoryWorkingSetRecord[0])
+        containerMemoryWorkingSetRecords = getContainerResourceUtilMetricRecords(batch_time,
+                                                                                 Constants::MEMORY_WORKING_SET_BYTES,
+                                                                                 0,
+                                                                                 container_zero_fill_dims,
+                                                                                 metric_threshold_hash[Constants::MEMORY_WORKING_SET_BYTES])
+        if !containerMemoryWorkingSetRecords.nil? && !containerMemoryWorkingSetRecords.empty?
+          containerMemoryWorkingSetRecords.each { |workingSetRecord|
+            if !workingSetRecord.nil? && !workingSetRecord.empty?
+              records.push(workingSetRecord)
+            end
+          }
         end
 
         pvZeroFillDims = {}
         pvZeroFillDims[Constants::INSIGHTSMETRICS_TAGS_PVC_NAMESPACE] = Constants::KUBESYSTEM_NAMESPACE_ZERO_FILL
         pvZeroFillDims[Constants::INSIGHTSMETRICS_TAGS_POD_NAME] = Constants::OMSAGENT_ZERO_FILL
         pvZeroFillDims[Constants::INSIGHTSMETRICS_TAGS_VOLUME_NAME] = Constants::VOLUME_NAME_ZERO_FILL
-        pvResourceUtilMetricRecord = getPVResourceUtilMetricRecords(batch_time,
-                                                                    Constants::PV_USED_BYTES,
-                                                                    @@hostName,
-                                                                    0,
-                                                                    pvZeroFillDims,
-                                                                    metric_threshold_hash[Constants::PV_USED_BYTES])
-        if !pvResourceUtilMetricRecord.nil? && !pvResourceUtilMetricRecord.empty? && !pvResourceUtilMetricRecord[0].nil? && !pvResourceUtilMetricRecord[0].empty?
-          records.push(pvResourceUtilMetricRecord[0])
+        pvResourceUtilMetricRecords = getPVResourceUtilMetricRecords(batch_time,
+                                                                     Constants::PV_USED_BYTES,
+                                                                     @@hostName,
+                                                                     0,
+                                                                     pvZeroFillDims,
+                                                                     metric_threshold_hash[Constants::PV_USED_BYTES])
+        if !pvResourceUtilMetricRecords.nil? && !pvResourceUtilMetricRecords.empty?
+          pvResourceUtilMetricRecords.each { |pvRecord|
+            if !pvRecord.nil? && !pvRecord.empty?
+              records.push(pvRecord)
+            end
+          }
         end
       rescue => errorStr
         @log.info "Error in zeroFillMetricRecords: #{errorStr}"

--- a/source/plugins/ruby/MdmMetricsGenerator.rb
+++ b/source/plugins/ruby/MdmMetricsGenerator.rb
@@ -173,7 +173,8 @@ class MdmMetricsGenerator
                                                                     Constants::CPU_USAGE_NANO_CORES,
                                                                     0,
                                                                     container_zero_fill_dims,
-                                                                    metric_threshold_hash[Constants::CPU_USAGE_NANO_CORES])
+                                                                    metric_threshold_hash[Constants::CPU_USAGE_NANO_CORES],
+                                                                    true)
         if !containerCpuRecords.nil? && !containerCpuRecords.empty?
           containerCpuRecords.each { |cpuRecord|
             if !cpuRecord.nil? && !cpuRecord.empty?
@@ -185,7 +186,8 @@ class MdmMetricsGenerator
                                                                           Constants::MEMORY_RSS_BYTES,
                                                                           0,
                                                                           container_zero_fill_dims,
-                                                                          metric_threshold_hash[Constants::MEMORY_RSS_BYTES])
+                                                                          metric_threshold_hash[Constants::MEMORY_RSS_BYTES],
+                                                                          true)
         if !containerMemoryRssRecords.nil? && !containerMemoryRssRecords.empty?
           containerMemoryRssRecords.each { |memoryRssRecord|
             if !memoryRssRecord.nil? && !memoryRssRecord.empty?
@@ -197,7 +199,8 @@ class MdmMetricsGenerator
                                                                                  Constants::MEMORY_WORKING_SET_BYTES,
                                                                                  0,
                                                                                  container_zero_fill_dims,
-                                                                                 metric_threshold_hash[Constants::MEMORY_WORKING_SET_BYTES])
+                                                                                 metric_threshold_hash[Constants::MEMORY_WORKING_SET_BYTES],
+                                                                                 true)
         if !containerMemoryWorkingSetRecords.nil? && !containerMemoryWorkingSetRecords.empty?
           containerMemoryWorkingSetRecords.each { |workingSetRecord|
             if !workingSetRecord.nil? && !workingSetRecord.empty?
@@ -215,7 +218,8 @@ class MdmMetricsGenerator
                                                                      @@hostName,
                                                                      0,
                                                                      pvZeroFillDims,
-                                                                     metric_threshold_hash[Constants::PV_USED_BYTES])
+                                                                     metric_threshold_hash[Constants::PV_USED_BYTES],
+                                                                     true)
         if !pvResourceUtilMetricRecords.nil? && !pvResourceUtilMetricRecords.empty?
           pvResourceUtilMetricRecords.each { |pvRecord|
             if !pvRecord.nil? && !pvRecord.empty?
@@ -274,7 +278,7 @@ class MdmMetricsGenerator
       return records
     end
 
-    def getContainerResourceUtilMetricRecords(recordTimeStamp, metricName, percentageMetricValue, dims, thresholdPercentage)
+    def getContainerResourceUtilMetricRecords(recordTimeStamp, metricName, percentageMetricValue, dims, thresholdPercentage, isZeroFill = false)
       records = []
       begin
         if dims.nil?
@@ -312,7 +316,7 @@ class MdmMetricsGenerator
           podNameDimValue: podName,
           controllerNameDimValue: controllerName,
           namespaceDimValue: podNamespace,
-          containerResourceThresholdViolated: 1,
+          containerResourceThresholdViolated: isZeroFill ? 0 : 1,
           thresholdPercentageDimValue: thresholdPercentage,
         }
         records.push(Yajl::Parser.parse(StringIO.new(resourceThresholdViolatedRecord)))
@@ -323,7 +327,7 @@ class MdmMetricsGenerator
       return records
     end
 
-    def getPVResourceUtilMetricRecords(recordTimeStamp, metricName, computer, percentageMetricValue, dims, thresholdPercentage)
+    def getPVResourceUtilMetricRecords(recordTimeStamp, metricName, computer, percentageMetricValue, dims, thresholdPercentage, isZeroFill = false)
       records = []
       begin
         containerName = dims[Constants::INSIGHTSMETRICS_TAGS_CONTAINER_NAME]
@@ -352,7 +356,7 @@ class MdmMetricsGenerator
           computerNameDimValue: computer,
           namespaceDimValue: pvcNamespace,
           volumeNameDimValue: volumeName,
-          pvResourceThresholdViolated: 1,
+          pvResourceThresholdViolated: isZeroFill ? 0 : 1,
           thresholdPercentageDimValue: thresholdPercentage,
         }
         records.push(Yajl::Parser.parse(StringIO.new(resourceThresholdViolatedRecord)))

--- a/source/plugins/ruby/MdmMetricsGenerator.rb
+++ b/source/plugins/ruby/MdmMetricsGenerator.rb
@@ -336,7 +336,7 @@ class MdmMetricsGenerator
           computerNameDimValue: computer,
           namespaceDimValue: pvcNamespace,
           volumeNameDimValue: volumeName,
-          pvResourceThresholdViolated: percentageMetricValue,
+          pvResourceThresholdViolated: 1,
           thresholdPercentageDimValue: thresholdPercentage,
         }
         records.push(Yajl::Parser.parse(StringIO.new(resourceThresholdViolatedRecord)))

--- a/source/plugins/ruby/constants.rb
+++ b/source/plugins/ruby/constants.rb
@@ -53,6 +53,10 @@ class Constants
   MDM_CONTAINER_MEMORY_RSS_UTILIZATION_METRIC = "memoryRssExceededPercentage"
   MDM_CONTAINER_MEMORY_WORKING_SET_UTILIZATION_METRIC = "memoryWorkingSetExceededPercentage"
   MDM_PV_UTILIZATION_METRIC = "pvUsageExceededPercentage"
+  MDM_CONTAINER_CPU_THRESHOLD_VIOLATED_METRIC = "cpuThresholdViolated"
+  MDM_CONTAINER_MEMORY_RSS_THRESHOLD_VIOLATED_METRIC = "memoryRssThresholdViolated"
+  MDM_CONTAINER_MEMORY_WORKING_SET_THRESHOLD_VIOLATED_METRIC = "memoryWorkingSetThresholdViolated"
+  MDM_PV_THRESHOLD_VIOLATED_METRIC = "pvUsageThresholdViolated"
   MDM_NODE_CPU_USAGE_PERCENTAGE = "cpuUsagePercentage"
   MDM_NODE_MEMORY_RSS_PERCENTAGE = "memoryRssPercentage"
   MDM_NODE_MEMORY_WORKING_SET_PERCENTAGE = "memoryWorkingSetPercentage"
@@ -77,9 +81,9 @@ class Constants
   OMSAGENT_ZERO_FILL = "omsagent"
   KUBESYSTEM_NAMESPACE_ZERO_FILL = "kube-system"
   VOLUME_NAME_ZERO_FILL = "-"
-  PV_TYPES =["awsElasticBlockStore", "azureDisk", "azureFile", "cephfs", "cinder", "csi", "fc", "flexVolume",
-    "flocker", "gcePersistentDisk", "glusterfs", "hostPath", "iscsi", "local", "nfs",
-    "photonPersistentDisk", "portworxVolume", "quobyte", "rbd", "scaleIO", "storageos", "vsphereVolume"]
+  PV_TYPES = ["awsElasticBlockStore", "azureDisk", "azureFile", "cephfs", "cinder", "csi", "fc", "flexVolume",
+              "flocker", "gcePersistentDisk", "glusterfs", "hostPath", "iscsi", "local", "nfs",
+              "photonPersistentDisk", "portworxVolume", "quobyte", "rbd", "scaleIO", "storageos", "vsphereVolume"]
 
   #Telemetry constants
   CONTAINER_METRICS_HEART_BEAT_EVENT = "ContainerMetricsMdmHeartBeatEvent"


### PR DESCRIPTION
Adding 4 new metrics for threshold violation so that nulls can be treated as zeroes and alerts can go back resolved state.