### PR TITLE
fix telegraf telemetry and improve fluentd liveness

### DIFF
--- a/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -53,4 +53,4 @@ package:
       repository_name: 'cdpxwin1809'                      # only supported ones are cdpx acr repos
       tag: 'win-ciprod'                                    # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
-      export_to_artifact_path: 'agentimage.tar.gz'   # path for exported image and use this instead of fixed tag
+      export_to_artifact_path: 'agentimage.tar.zip'   # path for exported image and use this instead of fixed tag

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -53,4 +53,4 @@ package:
       repository_name: 'cdpxwin1809'                      # only supported ones are cdpx acr repos
       tag: 'win-cidev'                                    # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
-      export_to_artifact_path: 'agentimage.tar.gz' # path for exported image and use this instead of fixed tag
+      export_to_artifact_path: 'agentimage.tar.zip' # path for exported image and use this instead of fixed tag

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -20,6 +20,9 @@ cp -f $TMPDIR/envmdsd /etc/mdsd.d
 sudo apt-get update
 sudo apt-get install inotify-tools -y
 
+#upgrade libsystemd0 to address CVE-2021-33910 
+apt-get upgrade libsystemd0 -y
+
 #used to parse response of kubelet apis
 #ref: https://packages.ubuntu.com/search?keywords=jq
 sudo apt-get install jq=1.5+dfsg-2 -y

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -959,6 +959,7 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 
 				if er != nil {
 					Log("Error::mdsd::Failed to write to mdsd %d records after %s. Will retry ... error : %s", len(msgPackEntries), elapsed, er.Error())
+					UpdateNumTelegrafMetricsSentTelemetry(0, 1, 0)
 					if MdsdInsightsMetricsMsgpUnixSocketClient != nil {
 						MdsdInsightsMetricsMsgpUnixSocketClient.Close()
 						MdsdInsightsMetricsMsgpUnixSocketClient = nil
@@ -970,6 +971,7 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 					return output.FLB_RETRY
 				} else {
 					numTelegrafMetricsRecords := len(msgPackEntries)
+					UpdateNumTelegrafMetricsSentTelemetry(numTelegrafMetricsRecords, 0, 0)
 					Log("Success::mdsd::Successfully flushed %d telegraf metrics records that was %d bytes to mdsd in %s ", numTelegrafMetricsRecords, bts, elapsed)
 				}
 		}


### PR DESCRIPTION
This PR addresses the following 
1.  Improve fluentd liveness probe checks to handle both supervisor and worker process in scenario any of the process gets terminated 
2. Fix missing telegraf metrics (TelegrafMetricsSentCount & TelegrafMetricsSendErrorCount) in mdsd route
3. Also fixed the newly identified vuln during the build.                                                                                                                     4. Fixed exported image file extensions for windows image