### PR TITLE
Gangams/addon token adapter image tag to telemetry

### DIFF
--- a/source/plugins/ruby/ApplicationInsightsUtility.rb
+++ b/source/plugins/ruby/ApplicationInsightsUtility.rb
@@ -243,6 +243,9 @@ class ApplicationInsightsUtility
           getContainerRuntimeInfo()
         end
         @@CustomProperties["Computer"] = properties["Computer"]
+        if !properties["addonTokenAdapterImageTag"].nil? && !properties["addonTokenAdapterImageTag"].empty?
+          @@CustomProperties["addonTokenAdapterImageTag"] = properties["addonTokenAdapterImageTag"]
+        end
         sendHeartBeatEvent(pluginName)
         sendLastProcessedContainerInventoryCountMetric(pluginName, properties)
       rescue => errorStr

--- a/source/plugins/ruby/in_containerinventory.rb
+++ b/source/plugins/ruby/in_containerinventory.rb
@@ -128,7 +128,7 @@ module Fluent::Plugin
           telemetryProperties["Computer"] = hostName
           telemetryProperties["ContainerCount"] = containerInventory.length
           if !addonTokenAdapterImageTag.empty?
-            telemetryProperties["addon-token-adapter"] = addonTokenAdapterImageTag
+            telemetryProperties["addonTokenAdapterImageTag"] = addonTokenAdapterImageTag
           end
           ApplicationInsightsUtility.sendTelemetry(@@PluginName, telemetryProperties)
         end

--- a/source/plugins/ruby/in_containerinventory.rb
+++ b/source/plugins/ruby/in_containerinventory.rb
@@ -57,6 +57,7 @@ module Fluent::Plugin
       containerInventory = Array.new
       eventStream = Fluent::MultiEventStream.new
       hostName = ""
+      addonTokenAdapterImageTag = ""
       $log.info("in_container_inventory::enumerate : Begin processing @ #{Time.now.utc.iso8601}")
       if ExtensionUtils.isAADMSIAuthMode()
         $log.info("in_container_inventory::enumerate: AAD AUTH MSI MODE")
@@ -81,6 +82,15 @@ module Fluent::Plugin
                   ContainerInventoryState.writeContainerState(containerRecord)
                   if hostName.empty? && !containerRecord["Computer"].empty?
                     hostName = containerRecord["Computer"]
+                  end
+                  if addonTokenAdapterImageTag.empty? && ExtensionUtils.isAADMSIAuthMode()
+                     if !containerRecord["ElementName"].nil? && !containerRecord["ElementName"].empty? &&
+                      containerRecord["ElementName"].include?("kube-system") &&
+                      containerRecord["ElementName"].include?("addon-token-adapter_omsagent")
+                      if !containerRecord["ImageTag"].nil? && !containerRecord["ImageTag"].empty?
+                        addonTokenAdapterImageTag = containerRecord["ImageTag"]
+                      end
+                     end
                   end
                   containerIds.push containerRecord["InstanceID"]
                   containerInventory.push containerRecord
@@ -117,6 +127,9 @@ module Fluent::Plugin
           telemetryProperties = {}
           telemetryProperties["Computer"] = hostName
           telemetryProperties["ContainerCount"] = containerInventory.length
+          if !addonTokenAdapterImageTag.empty?
+            telemetryProperties["addon-token-adapter"] = addonTokenAdapterImageTag
+          end
           ApplicationInsightsUtility.sendTelemetry(@@PluginName, telemetryProperties)
         end
       rescue => errorStr


### PR DESCRIPTION
Add addon-token-adapter image tag to the telemetry so that we can use for the telemetry and track the version which would helpful for us to investigate any issues related.  I will adding dashboard tile to track this version .