### PR TITLE
mdsd coredump fixes

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -10,7 +10,7 @@ sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_US.UTF-8
 
 #install oneagent - Official bits (05/17/2021)
-wget https://github.com/microsoft/Docker-Provider/releases/download/05172021-oneagent/azure-mdsd_1.10.1-build.master.213_x86_64.deb
+wget https://github.com/microsoft/Docker-Provider/releases/download/08042021-oneagent/azure-mdsd_1.10.1-build.master.251_x86_64.deb
 
 /usr/bin/dpkg -i $TMPDIR/azure-mdsd*.deb
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d


### PR DESCRIPTION
update with MDSD drop which has fixes for the core dump due to non200 status code from OMS Homing service.
Last release MDSD version has undeterministic behavior because  of Runtime exception, "theory from AMA folks, is that the stack unwinding on exception is sometimes resource intensive given their data volume and causing it to crash potentially due to hitting some resource limit".  verified no mdsd core dump because of non200 status codes, but this needs to be validated on customer reproed and other internal clusters to make sure this issue resolved fully.

New behavior is, 1) MDSD will not core dump because of the non 200 status codes from homing service 2) reduced the error message verbosity instead of before and it will be after 3 retry attempts for both OMS & ODS code paths.