### PR TITLE
add Read_from_Head config for all fluentbit tail plugins

### DIFF
--- a/build/linux/installer/conf/td-agent-bit-prom-side-car.conf
+++ b/build/linux/installer/conf/td-agent-bit-prom-side-car.conf
@@ -15,6 +15,7 @@
     Name tail
     Tag oms.container.log.flbplugin.terminationlog.*
     Path /dev/write-to-traces
+    Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/terminationlog-ai.db
     DB.Sync Off
     Parser docker

--- a/build/linux/installer/conf/td-agent-bit-rs.conf
+++ b/build/linux/installer/conf/td-agent-bit-rs.conf
@@ -14,6 +14,7 @@
     Name tail
     Tag oms.container.log.flbplugin.terminationlog.*
     Path /dev/write-to-traces
+    Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/terminationlog-ai.db
     DB.Sync Off
     Parser docker

--- a/build/linux/installer/conf/td-agent-bit.conf
+++ b/build/linux/installer/conf/td-agent-bit.conf
@@ -15,6 +15,7 @@
     Name tail
     Tag oms.container.log.la.*
     Path ${AZMON_LOG_TAIL_PATH}
+    Read_from_Head true
     DB /var/log/omsagent-fblogs.db
     DB.Sync Off
     Parser docker
@@ -32,6 +33,7 @@
     Name tail
     Tag oms.container.log.flbplugin.*
     Path /var/log/containers/omsagent*.log
+    Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/omsagent-ai.db
     DB.Sync Off
     Parser docker
@@ -44,6 +46,7 @@
     Name tail
     Tag oms.container.log.flbplugin.mdsd.*
     Path /var/opt/microsoft/linuxmonagent/log/mdsd.err
+    Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/mdsd-ai.db
     DB.Sync Off
     Parser docker
@@ -56,6 +59,7 @@
     Name tail
     Tag oms.container.log.flbplugin.terminationlog.*
     Path /dev/write-to-traces
+    Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/terminationlog-ai.db
     DB.Sync Off
     Parser docker


### PR DESCRIPTION
See the commit message of: https://github.com/fluent/fluent-bit/commit/70e33fa2618227882d48faf690848bb4117cdb3e
for details explaining the fluentbit change and what Read_from_Head does when set to true.

Setting Read_from_Head = true fixes the issues where:
- only the last lines of the omsagent startup logs are sent to traces
- when fluentbit sees new files (new container logs) that don't have an offset in the database, it starts tailing the file from the end and the beginning logs are missed

I tested these scenarios:
- full omsagent logs are now sent to traces (whether it's logs from starting up, restarting, shutting down, or just running)
- full logs are now sent to ContainerLogs for a new pod/container that's created after omsagent startup
- known log files are still tailed from the offset in the database after omsagent restart (they aren't affected by the Read_from_Head setting)
- /dev/write-to-traces for telegraf liveness still works as expected