### PR TITLE
add log rotation settings for fluentd logs

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -478,10 +478,10 @@ fi
 if [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ]; then     
       if [ ! -e "/etc/config/kube.conf" ]; then
          echo "*** starting fluentd v1 in daemonset"
-         fluentd -c /etc/fluent/container.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log &
+         fluentd -c /etc/fluent/container.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
       else
         echo "*** starting fluentd v1 in replicaset"
-        fluentd -c /etc/fluent/kube.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log &
+        fluentd -c /etc/fluent/kube.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
       fi      
 fi   
 


### PR DESCRIPTION
By default fluentd doesnt rotate its log file, see - https://docs.fluentd.org/deployment/logging#log-rotation-setting and this makes the fluentd.log growing infinitely.  Added the log rotation settings, 20MB and 5 generations to avoid infinite growth. In case of windows, growth of the fluentd log file is very low, ~i.e. 500 bytes per an hour and this is not critical, will add the task for fluentd in windows agent to add log rotation settings in next agent release.