### PR TITLE
[ArcA] Make custom metrics endpoint variable on ArcA cluster

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -103,6 +103,14 @@ spec:
        {{- end }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
+       {{ if .Values.omsagent.arcasettings.isArcACluster }}
+       - name: IS_ARCA_CLUSTER
+         value: {{ .Values.omsagent.arcasettings.isArcACluster | quote }}
+       {{- if ne .Values.omsagent.arcasettings.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: ARCA_Metrics_Endpoint
+         value: {{ .Values.omsagent.arcasettings.metricsEndpoint | quote }}
+       {{- end }}
+       {{- end }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -103,12 +103,12 @@ spec:
        {{- end }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
-       {{ if .Values.omsagent.arcasettings.isArcACluster }}
+       {{ if .Values.Azure.arcaSettings.isArcACluster }}
        - name: IS_ARCA_CLUSTER
-         value: {{ .Values.omsagent.arcasettings.isArcACluster | quote }}
-       {{- if ne .Values.omsagent.arcasettings.metricsEndpoint "<your_metrics_endpoint>" }}
+         value: {{ .Values.Azure.arcaSettings.isArcACluster | quote }}
+       {{- if ne .Values.Azure.arcaSettings.metricsEndpoint "<your_metrics_endpoint>" }}
        - name: ARCA_Metrics_Endpoint
-         value: {{ .Values.omsagent.arcasettings.metricsEndpoint | quote }}
+         value: {{ .Values.Azure.arcaSettings.metricsEndpoint | quote }}
        {{- end }}
        {{- end }}
        securityContext:

--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -103,13 +103,13 @@ spec:
        {{- end }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
-       {{ if .Values.Azure.arcaSettings.isArcACluster }}
+       {{ if .Values.omsagent.isArcACluster }}
        - name: IS_ARCA_CLUSTER
-         value: {{ .Values.Azure.arcaSettings.isArcACluster | quote }}
-       {{- if ne .Values.Azure.arcaSettings.metricsEndpoint "<your_metrics_endpoint>" }}
-       - name: ARCA_Metrics_Endpoint
-         value: {{ .Values.Azure.arcaSettings.metricsEndpoint | quote }}
+         value: {{ .Values.omsagent.isArcACluster | quote }}
        {{- end }}
+       {{- if ne .Values.omsagent.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: Custom_Metrics_Endpoint
+         value: {{ .Values.omsagent.metricsEndpoint | quote }}
        {{- end }}
        securityContext:
          privileged: true

--- a/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -89,12 +89,12 @@ spec:
          value: {{ .Values.omsagent.sidecarscraping | quote }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
-       {{ if .Values.omsagent.arcasettings.isArcACluster }}
+       {{ if .Values.Azure.arcaSettings.isArcACluster }}
        - name: IS_ARCA_CLUSTER
-         value: {{ .Values.omsagent.arcasettings.isArcACluster | quote }}
-       {{- if ne .Values.omsagent.arcasettings.metricsEndpoint "<your_metrics_endpoint>" }}
+         value: {{ .Values.Azure.arcaSettings.isArcACluster | quote }}
+       {{- if ne .Values.Azure.arcaSettings.metricsEndpoint "<your_metrics_endpoint>" }}
        - name: ARCA_Metrics_Endpoint
-         value: {{ .Values.omsagent.arcasettings.metricsEndpoint | quote }}
+         value: {{ .Values.Azure.arcaSettings.metricsEndpoint | quote }}
        {{- end }}
        {{- end }}
        securityContext:

--- a/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -89,13 +89,13 @@ spec:
          value: {{ .Values.omsagent.sidecarscraping | quote }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
-       {{ if .Values.Azure.arcaSettings.isArcACluster }}
+       {{ if .Values.omsagent.isArcACluster }}
        - name: IS_ARCA_CLUSTER
-         value: {{ .Values.Azure.arcaSettings.isArcACluster | quote }}
-       {{- if ne .Values.Azure.arcaSettings.metricsEndpoint "<your_metrics_endpoint>" }}
-       - name: ARCA_Metrics_Endpoint
-         value: {{ .Values.Azure.arcaSettings.metricsEndpoint | quote }}
+         value: {{ .Values.omsagent.isArcACluster | quote }}
        {{- end }}
+       {{- if ne .Values.omsagent.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: Custom_Metrics_Endpoint
+         value: {{ .Values.omsagent.metricsEndpoint | quote }}
        {{- end }}
        securityContext:
          privileged: true

--- a/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -89,6 +89,14 @@ spec:
          value: {{ .Values.omsagent.sidecarscraping | quote }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
+       {{ if .Values.omsagent.arcasettings.isArcACluster }}
+       - name: IS_ARCA_CLUSTER
+         value: {{ .Values.omsagent.arcasettings.isArcACluster | quote }}
+       {{- if ne .Values.omsagent.arcasettings.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: ARCA_Metrics_Endpoint
+         value: {{ .Values.omsagent.arcasettings.metricsEndpoint | quote }}
+       {{- end }}
+       {{- end }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -19,6 +19,9 @@ Azure:
     httpsProxy: ""
     noProxy: ""
     proxyCert: ""
+  arcaSettings:
+    isArcACluster: false
+    metricsEndpoint: <your_metrics_endpoint>
 omsagent:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"
@@ -71,9 +74,6 @@ omsagent:
     ## Applicable for only Azure Stack Edge K8s since it has custom mount path for container logs which will have symlink to /var/log path
     custommountpath: ""
 
-  arcasettings:
-    isArcACluster: false
-    metricsEndpoint: <your_metrics_endpoint>
 
   ## Configure node tolerations for scheduling onto nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -19,9 +19,6 @@ Azure:
     httpsProxy: ""
     noProxy: ""
     proxyCert: ""
-  arcaSettings:
-    isArcACluster: false
-    metricsEndpoint: <your_metrics_endpoint>
 omsagent:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"
@@ -52,6 +49,9 @@ omsagent:
   # This flag used to determine whether to use AAD MSI auth or not for Arc K8s cluster
   useAADAuth: false
 
+  # This flag used to determine whether this cluster is connected to ArcA control plane. This value will be setup before pushed into on-premise ArcA ACR.
+  isArcACluster: false
+
   ## To get your workspace id and key do the following
   ## You can create a Azure Loganalytics workspace from portal.azure.com and get its ID & PRIMARY KEY from 'Advanced Settings' tab in the Ux.
 
@@ -60,6 +60,8 @@ omsagent:
     key: <your_workspace_key>
   domain: opinsights.azure.com
   proxy: <your_proxy_config>
+  # This metricsEndpoint used to define the endpoint custom metrics emit to. If not defined, default public Azure monitoring endpoint '{aks_region}.monitoring.azure.com' will be used.
+  metricsEndpoint: <your_metrics_endpoint>
   env:
     clusterName: <your_cluster_name>
     ## Applicable for only managed clusters hosted in Azure

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -76,7 +76,6 @@ omsagent:
     ## Applicable for only Azure Stack Edge K8s since it has custom mount path for container logs which will have symlink to /var/log path
     custommountpath: ""
 
-
   ## Configure node tolerations for scheduling onto nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -71,6 +71,10 @@ omsagent:
     ## Applicable for only Azure Stack Edge K8s since it has custom mount path for container logs which will have symlink to /var/log path
     custommountpath: ""
 
+  arcasettings:
+    isArcACluster: false
+    metricsEndpoint: <your_metrics_endpoint>
+
   ## Configure node tolerations for scheduling onto nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -13,6 +13,10 @@ class CustomMetricsUtils
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
+            is_ArcA_Cluster = ENV['IS_ARCA_CLUSTER']
+            if is_ArcA_Cluster.to_s.downcase == "true" && !ENV['ARCA_Metrics_Endpoint'].to_s.empty?
+                return true
+            end
 
             return aks_cloud_environment.to_s.downcase == 'azurepubliccloud'
         end

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -13,8 +13,9 @@ class CustomMetricsUtils
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
+            # If this is cluster is connected to ArcA control plane and metrics endpoint provided, custom metrics shall be emitted.
             is_ArcA_Cluster = ENV['IS_ARCA_CLUSTER']
-            if is_ArcA_Cluster.to_s.downcase == "true" && !ENV['ARCA_Metrics_Endpoint'].to_s.empty?
+            if is_ArcA_Cluster.to_s.downcase == "true" && !ENV['Custom_Metrics_Endpoint'].to_s.empty?
                 return true
             end
 

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -103,7 +103,7 @@ module Fluent::Plugin
           is_ArcA_Cluster = ENV['IS_ARCA_CLUSTER']
           arcA_metrics_endpoint = ENV['ARCA_Metrics_Endpoint']
           if is_ArcA_Cluster.to_s.downcase == "true" && !arcA_metrics_endpoint.to_s.empty?
-            metrics_endpoint = arcA_metrics_endpoint
+            metrics_endpoint = arcA_metrics_endpoint.lstrip.rstrip.delete_prefix('http://').delete_prefix('https://')
           else
             metrics_endpoint = @@public_metrics_endpoint_template % { aks_region: aks_region }
           end

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -100,12 +100,12 @@ module Fluent::Plugin
             @isArcK8sCluster = true
           end
 
-          is_ArcA_Cluster = ENV['IS_ARCA_CLUSTER']
-          arcA_metrics_endpoint = ENV['ARCA_Metrics_Endpoint']
-          if is_ArcA_Cluster.to_s.downcase == "true" && !arcA_metrics_endpoint.to_s.empty?
-            metrics_endpoint = arcA_metrics_endpoint.lstrip.rstrip
+          # If Custom_Metrics_Endpoint provided, the url format shall be validated before emitting metrics into given endpoint.
+          Custom_Metrics_Endpoint = ENV['Custom_Metrics_Endpoint']
+          if !Custom_Metrics_Endpoint.to_s.empty?
+            metrics_endpoint = Custom_Metrics_Endpoint.lstrip.rstrip
             if !valid_url?(metrics_endpoint)
-              invalid_url_message = "The ARCA_Metrics_Endpoint (#{arcA_metrics_endpoint}) from environment vaiable is invalid."
+              invalid_url_message = "The Custom_Metrics_Endpoint (#{Custom_Metrics_Endpoint}) from environment vaiable is invalid."
               @log.warn invalid_url_message
               raise invalid_url_message
             end

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -26,7 +26,8 @@ module Fluent::Plugin
       @@token_resource_audience = "https://monitor.azure.com/"
       @@grant_type = "client_credentials"
       @@azure_json_path = "/etc/kubernetes/host/azure.json"
-      @@post_request_url_template = "https://%{aks_region}.monitoring.azure.com%{aks_resource_id}/metrics"
+      @@public_metrics_endpoint_template = "%{aks_region}.monitoring.azure.com"
+      @@post_request_url_template = "https://%{metrics_endpoint}%{aks_resource_id}/metrics"
       @@aad_token_url_template = "https://login.microsoftonline.com/%{tenant_id}/oauth2/token"
 
       # msiEndpoint is the well known endpoint for getting MSI authentications tokens
@@ -98,7 +99,15 @@ module Fluent::Plugin
           if aks_resource_id.downcase.include?("microsoft.kubernetes/connectedclusters")
             @isArcK8sCluster = true
           end
-          @@post_request_url = @@post_request_url_template % { aks_region: aks_region, aks_resource_id: aks_resource_id }
+
+          is_ArcA_Cluster = ENV['IS_ARCA_CLUSTER']
+          arcA_metrics_endpoint = ENV['ARCA_Metrics_Endpoint']
+          if is_ArcA_Cluster.to_s.downcase == "true" && !arcA_metrics_endpoint.to_s.empty?
+            metrics_endpoint = arcA_metrics_endpoint
+          else
+            metrics_endpoint = @@public_metrics_endpoint_template % { aks_region: aks_region }
+          end
+          @@post_request_url = @@post_request_url_template % { metrics_endpoint: metrics_endpoint, aks_resource_id: aks_resource_id }
           @post_request_uri = URI.parse(@@post_request_url)
           proxy = (ProxyUtils.getProxyConfiguration)
           if proxy.nil? || proxy.empty?


### PR DESCRIPTION
This changes make custom metrics endpoint variable on ArcA K8s clusters, containing the following changes:
1. ArcA settings were added in values.yaml, then set into environment variables in omsagent yaml files. 
2. Make custom metrics check pass on ArcA env.
3. Read metrics endpoint settings from environment variable in out_mdm.rb.