### PR TITLE
PodReadyPercentage metric bug fix

### DIFF
--- a/source/plugins/ruby/MdmMetricsGenerator.rb
+++ b/source/plugins/ruby/MdmMetricsGenerator.rb
@@ -79,7 +79,7 @@ class MdmMetricsGenerator
         @pod_ready_hash.each { |dim_key, value|
           podsNotReady = @pod_not_ready_hash.key?(dim_key) ? @pod_not_ready_hash[dim_key] : 0
           totalPods = value + podsNotReady
-          podsReadyPercentage = (value / totalPods) * 100
+          podsReadyPercentage = value * 100.0 / totalPods
           @pod_ready_percentage_hash[dim_key] = podsReadyPercentage
           # Deleting this key value pair from not ready hash,
           # so that we can get those dimensions for which there are 100% of the pods in not ready state


### PR DESCRIPTION
Fixes the issue where integer division was causing the percentage to either be 0 or 100.

I checked that this is not happening for the other percentage metrics. These are all calculated in the `filter_cadvisor2mdm.rb` file and use the format `value * 100 / total` where either `value` or `total` is a double or float.

I tested this with linux and windows controllers that have 0%, 50%, 66.67%, and 100% of pods ready.
I did not test with an ARM64 image. Please let me know if I should. I would need to whitelist my subscription to do so.