### PR TITLE
increase ds memory requests and limis due to additional hop from mdsd

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -22,6 +22,7 @@ Note : The agent version(s) below has dates (ciprod<mmddyyyy>), which indicate t
      - Increase Timeout for OMS Homing service API calls from 30s to 60s
    - Fix for https://github.com/Azure/AKS/issues/2457
    - In replicaset, tailing of the mdsd.err log file to agent telemetry
+   - Daemonset memory requests and limits increased by 25% due to additional hop with MDSD
 
 
 ### 07/13/2021 -

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -373,10 +373,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 600Mi
+              memory: 750Mi
             requests:
               cpu: 75m
-              memory: 225Mi
+              memory: 300Mi
           env:
             # azure devops pipeline uses AKS_RESOURCE_ID and AKS_REGION hence ensure to uncomment these
             - name: AKS_RESOURCE_ID


### PR DESCRIPTION
analyzed 30+ clusters which are DS oom kill. The pattern of  increase in the memory usage not consistent. This could because of the telemetry sample interval what we collect.  Based on the analysis, 25% increase should give pretty good coverage. We can watch this agent rollout and see whether we would further need to adjust.

telemetry analysis details are here - OOM-killed-ds-clusters.xlsx in aka.ms/inin under containerinsights->agent directory.