### PR TITLE
trying again to fix the json gem

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -50,7 +50,7 @@ sudo apt-add-repository ppa:brightbox/ruby-ng -y
 sudo apt-get update
 sudo apt-get install ruby2.6 ruby2.6-dev gcc make -y
 # to fix CVE-2020-10663
-gem update json -v 2.5.1
+gem install json -v 2.5.1
 # fluentd v1 gem
 gem install fluentd -v "1.12.2" --no-document
 fluentd --setup ./fluent

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -49,8 +49,6 @@ sudo apt-get install software-properties-common -y
 sudo apt-add-repository ppa:brightbox/ruby-ng -y
 sudo apt-get update
 sudo apt-get install ruby2.6 ruby2.6-dev gcc make -y
-# to fix CVE-2020-10663
-gem install json -v 2.5.1
 # fluentd v1 gem
 gem install fluentd -v "1.12.2" --no-document
 fluentd --setup ./fluent


### PR DESCRIPTION
Removing the manual json gem update

Tuns out we already had the fix to CVE-2020-10663, the installed patch level is 142
https://github.com/ruby/ruby/commit/36e9ed7fef6eb2d14becf6c52452e4ab16e4bf01