### PR TITLE
packaging omsagent.yaml and e2e-test.yaml in the output image

### DIFF
--- a/build/linux/installer/datafiles/base_container.data
+++ b/build/linux/installer/datafiles/base_container.data
@@ -56,6 +56,9 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/tomlparser-osm-config.rb;                                  build/linux/installer/scripts/tomlparser-osm-config.rb;     755; root; root
 /opt/test.json;			                                        build/linux/installer/conf/test.json;                    644; root; root
 
+/opt/omsagent.yaml;                                             kubernetes/omsagent.yaml; 644; root; root
+/opt/e2e-tests.yaml;                                            test/e2e/e2e-tests.yaml; 644; root; root
+
 
 
 /etc/opt/microsoft/docker-cimprov/health/healthmonitorconfig.json;					                   build/linux/installer/conf/healthmonitorconfig.json; 644; root; root
@@ -178,7 +181,6 @@ MAINTAINER:              'Microsoft Corporation'
 
 /etc/fluent/plugin/out_health_forward.rb;			                                        source/plugins/ruby/out_health_forward.rb;	644; root; root
 /etc/fluent/plugin/out_mdm.rb;			                                                 source/plugins/ruby/out_mdm.rb;	644; root; root
-
 
 
 %Links


### PR DESCRIPTION
This is to simplify the release pipeline. Currently it gets omsagent.yaml from github, but that connection is finicky. This change let's us remove all release pipeline dependencies except the build pipeline artifacts.