### PR TITLE
Gangams/july 2021 release tasks 3

### DIFF
--- a/.pipelines/pipeline.user.linux.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.linux.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -40,5 +40,6 @@ package:
                                                           # to be named differently. Defaults to Dockerfile.
                                                           # In effect, the -f option value passed to docker build will be repository_checkout_folder/src/DockerFinal/Foo.dockerfile.
       repository_name: 'cdpxlinux'                        # only supported ones are cdpx acr repos
-      tag: 'ciprod'                                        # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
+      tag: 'ciprod'                                       # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
+      export_to_artifact_path: 'agentimage.tar.gz'   # path for exported image and use this instead of fixed tag

--- a/.pipelines/pipeline.user.linux.yml
+++ b/.pipelines/pipeline.user.linux.yml
@@ -47,3 +47,4 @@ package:
       repository_name: 'cdpxlinux'                        # only supported ones are cdpx acr repos
       tag: 'cidev'                                        # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
+      export_to_artifact_path: 'agentimage.tar.gz'   # path for exported image and use this instead of fixed tag

--- a/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -53,3 +53,4 @@ package:
       repository_name: 'cdpxwin1809'                      # only supported ones are cdpx acr repos
       tag: 'win-ciprod'                                    # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
+      export_to_artifact_path: 'agentimage.tar.gz'   # path for exported image and use this instead of fixed tag

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -53,3 +53,4 @@ package:
       repository_name: 'cdpxwin1809'                      # only supported ones are cdpx acr repos
       tag: 'win-cidev'                                    # OPTIONAL: Defaults to latest. The tag for the built image. Final tag will be 1.0.0alpha, 1.0.0-timestamp-commitID.
       latest: false                                       # OPTIONAL: Defaults to false. If tag is not set to latest and this flag is set, then tag as latest as well and push latest as well.
+      export_to_artifact_path: 'agentimage.tar.gz' # path for exported image and use this instead of fixed tag

