### PR TITLE
Jan agent tasks

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,5 +1,8 @@
 name: pullrequest-build-and-scan
 on:
+  push:
+    branches:
+      - grace/upgrade-telegraf
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
@@ -56,7 +59,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH'
           vuln-type: 'os,library'
-          skip-dirs: '/opt,/usr/sbin'
+          skip-dirs: ''
           exit-code: '1'
           timeout: '5m0s'
   WINDOWS-build:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,8 +1,5 @@
 name: pullrequest-build-and-scan
 on:
-  push:
-    branches:
-      - grace/upgrade-telegraf
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -56,7 +56,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH'
           vuln-type: 'os,library'
-          skip-dirs: 'usr/sbin'
+          skip-dirs: '/usr/sbin'
           exit-code: '1'
           timeout: '5m0s'
   WINDOWS-build:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -59,7 +59,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH'
           vuln-type: 'os,library'
-          skip-dirs: ''
+          skip-dirs: 'usr/sbin'
           exit-code: '1'
           timeout: '5m0s'
   WINDOWS-build:

--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -425,7 +425,7 @@
   # Below due to Bug - https://github.com/influxdata/telegraf/issues/5615
   # ORDER matters here!! - i.e the below should be the LAST modifier
   [inputs.disk.tagdrop]
-    path = ["/var/lib/kubelet*", "/dev/termination-log", "/var/log", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/etc/kubernetes/host", "/var/lib/docker/containers", "/etc/config/settings"]
+    path = ["/var/lib/kubelet*", "/dev/termination-log", "/var/log", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/etc/kubernetes/host", "/var/lib/docker/containers", "/etc/config/settings", "/run/host/containerd/io.containerd.runtime.v2.task/k8s.io"]
 
 
 # Read metrics about memory usage

--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -425,7 +425,7 @@
   # Below due to Bug - https://github.com/influxdata/telegraf/issues/5615
   # ORDER matters here!! - i.e the below should be the LAST modifier
   [inputs.disk.tagdrop]
-    path = ["/var/lib/kubelet*", "/dev/termination-log", "/var/log", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/etc/kubernetes/host", "/var/lib/docker/containers", "/etc/config/settings", "/run/host/containerd/io.containerd.runtime.v2.task/k8s.io"]
+    path = ["/var/lib/kubelet*", "/dev/termination-log", "/var/log", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/etc/kubernetes/host", "/var/lib/docker/containers", "/etc/config/settings", "/run/host/containerd/io.containerd.runtime.v2.task/k8s.io/*"]
 
 
 # Read metrics about memory usage

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -178,7 +178,7 @@ omsagent:
         memory: 750Mi
     daemonsetwindows:
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 600Mi
     deployment:
       requests:

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -30,10 +30,10 @@ sudo apt-get install jq=1.5+dfsg-2 -y
 #used to setcaps for ruby process to read /proc/env
 sudo apt-get install libcap2-bin -y
 
-wget https://dl.influxdata.com/telegraf/releases/telegraf-1.21.2_linux_amd64.tar.gz
-tar -zxvf telegraf-1.21.2_linux_amd64.tar.gz
+wget https://dl.influxdata.com/telegraf/releases/telegraf-1.20.3_linux_amd64.tar.gz
+tar -zxvf telegraf-1.20.3_linux_amd64.tar.gz
 
-mv /opt/telegraf-1.21.2/usr/bin/telegraf /opt/telegraf
+mv /opt/telegraf-1.20.3/usr/bin/telegraf /opt/telegraf
 
 chmod 777 /opt/telegraf
 

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -30,10 +30,10 @@ sudo apt-get install jq=1.5+dfsg-2 -y
 #used to setcaps for ruby process to read /proc/env
 sudo apt-get install libcap2-bin -y
 
-wget https://dl.influxdata.com/telegraf/releases/telegraf-1.18.0_linux_amd64.tar.gz
-tar -zxvf telegraf-1.18.0_linux_amd64.tar.gz
+wget https://dl.influxdata.com/telegraf/releases/telegraf-1.21.2_linux_amd64.tar.gz
+tar -zxvf telegraf-1.21.2_linux_amd64.tar.gz
 
-mv /opt/telegraf-1.18.0/usr/bin/telegraf /opt/telegraf
+mv /opt/telegraf-1.21.2/usr/bin/telegraf /opt/telegraf
 
 chmod 777 /opt/telegraf
 

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -61,6 +61,7 @@ rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/azure-mdsd*.deb
 rm -f $TMPDIR/mdsd.xml
 rm -f $TMPDIR/envmdsd
+rm -f $TMPDIR/telegraf-*.tar.gz
 
 # remove build dependencies
 sudo apt-get remove ruby2.6-dev gcc make -y

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -780,7 +780,7 @@ spec:
          imagePullPolicy: IfNotPresent
          resources:
           limits:
-           cpu: 200m
+           cpu: 500m
            memory: 600Mi
          env:
           - name: FBIT_SERVICE_FLUSH_INTERVAL

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -31,7 +31,7 @@ Write-Host ('Finished Installing Fluentbit')
 
 Write-Host ('Installing Telegraf');
 try {
-    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.18.0_windows_amd64.zip'
+    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.20.3_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue


### PR DESCRIPTION
- Upgrade telegraf and re-enable /opt path for trivy scan (1.21.x has a bug with the inputs.disk plugin, so using 1.20.3, but vulnerability scan is clear)
- Ignore new disk path that comes from containerd starting with k8s version >= 1.19.x, which was adding unnecessary InsightsMetrics logs and increasing cost
- Upgrade windows daemonset CPU request and limit to 500mc to fix issues with continuous restarts because of fluentd/fluent-bit not starting up in time

(This is pending AKS approval for windows CPU increase ~~and me currently testing the new telegraf bits on windows~~)