### PR TITLE
bumping image tag to 08052021-1

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,11 @@ additional questions or comments.
 
 Note : The agent version(s) below has dates (ciprod<mmddyyyy>), which indicate the agent build dates (not release dates)
 
+### 09/02/2021 -
+##### Version microsoft/oms:ciprod08052021-1 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021-1 (linux)
+##### Code change log
+- Bumping image tag for some tooling (no code changes except the IMAGE_TAG environment variable)
+
 ### 08/05/2021 -
 ##### Version microsoft/oms:ciprod08052021 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021 (linux)
 ##### Code change log
@@ -22,7 +27,6 @@ Note : The agent version(s) below has dates (ciprod<mmddyyyy>), which indicate t
      - Increase Timeout for OMS Homing service API calls from 30s to 60s
    - Fix for https://github.com/Azure/AKS/issues/2457
    - In replicaset, tailing of the mdsd.err log file to agent telemetry
-
 
 ### 07/13/2021 -
 ##### Version microsoft/oms:win-ciprod06112021-2 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021-2 (windows)

--- a/kubernetes/linux/Dockerfile
+++ b/kubernetes/linux/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"
-ARG IMAGE_TAG=ciprod08052021
+ARG IMAGE_TAG=ciprod08052021-1
 ENV AGENT_VERSION ${IMAGE_TAG}
 ENV tmpdir /opt
 ENV APPLICATIONINSIGHTS_AUTH NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -368,7 +368,7 @@ spec:
             value: "3"
       containers:
         - name: omsagent
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021-1"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -446,7 +446,7 @@ spec:
             timeoutSeconds: 15
 #Only in sidecar scraping mode
         - name: omsagent-prometheus
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021-1"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -589,7 +589,7 @@ spec:
       serviceAccountName: omsagent
       containers:
         - name: omsagent
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod08052021-1"
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
Bumping the image tag so that we can toggle clusters back to the prod image (for clusters with a different image under the same tag as the prod image)