--- a/.pipelines/release-agent.sh
+++ b/.pipelines/release-agent.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Note - This script used in the pipeline as inline script
+
+#Name of the ACR for ciprod & cidev images
+AGENT_RELEASE=cidev
+LINUX_AGENT_IMAGE_TAG_SUFFIX=07222021
+
+ACR_NAME=containerinsightsprod.azurecr.io
+AGENT_IMAGE_FULL_PATH=${ACR_NAME}/public/azuremonitor/containerinsights/${AGENT_RELEASE}:${AGENT_RELEASE}${LINUX_AGENT_IMAGE_TAG_SUFFIX}
+AGENT_IMAGE_TAR_FILE_NAME=agentimage.tar.gz
+
+
+echo "ACR NAME - ${ACR_NAME}"
+echo "AGENT RELEASE -  ${AGENT_RELEASE}"
+echo "AGENT IMAGE TAG SUFFIX -  ${LINUX_AGENT_IMAGE_TAG_SUFFIX}"
+echo "AGENT IMAGE FULL PATH -  ${AGENT_IMAGE_FULL_PATH}"
+echo "AGENT IMAGE TAR FILE PATH -  ${AGENT_IMAGE_TAR_FILE_NAME}"
+
+echo "loading linuxagent image tarball"
+IMAGE_NAME=$(docker load -i ${AGENT_IMAGE_TAR_FILE_NAME})
+echo IMAGE_NAME: $IMAGE_NAME
+if [ $? -ne 0 ]; then
+  echo "Error, on loading linux agent tarball from ${AGENT_IMAGE_TAR_FILE_NAME}"
+  echo "** Please check if this caused due to build error **"
+  exit 1
+else
+  echo "successfully loaded linux agent image tarball"
+fi
+# IMAGE_ID=$(docker images $IMAGE_NAME | awk '{print $3 }' | tail -1)
+# echo "Image Id is : ${IMAGE_ID}"
+prefix="Loadedimage:"
+IMAGE_NAME=$(echo $IMAGE_NAME | tr -d '"' | tr -d "[:space:]")
+IMAGE_NAME=${IMAGE_NAME/#$prefix}
+echo "*** trimmed image name-:${IMAGE_NAME}"
+echo "tagging the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
+# docker tag $IMAGE_NAME ${AGENT_IMAGE_FULL_PATH}
+docker tag $IMAGE_NAME $AGENT_IMAGE_FULL_PATH
+
+if [ $? -ne 0 ]; then
+  echo "Error, tagging the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
+  exit 1
+else
+  echo "successfully tagged the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
+fi
+
+# used pipeline identity to push the image to ciprod acr
+echo "logging to acr: ${ACR_NAME}"
+az acr login --name ${ACR_NAME}
+if [ $? -ne 0 ]; then
+  echo "Error, log into acr failed: ${ACR_NAME}"
+  exit 1
+else
+ echo "successfully logged into acr:${ACR_NAME}"
+fi
+
+echo "pushing ${AGENT_IMAGE_FULL_PATH}"
+docker push ${AGENT_IMAGE_FULL_PATH}
+if [ $? -ne 0 ]; then
+  echo "Error, on pushing the image ${AGENT_IMAGE_FULL_PATH}"
+  exit 1
+else
+  echo "Successfully pushed the image ${AGENT_IMAGE_FULL_PATH}"
+fi

--- a/.pipelines/release-agent.sh
+++ b/.pipelines/release-agent.sh
@@ -2,18 +2,28 @@
 
 # Note - This script used in the pipeline as inline script
 
-#Name of the ACR for ciprod & cidev images
-AGENT_RELEASE=cidev
-LINUX_AGENT_IMAGE_TAG_SUFFIX=07222021
+# These are plain pipeline variable which can be modified anyone in the team
+# AGENT_RELEASE=cidev
+# AGENT_IMAGE_TAG_SUFFIX=07222021
 
+#Name of the ACR for ciprod & cidev images
 ACR_NAME=containerinsightsprod.azurecr.io
-AGENT_IMAGE_FULL_PATH=${ACR_NAME}/public/azuremonitor/containerinsights/${AGENT_RELEASE}:${AGENT_RELEASE}${LINUX_AGENT_IMAGE_TAG_SUFFIX}
+AGENT_IMAGE_FULL_PATH=${ACR_NAME}/public/azuremonitor/containerinsights/${AGENT_RELEASE}:${AGENT_RELEASE}${AGENT_IMAGE_TAG_SUFFIX}
 AGENT_IMAGE_TAR_FILE_NAME=agentimage.tar.gz
 
+if [ -z $AGENT_IMAGE_TAG_SUFFIX ]; then
+  echo "-e error value of AGENT_RELEASE variable shouldnt be empty"
+  exit 1
+fi
+
+if [ -z $AGENT_RELEASE ]; then
+  echo "-e error AGENT_RELEASE shouldnt be empty"
+  exit 1
+fi
 
 echo "ACR NAME - ${ACR_NAME}"
 echo "AGENT RELEASE -  ${AGENT_RELEASE}"
-echo "AGENT IMAGE TAG SUFFIX -  ${LINUX_AGENT_IMAGE_TAG_SUFFIX}"
+echo "AGENT IMAGE TAG SUFFIX -  ${AGENT_IMAGE_TAG_SUFFIX}"
 echo "AGENT IMAGE FULL PATH -  ${AGENT_IMAGE_FULL_PATH}"
 echo "AGENT IMAGE TAR FILE PATH -  ${AGENT_IMAGE_TAR_FILE_NAME}"
 
@@ -21,7 +31,7 @@ echo "loading linuxagent image tarball"
 IMAGE_NAME=$(docker load -i ${AGENT_IMAGE_TAR_FILE_NAME})
 echo IMAGE_NAME: $IMAGE_NAME
 if [ $? -ne 0 ]; then
-  echo "Error, on loading linux agent tarball from ${AGENT_IMAGE_TAR_FILE_NAME}"
+  echo "-e error, on loading linux agent tarball from ${AGENT_IMAGE_TAR_FILE_NAME}"
   echo "** Please check if this caused due to build error **"
   exit 1
 else
@@ -38,7 +48,7 @@ echo "tagging the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
 docker tag $IMAGE_NAME $AGENT_IMAGE_FULL_PATH
 
 if [ $? -ne 0 ]; then
-  echo "Error, tagging the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
+  echo "-e error  tagging the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
   exit 1
 else
   echo "successfully tagged the image $IMAGE_NAME as ${AGENT_IMAGE_FULL_PATH}"
@@ -48,7 +58,7 @@ fi
 echo "logging to acr: ${ACR_NAME}"
 az acr login --name ${ACR_NAME}
 if [ $? -ne 0 ]; then
-  echo "Error, log into acr failed: ${ACR_NAME}"
+  echo "-e error  log into acr failed: ${ACR_NAME}"
   exit 1
 else
  echo "successfully logged into acr:${ACR_NAME}"
@@ -57,7 +67,7 @@ fi
 echo "pushing ${AGENT_IMAGE_FULL_PATH}"
 docker push ${AGENT_IMAGE_FULL_PATH}
 if [ $? -ne 0 ]; then
-  echo "Error, on pushing the image ${AGENT_IMAGE_FULL_PATH}"
+  echo "-e error  on pushing the image ${AGENT_IMAGE_FULL_PATH}"
   exit 1
 else
   echo "Successfully pushed the image ${AGENT_IMAGE_FULL_PATH}"

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -20,6 +20,9 @@ cp -f $TMPDIR/envmdsd /etc/mdsd.d
 sudo apt-get update
 sudo apt-get install inotify-tools -y
 
+#upgrade libsystemd0 to address CVE-2021-33910
+apt-get upgrade libsystemd0 -y
+
 #used to parse response of kubelet apis
 #ref: https://packages.ubuntu.com/search?keywords=jq
 sudo apt-get install jq=1.5+dfsg-2 -y


### PR DESCRIPTION
This PR addresses following items 

- Instead of pulling the image from CDPx ACR and uses the image tar exported as part of the build output. 
-  Update pipeline to use inline script which Pipeline service pipeline to push the images to ciprod acr. When we have our ACR in AME then that point of time, we can read the SP (which has access to our acr) creds from KV in public cloud.  FYI, for @daweim0 .

