### PR TITLE
partially disabled telegraf liveness probe check

### DIFF
--- a/build/linux/installer/scripts/livenessprobe.sh
+++ b/build/linux/installer/scripts/livenessprobe.sh
@@ -30,9 +30,9 @@ fi
 (ps -ef | grep telegraf | grep -v "grep")
 if [ $? -ne 0 ]
 then
- echo "Telegraf is not running" > /dev/termination-log
+ # echo "Telegraf is not running" > /dev/termination-log
  echo "Telegraf is not running (controller: ${CONTROLLER_TYPE}, container type: ${CONTAINER_TYPE})" > /dev/write-to-traces  # this file is tailed and sent to traces
- exit 1
+ # exit 1
 fi
 
 if [ -s "inotifyoutput.txt" ]


### PR DESCRIPTION
I'm leaving the check in the liveness probe, just commenting out the `exit 1` line. This way we will still have telemetry about when telegraf dies (in traces).