### PR TITLE
Updating pod annotation for latest agent version

### DIFF
--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -357,7 +357,7 @@ spec:
         component: oms-agent
         tier: node
       annotations:
-        agentVersion: "1.10.0.1"
+        agentVersion: "azure-mdsd-1.14.2"
         dockerProviderVersion: "16.0.0-0"
         schema-versions: "v1"
     spec:
@@ -596,7 +596,7 @@ spec:
       labels:
         rsName: "omsagent-rs"
       annotations:
-        agentVersion: "1.10.0.1"
+        agentVersion: "azure-mdsd-1.14.2"
         dockerProviderVersion: "16.0.0-0"
         schema-versions: "v1"
     spec:
@@ -765,7 +765,7 @@ spec:
         component: oms-agent-win
         tier: node-win
       annotations:
-        agentVersion: "1.10.0.1"
+        agentVersion: "azure-mdsd-1.14.2"
         dockerProviderVersion: "16.0.0-0"
         schema-versions: "v1"
     spec:

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -765,7 +765,7 @@ spec:
         component: oms-agent-win
         tier: node-win
       annotations:
-        agentVersion: "azure-mdsd-1.14.2"
+        agentVersion: "0.0.0-0"
         dockerProviderVersion: "16.0.0-0"
         schema-versions: "v1"
     spec:


### PR DESCRIPTION
1. Updated agent version from 1.10.0-1 to azure-mdsd-1.14.2
2. Made the change for windows ds as well since it had the agent version even though agent is not used in windows since 1.10.0-1 may create confusion regarding the omi issue even though we dont use it.