### PR TITLE
CA Cert Fix for Mariner Hosts in Air Gap

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -296,16 +296,19 @@ echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >> ~/.bashrc
 # OS_ID here is the container distro.
 # Adding Mariner now even though the elif will never currently evaluate. 
 if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
-  OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f2)
-  if [ $OS_ID == "ubuntu" ]; then
+  OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f2 | tr -d '"' | tr -d "'")
+  if [ $OS_ID == "mariner" ]; then
+    cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
+    cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
+    update-ca-trust
+  else
+    if [ $OS_ID != "ubuntu" ]; then
+      echo "Error: The ID in /etc/os-release is not ubuntu or mariner. Defaulting to ubuntu."
+    fi
     cp /anchors/ubuntu/* /usr/local/share/ca-certificates/
     cp /anchors/mariner/* /usr/local/share/ca-certificates/
     update-ca-certificates
     cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
-  elif [ $OS_ID == "mariner" ]; then
-    cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
-    cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
-    update-ca-trust
   fi
 fi
 


### PR DESCRIPTION
This is the script changes. The AKS RP changes for mounting /anchors/mariner and /anchors/ubuntu will need to go in with this image change. I will make a PR for this when we release.

Issue is Mariner host has CA certs in a different location that we still need to mount on the container. Other teams saw issues when just mounting directly for both Ubuntu and Mariner, so solution is to mount into a different location and copy over in the main.sh script.