### PR TITLE
Gangams/remove chart version dependency

### DIFF
--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -39,48 +39,49 @@ Image automatically synched to MCR CN from Public cloud MCR.
 
 Make PR against [AKS-Engine](https://github.com/Azure/aks-engine). Refer PR https://github.com/Azure/aks-engine/pull/2318
 
-## Arc for Kubernetes 
+## Arc for Kubernetes
 
-Ev2 pipeline used to deploy the chart of the Arc K8s Container Insights Extension as per Safe Deployment Process. 
+Ev2 pipeline used to deploy the chart of the Arc K8s Container Insights Extension as per Safe Deployment Process.
 Here is the high level process
 ```
  1. Specify chart version of the release candidate and trigger [container-insights-arc-k8s-extension-ci_prod-release](https://github-private.visualstudio.com/microsoft/_release?_a=releases&view=all)
  2. Get the approval from one of team member for the release
- 3. Once the approved, release should be triggered automatically 
+ 3. Once the approved, release should be triggered automatically
  4. use `cimon-arck8s-eastus2euap` for validating latest release in canary region
  5. TBD - Notify vendor team for the validation on all Arc K8s supported platforms
 ```
 
 ## Microsoft Charts Repo release for On-prem K8s
+> Note: This chart repo being used in the ARO v4 onboarding script as well.
 
-Since HELM charts repo being deprecated, Microsoft charts repo being used for HELM chart release of on-prem K8s clusters. 
-To make chart release PR, fork [Microsoft-charts-repo]([https://github.com/microsoft/charts/tree/gh-pages) and make the PR against `gh-pages` branch of the upstream repo. 
+Since HELM charts repo being deprecated, Microsoft charts repo being used for HELM chart release of on-prem K8s clusters.
+To make chart release PR, fork [Microsoft-charts-repo]([https://github.com/microsoft/charts/tree/gh-pages) and make the PR against `gh-pages` branch of the upstream repo.
 
 Refer PR - https://github.com/microsoft/charts/pull/23 for example.
 Once the PR merged, latest version of HELM chart should be available in couple of mins in https://microsoft.github.io/charts/repo and https://artifacthub.io/.
 
 Instructions to create PR
 ```
-# 1. create helm package for the release candidate 
+# 1. create helm package for the release candidate
    git clone git@github.com:microsoft/Docker-Provider.git
    git checkout ci_prod
    cd ~/Docker-Provider/charts/azuremonitor-containers # this path based on where you have cloned the repo
-   helm package . 
+   helm package .
 
-# 2. clone your fork repo and checkout gh_pages branch # gh_pages branch used as release branch 
-   cd ~ 
+# 2. clone your fork repo and checkout gh_pages branch # gh_pages branch used as release branch
+   cd ~
    git clone <your-forked-repo-of-microsoft-charts-repo>
    cd  ~/charts # assumed the root dir of the clone is charts
    git checkout gh_pages
 
-# 3. copy release candidate helm package 
-   cd ~/charts/repo/azuremonitor-containers 
+# 3. copy release candidate helm package
+   cd ~/charts/repo/azuremonitor-containers
    # update chart version value with the version of chart being released
-   cp ~/Docker-Provider/charts/azuremonitor-containers/azuremonitor-containers-<chart-version>.tgz  .  
+   cp ~/Docker-Provider/charts/azuremonitor-containers/azuremonitor-containers-<chart-version>.tgz  .
    cd ~/charts/repo
-   # update repo index file 
+   # update repo index file
    helm repo index  .
-    
+
 # 4. Review the changes and make PR. Please note, you may need to revert unrelated changes automatically added by `helm repo index .` command
 
 ```

--- a/scripts/onboarding/managed/enable-monitoring.ps1
+++ b/scripts/onboarding/managed/enable-monitoring.ps1
@@ -62,11 +62,10 @@ $isArcK8sCluster = $false
 $isAksCluster = $false
 $isUsingServicePrincipal = $false
 
-# released chart version in mcr
-$mcr = "mcr.microsoft.com"
-$mcrChartVersion = "2.8.3"
-$mcrChartRepoPath = "azuremonitor/containerinsights/preview/azuremonitor-containers"
-$helmLocalRepoName = "."
+# microsoft helm chart repo
+$microsoftHelmRepo="https://microsoft.github.io/charts/repo"
+$microsoftHelmRepoName="microsoft"
+
 $omsAgentDomainName="opinsights.azure.com"
 
 if ([string]::IsNullOrEmpty($azureCloudName) -eq $true) {
@@ -547,16 +546,12 @@ Write-Host "Helm version" : $helmVersion
 Write-Host("Installing or upgrading if exists, Azure Monitor for containers HELM chart ...")
 try {
 
-     Write-Host("pull the chart from mcr.microsoft.com")
-    [System.Environment]::SetEnvironmentVariable("HELM_EXPERIMENTAL_OCI", 1, "Process")
+    Write-Host("Add helm chart repo- ${microsoftHelmRepoName} with repo path: ${microsoftHelmRepo}")
+    helm repo add ${microsoftHelmRepoName} ${microsoftHelmRepo}
+    Write-Host("Updating the helm chart repo- ${microsoftHelmRepoName} to get latest chart versions")
+    helm repo update ${microsoftHelmRepoName}
 
-    Write-Host("pull the chart from mcr.microsoft.com")
-    helm chart pull ${mcr}/${mcrChartRepoPath}:${mcrChartVersion}
-
-    Write-Host("export the chart from local cache to current directory")
-    helm chart export ${mcr}/${mcrChartRepoPath}:${mcrChartVersion} --destination .
-
-    $helmChartRepoPath = "${helmLocalRepoName}" + "/" + "${helmChartName}"
+    $helmChartRepoPath = "${microsoftHelmRepoName}" + "/" + "${helmChartName}"
 
     Write-Host("helmChartRepoPath is : ${helmChartRepoPath}")
 

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -216,7 +216,7 @@ validate_cluster_identity() {
 
 validate_monitoring_tags() {
   echo "get loganalyticsworkspaceResourceId tag on to cluster resource"
-  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type $resourceProvider -o json)
+  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type 'microsoft.operationalinsights/workspaces' -o json)
   echo "configured log analytics workspace: ${logAnalyticsWorkspaceResourceIdTag}"
   echo "successfully got logAnalyticsWorkspaceResourceId tag on the cluster resource"
   if [ -z "$logAnalyticsWorkspaceResourceIdTag" ]; then

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -38,6 +38,9 @@ arcK8sResourceProvider="Microsoft.Kubernetes/connectedClusters"
 # default of resourceProvider is Azure Arc enabled Kubernetes and this will get updated based on the provider cluster resource
 resourceProvider="Microsoft.Kubernetes/connectedClusters"
 
+# resource provider for azure redhat openshift v4 cluster
+aroV4ResourceProvider="Microsoft.RedHatOpenShift/OpenShiftClusters"
+
 # Azure Arc enabled Kubernetes cluster resource
 isArcK8sCluster=false
 
@@ -216,7 +219,7 @@ validate_cluster_identity() {
 
 validate_monitoring_tags() {
   echo "get loganalyticsworkspaceResourceId tag on to cluster resource"
-  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type 'microsoft.operationalinsights/workspaces' -o json)
+  logAnalyticsWorkspaceResourceIdTag=$(az resource show --query tags.logAnalyticsWorkspaceResourceId -g $clusterResourceGroup -n $clusterName --resource-type $resourceProvider -o json)
   echo "configured log analytics workspace: ${logAnalyticsWorkspaceResourceIdTag}"
   echo "successfully got logAnalyticsWorkspaceResourceId tag on the cluster resource"
   if [ -z "$logAnalyticsWorkspaceResourceIdTag" ]; then

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -19,14 +19,21 @@
 set -e
 set -o pipefail
 
+# microsoft helm chart repo
+microsoftHelmRepo="https://microsoft.github.io/charts/repo"
+microsoftHelmRepoName="microsoft"
+
 # released chart version for Azure Arc enabled Kubernetes public preview
-mcrChartVersion="2.8.3"
-mcr="mcr.microsoft.com"
-mcrChartRepoPath="azuremonitor/containerinsights/preview/azuremonitor-containers"
+# mcrChartVersion="2.8.3"
+# mcr="mcr.microsoft.com"
+# mcrChartRepoPath="azuremonitor/containerinsights/preview/azuremonitor-containers"
 
 # default to public cloud since only supported cloud is azure public clod
 defaultAzureCloud="AzureCloud"
-helmLocalRepoName="."
+#helmLocalRepoName="."
+# microsoft helm chart repo
+microsoftHelmRepo="https://microsoft.github.io/charts/repo"
+microsoftHelmRepoName="microsoft"
 helmChartName="azuremonitor-containers"
 
 # default release name used during onboarding
@@ -249,15 +256,7 @@ upgrade_helm_chart_release() {
     echo "installing Azure Monitor for containers HELM chart on to the cluster with kubecontext:${kubeconfigContext} ..."
   fi
 
-  export HELM_EXPERIMENTAL_OCI=1
-
-  echo "pull the chart from ${mcr}/${mcrChartRepoPath}:${mcrChartVersion}"
-  helm chart pull ${mcr}/${mcrChartRepoPath}:${mcrChartVersion}
-
-  echo "export the chart from local cache to current directory"
-  helm chart export ${mcr}/${mcrChartRepoPath}:${mcrChartVersion} --destination .
-
-  helmChartRepoPath=$helmLocalRepoName/$helmChartName
+  helmChartRepoPath=$microsoftHelmRepoName/$helmChartName
 
   echo "upgrading the release: $releaseName to chart version : ${mcrChartVersion}"
   helm get values $releaseName -o yaml | helm upgrade --install $releaseName $helmChartRepoPath -f -
@@ -296,6 +295,14 @@ validate_and_configure_supported_cloud() {
   fi
 }
 
+# add helm chart repo and update repo to get latest chart version
+add_and_update_helm_chart_repo() {
+  echo "adding helm repo: ${microsoftHelmRepoName} with repo path: ${microsoftHelmRepo}"
+  helm repo add ${microsoftHelmRepoName} ${microsoftHelmRepo}
+  echo "updating helm repo: ${microsoftHelmRepoName} to get local charts updated with latest ones"
+  helm repo update
+}
+
 # parse and validate args
 parse_args $@
 
@@ -321,6 +328,9 @@ fi
 
 # validate the cluster has monitoring tags
 validate_monitoring_tags
+
+# add helm repo & update to get the latest chart version
+add_and_update_helm_chart_repo
 
 # upgrade helm chart release
 upgrade_helm_chart_release

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -22,15 +22,8 @@ set -o pipefail
 # microsoft helm chart repo
 microsoftHelmRepo="https://microsoft.github.io/charts/repo"
 microsoftHelmRepoName="microsoft"
-
-# released chart version for Azure Arc enabled Kubernetes public preview
-# mcrChartVersion="2.8.3"
-# mcr="mcr.microsoft.com"
-# mcrChartRepoPath="azuremonitor/containerinsights/preview/azuremonitor-containers"
-
 # default to public cloud since only supported cloud is azure public clod
 defaultAzureCloud="AzureCloud"
-#helmLocalRepoName="."
 # microsoft helm chart repo
 microsoftHelmRepo="https://microsoft.github.io/charts/repo"
 microsoftHelmRepoName="microsoft"

--- a/scripts/onboarding/managed/upgrade-monitoring.sh
+++ b/scripts/onboarding/managed/upgrade-monitoring.sh
@@ -238,10 +238,14 @@ upgrade_helm_chart_release() {
     adminUserName=$(az aro list-credentials -g $clusterResourceGroup -n $clusterName --query 'kubeadminUsername' -o tsv)
     adminPassword=$(az aro list-credentials -g $clusterResourceGroup -n $clusterName --query 'kubeadminPassword' -o tsv)
     apiServer=$(az aro show -g $clusterResourceGroup -n $clusterName --query apiserverProfile.url -o tsv)
+    # certain az cli versions adds /r/n so trim them
+    adminUserName=$(echo $adminUserName |tr -d '"\r\n')
+    adminPassword=$(echo $adminPassword |tr -d '"\r\n')
+    apiServer=$(echo $apiServer |tr -d '"\r\n')
     echo "login to the cluster via oc login"
     oc login $apiServer -u $adminUserName -p $adminPassword
-    echo "creating project azure-monitor-for-containers"
-    oc new-project $openshiftProjectName
+    echo "switching to project azure-monitor-for-containers"
+    oc project $openshiftProjectName
     echo "getting config-context of aro v4 cluster"
     kubeconfigContext=$(oc config current-context)
   fi


### PR DESCRIPTION
Removed chart version dependency in onboarding scripts  which will address issues of pulling pre-released chart version. Chart repo used same as one we have here - https://docs.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-hybrid-setup#install-the-helm-chart