### PR TITLE
1m, 1m, 1s by default

### DIFF
--- a/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/td-agent-bit-conf-customizer.rb
@@ -3,7 +3,9 @@ require_relative "ConfigParseErrorLogger"
 
 @td_agent_bit_conf_path = "/etc/opt/microsoft/docker-cimprov/td-agent-bit.conf"
 
-@default_service_interval = "15"
+@default_service_interval = "1"
+@default_buffer_chunk_size = "1"
+@default_buffer_max_size = "1"
 
 def is_number?(value)
   true if Integer(value) rescue false
@@ -21,9 +23,9 @@ def substituteFluentBitPlaceHolders
     serviceInterval = (!interval.nil? && is_number?(interval) && interval.to_i > 0 ) ? interval : @default_service_interval
     serviceIntervalSetting = "Flush         " + serviceInterval
 
-    tailBufferChunkSize = (!bufferChunkSize.nil? && is_number?(bufferChunkSize) && bufferChunkSize.to_i > 0) ? bufferChunkSize : nil
+    tailBufferChunkSize = (!bufferChunkSize.nil? && is_number?(bufferChunkSize) && bufferChunkSize.to_i > 0) ? bufferChunkSize : @default_buffer_chunk_size
 
-    tailBufferMaxSize = (!bufferMaxSize.nil? && is_number?(bufferMaxSize) && bufferMaxSize.to_i > 0) ? bufferMaxSize : nil
+    tailBufferMaxSize = (!bufferMaxSize.nil? && is_number?(bufferMaxSize) && bufferMaxSize.to_i > 0) ? bufferMaxSize : @default_buffer_max_size = "1"
 
     if ((!tailBufferChunkSize.nil? && tailBufferMaxSize.nil?) ||  (!tailBufferChunkSize.nil? && !tailBufferMaxSize.nil? && tailBufferChunkSize.to_i > tailBufferMaxSize.to_i))
       puts "config:warn buffer max size must be greater or equal to chunk size"

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -144,12 +144,16 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if !fbitFlushIntervalSecs.nil? && is_number?(fbitFlushIntervalSecs) && fbitFlushIntervalSecs.to_i > 0
           @fbitFlushIntervalSecs = fbitFlushIntervalSecs.to_i
           puts "Using config map value: log_flush_interval_secs = #{@fbitFlushIntervalSecs}"
+        else
+          @fbitFlushIntervalSecs = 1
         end
 
         fbitTailBufferChunkSizeMBs = fbit_config[:tail_buf_chunksize_megabytes]
         if !fbitTailBufferChunkSizeMBs.nil? && is_number?(fbitTailBufferChunkSizeMBs) && fbitTailBufferChunkSizeMBs.to_i > 0
           @fbitTailBufferChunkSizeMBs = fbitTailBufferChunkSizeMBs.to_i
           puts "Using config map value: tail_buf_chunksize_megabytes  = #{@fbitTailBufferChunkSizeMBs}"
+        else
+          @fbitTailBufferChunkSizeMBs = 1
         end
 
         fbitTailBufferMaxSizeMBs = fbit_config[:tail_buf_maxsize_megabytes]

--- a/build/linux/installer/scripts/tomlparser-agent-config.rb
+++ b/build/linux/installer/scripts/tomlparser-agent-config.rb
@@ -144,16 +144,12 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if !fbitFlushIntervalSecs.nil? && is_number?(fbitFlushIntervalSecs) && fbitFlushIntervalSecs.to_i > 0
           @fbitFlushIntervalSecs = fbitFlushIntervalSecs.to_i
           puts "Using config map value: log_flush_interval_secs = #{@fbitFlushIntervalSecs}"
-        else
-          @fbitFlushIntervalSecs = 1
         end
 
         fbitTailBufferChunkSizeMBs = fbit_config[:tail_buf_chunksize_megabytes]
         if !fbitTailBufferChunkSizeMBs.nil? && is_number?(fbitTailBufferChunkSizeMBs) && fbitTailBufferChunkSizeMBs.to_i > 0
           @fbitTailBufferChunkSizeMBs = fbitTailBufferChunkSizeMBs.to_i
           puts "Using config map value: tail_buf_chunksize_megabytes  = #{@fbitTailBufferChunkSizeMBs}"
-        else
-          @fbitTailBufferChunkSizeMBs = 1
         end
 
         fbitTailBufferMaxSizeMBs = fbit_config[:tail_buf_maxsize_megabytes]


### PR DESCRIPTION
Changing default tail plugin settings to 1m, 1m,  1s  (in fluent-bit)