### PR TITLE
Faster Linux builds (part 1)

### DIFF
--- a/kubernetes/linux/Dockerfile
+++ b/kubernetes/linux/Dockerfile
@@ -17,7 +17,7 @@ ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR 0.9
 RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes init-system-helpers  net-tools rsyslog cron vim dmidecode apt-transport-https gnupg && rm -rf /var/lib/apt/lists/*
 COPY setup.sh main.sh defaultpromenvvariables defaultpromenvvariables-rs defaultpromenvvariables-sidecar mdsd.xml envmdsd logrotate.conf $tmpdir/
 
-ARG IMAGE_TAG=ciprod08052021
+ARG IMAGE_TAG=ciprod10132021
 ENV AGENT_VERSION ${IMAGE_TAG}
 
 WORKDIR ${tmpdir}

--- a/kubernetes/linux/Dockerfile
+++ b/kubernetes/linux/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:18.04
 MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"
-ARG IMAGE_TAG=ciprod10132021
-ENV AGENT_VERSION ${IMAGE_TAG}
 ENV tmpdir /opt
 ENV APPLICATIONINSIGHTS_AUTH NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi
 ENV MALLOC_ARENA_MAX 2
@@ -18,6 +16,10 @@ ENV KUBE_CLIENT_BACKOFF_DURATION 0
 ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR 0.9
 RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes init-system-helpers  net-tools rsyslog cron vim dmidecode apt-transport-https gnupg && rm -rf /var/lib/apt/lists/*
 COPY setup.sh main.sh defaultpromenvvariables defaultpromenvvariables-rs defaultpromenvvariables-sidecar mdsd.xml envmdsd logrotate.conf $tmpdir/
+
+ARG IMAGE_TAG=ciprod08052021
+ENV AGENT_VERSION ${IMAGE_TAG}
+
 WORKDIR ${tmpdir}
 
 # copy docker provider shell bundle to use the agent image
@@ -27,3 +29,4 @@ COPY ./Linux_ULINUX_1.0_x64_64_Release/docker-cimprov-*.*.*-*.x86_64.sh .
 
 RUN chmod 775 $tmpdir/*.sh; sync; $tmpdir/setup.sh
 CMD [ "/opt/main.sh" ]
+


### PR DESCRIPTION
Since the Docker build arg IMAGE_TAG is used very early in the Linux Dockerfile, changing it invalidates the local docker build cache. Moving the arg lower in the docker file lets Docker cache some apt installs and speeds up subsequent builds. (this optimization shaves two minutes off build times on my dev machine)

I don't think the arg is used during image builds (just runtime), but I didn't move it all the way down to the bottom of the dockerfile just to be sure nothing breaks.