### PR TITLE
Adding script to collect logs (for troubleshooting)

### DIFF
--- a/scripts/troubleshoot/collect_logs.sh
+++ b/scripts/troubleshoot/collect_logs.sh
@@ -1,21 +1,32 @@
 #!/bin/bash
 
+
+# This script pulls logs from the replicaset agent pod and a random daemonset pod. This script is to make troubleshooting faster
+
 export ds_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-[a-z0-9]{5} | head -n 1)
+export ds_win_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-win-[a-z0-9]{5} | head -n 1)
 export rs_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-rs-[a-z0-9]{5} | head -n 1)
 
-echo "collecting logs from ${ds_pod} and ${rs_pod}"
+echo "collecting logs from ${ds_pod}, ${ds_win_pod}, and ${rs_pod}"
+echo "    note: some erros are expected for clusters without windows nodes, they can safely be disregarded (filespec must match the canonical format:, zip warning: name not matched: omsagent-win-daemonset-fbit)"
 
-kubectl cp ${ds_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-daemonset-log --namespace=kube-system
+kubectl cp ${ds_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-daemonset --namespace=kube-system --container omsagent
+kubectl cp ${ds_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-daemonset-mdsd --namespace=kube-system --container omsagent
 
-kubectl cp ${ds_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-daemonset-mdsd-log --namespace=kube-system
+kubectl cp ${ds_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-prom-daemonset --namespace=kube-system --container omsagent-prometheus
+kubectl cp ${ds_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-prom-daemonset-mdsd --namespace=kube-system --container omsagent-prometheus
 
-kubectl cp ${rs_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-replicaset-log --namespace=kube-system
+# for some reason copying logs out of /etc/omsagentwindows doesn't work (gives a permission error), but exec then cat does work.
+# skip collecting these logs for now, would be good to come back and fix this next time a windows support case comes up
+# kubectl cp ${ds_win_pod}:/etc/omsagentwindows omsagent-win-daemonset --namespace=kube-system
+kubectl cp ${ds_win_pod}:/etc/fluent-bit omsagent-win-daemonset-fbit --namespace=kube-system
 
-kubectl cp ${rs_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-replicaset-mdsd-log --namespace=kube-system
+kubectl cp ${rs_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-replicaset --namespace=kube-system
+kubectl cp ${rs_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-replicaset-mdsd --namespace=kube-system
 
-zip -r azure-monitor-logs.zip omsagent-daemonset-log omsagent-daemonset-mdsd-log omsagent-replicaset-log omsagent-replicaset-mdsd-log
+zip -r azure-monitor-logs.zip omsagent-daemonset omsagent-daemonset-mdsd omsagent-prom-daemonset omsagent-prom-daemonset-mdsd omsagent-win-daemonset-fbit omsagent-replicaset omsagent-replicaset-mdsd
 
-rm -rf omsagent-daemonset-log omsagent-daemonset-mdsd-log omsagent-replicaset-log omsagent-replicaset-mdsd-log
+rm -rf omsagent-daemonset omsagent-daemonset-mdsd omsagent-prom-daemonset omsagent-prom-daemonset-mdsd omsagent-win-daemonset-fbit omsagent-replicaset omsagent-replicaset-mdsd
 
 echo
 echo "log files have been written to azure-monitor-logs.zip"

--- a/scripts/troubleshoot/collect_logs.sh
+++ b/scripts/troubleshoot/collect_logs.sh
@@ -2,6 +2,9 @@
 
 # This script pulls logs from the replicaset agent pod and a random daemonset pod. This script is to make troubleshooting faster
 
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
 mkdir azure-monitor-logs-tmp
 cd azure-monitor-logs-tmp
 
@@ -9,8 +12,8 @@ export ds_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata
 export ds_win_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-win-[a-z0-9]{5} | head -n 1)
 export rs_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-rs-[a-z0-9]{5} | head -n 1)
 
-echo "collecting logs from ${ds_pod}, ${ds_win_pod}, and ${rs_pod}"
-echo "    note: some erros are expected for clusters without windows nodes, they can safely be disregarded (filespec must match the canonical format:, zip warning: name not matched: omsagent-win-daemonset-fbit)"
+echo -e "Collecting logs from ${ds_pod}, ${ds_win_pod}, and ${rs_pod}"
+echo -e "${CYAN}Note: some errors about pods and files not existing are expected in clusters without windows nodes or sidecar prometheus scraping. They can safely be disregarded ${NC}"
 
 # grab `kubectl describe` and `kubectl log`
 echo "collecting kubectl describe and kubectl log output"
@@ -27,7 +30,7 @@ kubectl logs ${rs_pod} --container omsagent --namespace=kube-system > logs_${rs_
 
 
 # now collect log files from in containers
-echo "collecting log files from inside agent containers"
+echo "Collecting log files from inside agent containers"
 
 kubectl cp ${ds_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-daemonset --namespace=kube-system --container omsagent
 kubectl cp ${ds_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-daemonset-mdsd --namespace=kube-system --container omsagent

--- a/scripts/troubleshoot/collect_logs.sh
+++ b/scripts/troubleshoot/collect_logs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export ds_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-[a-z0-9]{5} | head -n 1)
+export rs_pod=$(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name | grep -E omsagent-rs-[a-z0-9]{5} | head -n 1)
+
+echo "collecting logs from ${ds_pod} and ${rs_pod}"
+
+kubectl cp ${ds_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-daemonset-log --namespace=kube-system
+
+kubectl cp ${ds_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-daemonset-mdsd-log --namespace=kube-system
+
+kubectl cp ${rs_pod}:/var/opt/microsoft/docker-cimprov/log omsagent-replicaset-log --namespace=kube-system
+
+kubectl cp ${rs_pod}:/var/opt/microsoft/linuxmonagent/log omsagent-replicaset-mdsd-log --namespace=kube-system
+
+zip -r azure-monitor-logs.zip omsagent-daemonset-log omsagent-daemonset-mdsd-log omsagent-replicaset-log omsagent-replicaset-mdsd-log
+
+rm -rf omsagent-daemonset-log omsagent-daemonset-mdsd-log omsagent-replicaset-log omsagent-replicaset-mdsd-log
+
+echo
+echo "log files have been written to azure-monitor-logs.zip"


### PR DESCRIPTION
Adding a script to pull logs from a daemonset and replicaset agent pod. I frequently ask customers to collect these logs, making a script to grab and zip them should make the process faster for everyone involved.

The one way this script needs to be improved is that it doesn't collect any logs under /etc/omsagentwindows (kubectl cp was returning permission errors for that directory). I don't have time to investigate why now, and this script is still useful without it.