### PR TITLE
updating json gem to address CVE-2020-10663

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -44,11 +44,13 @@ sudo echo "deb https://packages.fluentbit.io/ubuntu/xenial xenial main" >> /etc/
 sudo apt-get update
 sudo apt-get install td-agent-bit=1.6.8 -y
 
-# install ruby2.6 
+# install ruby2.6
 sudo apt-get install software-properties-common -y
 sudo apt-add-repository ppa:brightbox/ruby-ng -y
 sudo apt-get update
 sudo apt-get install ruby2.6 ruby2.6-dev gcc make -y
+# to fix CVE-2020-10663
+gem update json -v 2.5.1
 # fluentd v1 gem
 gem install fluentd -v "1.12.2" --no-document
 fluentd --setup ./fluent


### PR DESCRIPTION
The title says it all. The json gem that comes with our version of ruby has a security vulnerability (not sure why it hasn't been fixed in the default json gem version 🤔)

I think this upgrade should be pretty safe, although we do use the default json gem in a few places (specifically build/common/installer/scripts/ConfigParseErrorLogger.rb, source/plugins/ruby/MdmMetricsGenerator.rb, and source/plugins/ruby/kubernetes_container_inventory). The next release will need extensive testing anyways (WM stage 3), so this change should be well covered.