### PR TITLE
check onboarding status

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -38,6 +38,51 @@ waitforlisteneronTCPport() {
       fi
 }
 
+checkAgentOnboardingStatus() {
+      local sleepdurationsecs=1
+      local totalsleptsecs=0
+      local isaadmsiauthmode=$1
+      local waittimesecs=$2
+      local numeric='^[0-9]+$'
+
+      if [ -z "$1" ] || [ -z "$2" ]; then
+            echo "${FUNCNAME[0]} called with incorrect arguments<$1 , $2>. Required arguments <#isaadmsiauthmode, #wait-time-in-seconds>"
+            return -1
+      else
+
+            if [[ $waittimesecs =~ $numeric ]]; then
+                  successMessage="Onboarding success"
+                  failureMessage="Failed to register certificate with OMS Homing service, giving up"
+                  if [ "${isaadmsiauthmode}" == "true" ]; then
+                        successMessage="Loaded data sources"
+                        failureMessage="Failed to load data sources into config"
+                  fi
+                  while true
+                  do
+                     if [ $totalsleptsecs -gt $waittimesecs ]; then
+                        echo "${FUNCNAME[0]} giving up checking agent onboarding status after $totalsleptsecs secs"
+                        return 1
+                     fi
+
+                     if grep "$successMessage" "${MDSD_LOG}/mdsd.info"; then
+                        echo "Onboarding success"
+                        return 0
+                     elif  grep "$failureMessage" "${MDSD_LOG}/mdsd.err"; then
+                        echo "Onboarding Failure: Reason: Failed to onboard the agent"
+                        echo "Onboarding Failure: Please verify log analytics workspace configuration such as existence of the workspace, workspace key and workspace enabled for public ingestion"
+                        return 1
+                     fi
+                     sleep $sleepdurationsecs
+                     totalsleptsecs=$(($totalsleptsecs+1))
+                  done
+            else
+                  echo "${FUNCNAME[0]} called with non-numeric arguments<$2>. Required arguments <#wait-time-in-seconds>"
+                  return -1
+            fi
+      fi
+}
+
+
 #using /var/opt/microsoft/docker-cimprov/state instead of /var/opt/microsoft/omsagent/state since the latter gets deleted during onboarding
 mkdir -p /var/opt/microsoft/docker-cimprov/state
 
@@ -671,6 +716,8 @@ service rsyslog stop
 
 echo "getting rsyslog status..."
 service rsyslog status
+
+checkAgentOnboardingStatus $AAD_MSI_AUTH_MODE 30
 
 shutdown() {
 	 pkill -f mdsd

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -10,7 +10,7 @@ sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_US.UTF-8
 
 #install oneagent - Official bits (08/04/2021)
-wget https://github.com/microsoft/Docker-Provider/releases/download/08042021-oneagent/azure-mdsd_1.10.1-build.master.251_x86_64.deb
+wget https://github.com/microsoft/Docker-Provider/releases/download/06242021-oneagent/azure-mdsd_1.10.3-build.master.257_x86_64.deb
 
 /usr/bin/dpkg -i $TMPDIR/azure-mdsd*.deb
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d


### PR DESCRIPTION
This PR has following changes 
  1.  onboarding success status for both legacy and MSI auth and which will be used by AKS Black box telemetry to track onboarding status
  2.  MDSD update with recent MDSD fixes related OMS homing service  and reduce verbosity for the logs) on top of MDSD official version with MSI auth changes.