### PR TITLE
run unit tests after a merge too

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - ci_dev
       - ci_prod
+  push:
+    branches:
+      - ci_dev
+      - ci_prod
 jobs:
   Golang-Tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently unit tests only run when a PR is created or updated. This PR runs unit tests after the PR is merged too.