### PR TITLE
fix programdata mount issue on containerd win nodes

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -118,6 +118,7 @@ spec:
     - name: docker-windows-containers
       hostPath:
         path: C:\ProgramData\docker\containers
+        type: DirectoryOrCreate
     - name: settings-vol-config
       configMap:
         name: container-azm-ms-agentconfig

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -839,6 +839,7 @@ spec:
       - name: docker-windows-containers
         hostPath:
           path: C:\ProgramData\docker\containers
+          type: DirectoryOrCreate
       - name: settings-vol-config
         configMap:
           name: container-azm-ms-agentconfig


### PR DESCRIPTION
Recent change in AKS & AKS-E to remove docker completely on windows containerd nodes. This broke our containerlog because this path C:\ProgramData\docker\containers doesnt exist in containerd windows nodes.  The AKS team made change to create C:\ProgramData\docker\containers path if doesnt exist via type: DirectoryOrCreate attribute. This change has been validated on both docker & containerd windows nodes.  AKS side this change already taken care and I am making this change in our side to keep insync with AKS repo changes.


