### PR TITLE
upgrade golang version for windows in pipeline and locally

### DIFF
--- a/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
+++ b/.pipelines/pipeline.user.windows.official.all_tag.all_phase.all_config.ci_prod.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/user/azure-monitor/container-insights:6.0'
+    image: 'cdpxwin1809.azurecr.io/user/azure-monitor/container-insights:latest'
     source_mode: 'map'
 
 version:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/user/azure-monitor/container-insights:6.0'
+    image: 'cdpxwin1809.azurecr.io/user/azure-monitor/container-insights:latest'
     source_mode: 'map'
 
 version:

--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -13,8 +13,8 @@ function Install-Go {
         exit
     }
 
-   $url = "https://dl.google.com/go/go1.14.1.windows-amd64.msi"
-   $output = Join-Path -Path $tempGo -ChildPath "go1.14.1.windows-amd64.msi"
+   $url = "https://dl.google.com/go/go1.15.14.windows-amd64.msi"
+   $output = Join-Path -Path $tempGo -ChildPath "go1.15.14.windows-amd64.msi"
    Write-Host("downloading go msi into directory path : " + $output + "  ...")
    Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop
    Write-Host("downloading of go msi into directory path : " + $output + "  completed")


### PR DESCRIPTION
Upgrade to fix this error from the pipeline build and local build:
```
C:\Program Files\Go\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
C:/TDM-GCC-64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: error: export ordinal too large: 69814
```
See https://github.com/golang/go/issues/40795 and https://github.com/golang/go/issues/30674 (which confirms others reproducing with 1.14). This was patched for > 1.15.10 but not patched for 1.14

Will wait to merge until the image is pushed to cdpxwin1809.azurecr.io.