### PR TITLE
cherry picked changes from 03112022 release

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,17 @@ additional questions or comments.
 
 Note : The agent version(s) below has dates (ciprod<mmddyyyy>), which indicate the agent build dates (not release dates)
 
+### 3/11/2022 -
+##### Version microsoft/oms:ciprod03112022 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod03112022 (linux)
+##### Version microsoft/oms:win-ciprod03112022 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod03112022 (windows)
+##### Code change log
+- Linux Agent
+  - Vulnerability fixes
+- Windows Agent
+  - Bug fix for FluentBit stdout and stderr log filtering
+- Common
+    - Upgrade Go lang version from 1.14.1 to 1.15.14
+
 ### 1/31/2022 -
 ##### Version microsoft/oms:ciprod01312022 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01312022 (linux)
 ##### Version microsoft/oms:win-ciprod01312022 Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod01312022 (windows)

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -261,7 +261,17 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
   file = File.open("setenv.ps1", "w")
 
   if !file.nil?
-    commands = get_command_windows('AZMON_COLLECT_STDOUT_LOGS', @collectStdoutLogs)
+    # This will be used in fluent-bit.conf file to filter out logs
+    if (!@collectStdoutLogs && !@collectStderrLogs)
+      #Stop log tailing completely
+      @logTailPath = "C:\\opt\\nolog*.log"
+      @logExclusionRegexPattern = "stdout|stderr"
+    elsif !@collectStdoutLogs
+      @logExclusionRegexPattern = "stdout"
+    elsif !@collectStderrLogs
+      @logExclusionRegexPattern = "stderr"
+    end
+    commands = get_command_windows("AZMON_COLLECT_STDOUT_LOGS", @collectStdoutLogs)
     file.write(commands)
     commands = get_command_windows('AZMON_LOG_TAIL_PATH', @logTailPath)
     file.write(commands)

--- a/build/windows/installer/conf/fluent-bit.conf
+++ b/build/windows/installer/conf/fluent-bit.conf
@@ -50,15 +50,6 @@
     Buffer_Size         64
     Mem_Buf_Limit       5m
 
-[INPUT]
-    Name        tcp
-    Tag         oms.container.perf.telegraf.*
-    Listen      0.0.0.0
-    Port        25229
-    Chunk_Size  32
-    Buffer_Size 64
-    Mem_Buf_Limit 5m
-
 [FILTER]
     Name grep
     Match oms.container.log.la.*

--- a/build/windows/installer/conf/fluent-bit.conf
+++ b/build/windows/installer/conf/fluent-bit.conf
@@ -50,6 +50,26 @@
     Buffer_Size         64
     Mem_Buf_Limit       5m
 
+[INPUT]
+    Name        tcp
+    Tag         oms.container.perf.telegraf.*
+    Listen      0.0.0.0
+    Port        25229
+    Chunk_Size  32
+    Buffer_Size 64
+    Mem_Buf_Limit 5m
+
+[FILTER]
+    Name grep
+    Match oms.container.log.la.*
+    Exclude stream ${AZMON_LOG_EXCLUSION_REGEX_PATTERN}
+
+# Exclude prometheus plugin exceptions that might be caused due to invalid config.(Logs which contain - E! [inputs.prometheus])
+# Excluding these logs from being sent to AI since it can result in high volume of data in telemetry due to invalid config.
+[FILTER]
+    Name grep
+    Match oms.container.log.flbplugin.*
+
 [OUTPUT]
     Name  oms
     EnableTelemetry                 true

--- a/charts/azuremonitor-containers/Chart.yaml
+++ b/charts/azuremonitor-containers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 7.0.0-1
 description: Helm chart for deploying Azure Monitor container monitoring agent in Kubernetes
 name: azuremonitor-containers
-version: 2.9.1
+version: 2.9.2
 kubeVersion: "^1.10.0-0"
 keywords:
   - monitoring

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -21,8 +21,8 @@ Azure:
 omsagent:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"
-    tag: "ciprod01312022"
-    tagWindows: "win-ciprod01312022"
+    tag: "ciprod03112022"
+    tagWindows: "win-ciprod03112022"
     pullPolicy: IfNotPresent
     dockerProviderVersion: "16.0.0-0"
     agentVersion: "azure-mdsd-1.14.2"

--- a/kubernetes/linux/Dockerfile
+++ b/kubernetes/linux/Dockerfile
@@ -17,7 +17,7 @@ ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR 0.9
 RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes init-system-helpers  net-tools rsyslog cron vim dmidecode apt-transport-https gnupg && rm -rf /var/lib/apt/lists/*
 COPY setup.sh main.sh defaultpromenvvariables defaultpromenvvariables-rs defaultpromenvvariables-sidecar mdsd.xml envmdsd logrotate.conf $tmpdir/
 
-ARG IMAGE_TAG=ciprod01312022
+ARG IMAGE_TAG=ciprod03112022
 ENV AGENT_VERSION ${IMAGE_TAG}
 
 WORKDIR ${tmpdir}

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -368,7 +368,7 @@ spec:
             value: "3"
       containers:
         - name: omsagent
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01312022"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod03112022"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -603,7 +603,7 @@ spec:
       serviceAccountName: omsagent
       containers:
         - name: omsagent
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01312022"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod03112022"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -776,7 +776,7 @@ spec:
             value: "3"
      containers:
        - name: omsagent-win
-         image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod01312022"
+         image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod03112022"
          imagePullPolicy: IfNotPresent
          resources:
           limits:

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"
 
-ARG IMAGE_TAG=win-ciprod01312022
+ARG IMAGE_TAG=win-ciprod03112022
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement


### PR DESCRIPTION
The latest 03112022 release which had fix for windows log filtering was created in a branch off of ci_prod. This PR brings those changes into ci_dev. 
Release PR for reference: https://github.com/microsoft/Docker-Provider/pull/718