### PR TITLE
chart updates for rbac api version change

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-crd.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-crd.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -32,7 +32,7 @@ spec:
      options:
        - name: ndots
          value: "3"
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}
    nodeSelector:
       kubernetes.io/os: windows
 {{- else }}

--- a/charts/azuremonitor-containers/templates/omsagent-rbac.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-rbac.yaml
@@ -10,7 +10,11 @@ metadata:
     heritage: {{ .Release.Service }}
 ---
 kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 metadata:
   name: omsagent-reader
   labels:
@@ -33,7 +37,7 @@ rules:
   verbs: ["get", "create", "patch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-#arc k8s extension model grants access as part of the extension msi 
+#arc k8s extension model grants access as part of the extension msi
 #remove this explicit permission once the extension available in public preview
 {{- if (empty .Values.Azure.Extension.Name) }}
 - apiGroups: [""]
@@ -43,7 +47,11 @@ rules:
 {{- end }}
 ---
 kind: ClusterRoleBinding
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 metadata:
   name: omsagentclusterrolebinding
   labels:


### PR DESCRIPTION
This PR has following changes 
 1.  handle both rbac.authorization.k8s.io/v1 & rbac.authorization.k8s.io/v1beta1 since v1beta1 api version not supported in K8s 1.22/+
 2.  update from .Capabilities.KubeVersion.GitVersion to .Capabilities.KubeVersion.Version  since .Capabilities.KubeVersion.GitVersion  deprecated in helm3.
https://github.com/helm/helm/blob/main/pkg/chartutil/capabilities.go#L82
https://helm.sh/docs/chart_template_guide/builtin_objects/