### PR TITLE
Update enable-monitoring.sh

### DIFF
--- a/scripts/onboarding/managed/enable-monitoring.sh
+++ b/scripts/onboarding/managed/enable-monitoring.sh
@@ -44,7 +44,7 @@ defaultAzureCloud="AzureCloud"
 omsAgentDomainName="opinsights.azure.com"
 
 # released chart version in mcr
-mcrChartVersion="2.8.3"
+mcrChartVersion="2.8.2"
 mcr="mcr.microsoft.com"
 mcrChartRepoPath="azuremonitor/containerinsights/preview/azuremonitor-containers"
 helmLocalRepoName="."


### PR DESCRIPTION
The version 2.8.3 doesn't exist and the whole script fails at the end. Check the following tag list
https://mcr.microsoft.com/v2/azuremonitor/containerinsights/preview/azuremonitor-containers/tags/list