### PR TITLE
Gangams/ws2022 support

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -91,7 +91,7 @@ jobs:
         run: cd ./build/windows/ && & .\Makefile.ps1
       - name: Create-docker-image
         run: |
-            cd ./kubernetes/windows/ && docker build . --file Dockerfile -t $env:IMAGETAG --build-arg IMAGE_TAG=$env:IMAGETAG_TELEMETRY
+            cd ./kubernetes/windows/ && docker build . --file Dockerfile -t $env:IMAGETAG --build-arg WINDOWS_VERSION=ltsc2019 --build-arg IMAGE_TAG=$env:IMAGETAG_TELEMETRY
       - name: List-docker-images
         run: docker images --digests --all
-      
+

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -225,7 +225,7 @@ jobs:
            docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
         }
 
-- job: build_windows
+- job: build_windows_multi_arc
   dependsOn:
   - common
   - build_windows_2019

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -228,7 +228,9 @@ jobs:
           docker push ${{ variables.repoImageName }}:$(windows2022ImageTag)
         }
 - job: build_windows_multi_arc
-  dependsOn: build_windows_2019, build_windows_2022
+  dependsOn:
+  -  build_windows_2019
+  -  build_windows_2022
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -19,6 +19,8 @@ variables:
   subscription: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
   containerRegistry: 'containerinsightsprod'
   repoImageName: '${{ variables.containerRegistry }}.azurecr.io/public/azuremonitor/containerinsights/cidev'
+  windows2019BaseImageVersion: ltsc2019
+  windows2022BaseImageVersion: ltsc2022
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
 
 jobs:
@@ -141,98 +143,13 @@ jobs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
 
-- job: build_windows_2019
-  dependsOn: common
-  pool:
-    name: Azure-Pipelines-Windows-CI-Test-EO
-  variables:
-    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    windowsBaseImageVersion: ltsc2019
-  steps:
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-    displayName: 'install prereqs'
-
-  - script: |
-      setlocal enabledelayedexpansion
-      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-      endlocal
-      exit /B %ERRORLEVEL%
-    displayName: 'build base'
-
-  - task: AzureCLI@2
-    displayName: "Docker windows build for base image ltsc2019"
-    inputs:
-      azureSubscription: ${{ variables.armServiceConnectionName }}
-      scriptType: ps
-      scriptLocation: inlineScript
-      inlineScript: |
-        mkdir -p $(Build.ArtifactStagingDirectory)/windows
-        cd kubernetes/windows
-
-        az --version
-        az account show
-        az account set -s ${{ variables.subscription }}
-        az acr login -n ${{ variables.containerRegistry }}
-
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-
-        docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
-- job: build_windows_2022
-  dependsOn: common
-  pool:
-    name: Azure-Pipelines-Windows-CI-Test-EO
-  variables:
-    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    windowsBaseImageVersion: ltsc2022
-
-  steps:
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-    displayName: 'install prereqs'
-
-  - script: |
-      setlocal enabledelayedexpansion
-      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-      endlocal
-      exit /B %ERRORLEVEL%
-    displayName: 'build base'
-
-  - task: AzureCLI@2
-    displayName: "Docker windows build for base image ltsc2022"
-    inputs:
-      azureSubscription: ${{ variables.armServiceConnectionName }}
-      scriptType: ps
-      scriptLocation: inlineScript
-      inlineScript: |
-        mkdir -p $(Build.ArtifactStagingDirectory)/windows
-        cd kubernetes/windows
-
-        az --version
-        az account show
-        az account set -s ${{ variables.subscription }}
-        az acr login -n ${{ variables.containerRegistry }}
-
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-
-        docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
-
-- job: build_windows_multi_arc
+- job: build_windows
   dependsOn:
   -  common
-  -  build_windows_2019
-  -  build_windows_2022
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
     windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    windows2019BaseImageVersion: ltsc2019
-    windows2022BaseImageVersion: ltsc2022
-
   steps:
   - task: AzureCLI@2
     displayName: "Docker windows build for multi-arc image"
@@ -251,14 +168,15 @@ jobs:
 
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
 
-        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
 
         docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
 
-        docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-
+        if ("$(Build.Reason)" -ne "PullRequest") {
+          docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+        }
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -177,7 +177,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
 
         docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
 - job: build_windows_2022
@@ -217,7 +217,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
 
         docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
 

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -227,7 +227,7 @@ jobs:
         if ("$(Build.Reason)" -ne "PullRequest") {
           docker push ${{ variables.repoImageName }}:$(windows2022ImageTag)
         }
-- job: build_windows_multi-arc
+- job: build_windows_multi_arc
   dependsOn: build_windows_2019, build_windows_2022
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
@@ -271,7 +271,6 @@ jobs:
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
       DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022, ${{ variables.repoImageName }}:$(windowsImageTag)'
-
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -141,7 +141,7 @@ jobs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
 
-- job: build_windows
+- job: build_windows_2019
   dependsOn: common
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
@@ -163,7 +163,80 @@ jobs:
     displayName: 'build base'
 
   - task: AzureCLI@2
-    displayName: "Docker windows build"
+    displayName: "Docker windows build for base image ltsc2019"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+        export WINDOWS_VERSION=ltsc2019
+        windows2019ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
+
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2019ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .
+
+        if ("$(Build.Reason)" -ne "PullRequest") {
+          docker push ${{ variables.repoImageName }}:$(windows2019ImageTag)
+        }
+- job: build_windows_2022
+  dependsOn: common
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+
+  steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    displayName: 'install prereqs'
+
+  - script: |
+      setlocal enabledelayedexpansion
+      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+      endlocal
+      exit /B %ERRORLEVEL%
+    displayName: 'build base'
+
+  - task: AzureCLI@2
+    displayName: "Docker windows build for base image ltsc2022"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+        export WINDOWS_VERSION=ltsc2022
+        windows2022ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
+
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2022ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .
+
+        if ("$(Build.Reason)" -ne "PullRequest") {
+          docker push ${{ variables.repoImageName }}:$(windows2022ImageTag)
+        }
+- job: build_windows_multi-arc
+  dependsOn: build_windows_2019, build_windows_2022
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+
+  steps:
+  - task: AzureCLI@2
+    displayName: "Docker windows build for multi-arc image"
     inputs:
       azureSubscription: ${{ variables.armServiceConnectionName }}
       scriptType: ps
@@ -177,27 +250,27 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
+        windows2019ImageTag=$(windowsImageTag)-ltsc2019
+        windows2022ImageTag=$(windowsImageTag)-ltsc2022
+
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag) --build-arg IMAGE_TAG=$(windowsImageTag) .
-
         if ("$(Build.Reason)" -ne "PullRequest") {
-          docker push ${{ variables.repoImageName }}:$(windowsImageTag)
+          docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windows2019ImageTag) ${{ variables.repoImageName }}:$(windows2022ImageTag)
+          docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
         }
-
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019'
-
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022'
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, false)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, ${{ variables.repoImageName }}:$(windowsImageTag)'
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022, ${{ variables.repoImageName }}:$(windowsImageTag)'
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -250,10 +250,12 @@ jobs:
 
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2019BaseImageVersion}
-        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2022BaseImageVersion}
+        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
 
-        docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2019BaseImageVersion} ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2022BaseImageVersion}
+        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+
+        docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+
         docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -19,8 +19,6 @@ variables:
   subscription: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
   containerRegistry: 'containerinsightsprod'
   repoImageName: '${{ variables.containerRegistry }}.azurecr.io/public/azuremonitor/containerinsights/cidev'
-  windows2019BaseImageVersion: ltsc2019
-  windows2022BaseImageVersion: ltsc2022
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
 
 jobs:
@@ -150,7 +148,22 @@ jobs:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
     windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2019BaseImageVersion: ltsc2019
+    windows2022BaseImageVersion: ltsc2022
   steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    displayName: 'install prereqs'
+
+  - script: |
+      setlocal enabledelayedexpansion
+      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+      endlocal
+      exit /B %ERRORLEVEL%
+    displayName: 'build base'
+
   - task: AzureCLI@2
     displayName: "Docker windows build for multi-arc image"
     inputs:
@@ -169,20 +182,17 @@ jobs:
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-
         docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+        docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
 
-        if ("$(Build.Reason)" -ne "PullRequest") {
-          docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-        }
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
       DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022'
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, false)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -178,11 +178,9 @@ jobs:
         az acr login -n ${{ variables.containerRegistry }}
         windows2019ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2019ImageTag) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 
-        if ("$(Build.Reason)" -ne "PullRequest") {
-          docker push ${{ variables.repoImageName }}:$(windows2019ImageTag)
-        }
+        docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
 - job: build_windows_2022
   dependsOn: common
   pool:
@@ -221,11 +219,10 @@ jobs:
         az acr login -n ${{ variables.containerRegistry }}
         windows2022ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2022ImageTag) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 
-        if ("$(Build.Reason)" -ne "PullRequest") {
-          docker push ${{ variables.repoImageName }}:$(windows2022ImageTag)
-        }
+        docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion)
+
 - job: build_windows_multi_arc
   dependsOn:
   -  build_windows_2019
@@ -234,6 +231,8 @@ jobs:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
     windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2019BaseImageVersion: ltsc2019
+    windows2022BaseImageVersion: ltsc2022
 
   steps:
   - task: AzureCLI@2
@@ -251,15 +250,14 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        windows2019ImageTag=$(windowsImageTag)-ltsc2019
-        windows2022ImageTag=$(windowsImageTag)-ltsc2022
-
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        if ("$(Build.Reason)" -ne "PullRequest") {
-          docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windows2019ImageTag) ${{ variables.repoImageName }}:$(windows2022ImageTag)
-          docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-        }
+        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2019BaseImageVersion}
+        docker pull ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2022BaseImageVersion}
+
+        docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2019BaseImageVersion} ${{ variables.repoImageName }}:$(windowsImageTag)-{windows2022BaseImageVersion}
+        docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -183,9 +183,12 @@ jobs:
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-        docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-        docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-
+        if ("$(Build.Reason)" -ne "PullRequest") {
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+           docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+           docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+        }
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -237,19 +237,6 @@ jobs:
     windows2019BaseImageVersion: ltsc2019
     windows2022BaseImageVersion: ltsc2022
   steps:
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-    displayName: 'install prereqs'
-
-  - script: |
-      setlocal enabledelayedexpansion
-      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-      endlocal
-      exit /B %ERRORLEVEL%
-    displayName: 'build base'
-
   - task: AzureCLI@2
     displayName: "Docker windows build for multi-arc image"
     inputs:

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -91,7 +91,7 @@ jobs:
   pool:
     name: Azure-Pipelines-CI-Test-EO
   variables:
-    linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]  
+    linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
 
   steps:
   - task: AzureCLI@2
@@ -146,8 +146,8 @@ jobs:
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
-    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]  
-  
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+
   steps:
   - task: PowerShell@2
     inputs:
@@ -179,7 +179,7 @@ jobs:
 
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        docker build --tag ${{ variables.repoImageName }}:$(windowsImageTag) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag) --build-arg IMAGE_TAG=$(windowsImageTag) .
 
         if ("$(Build.Reason)" -ne "PullRequest") {
           docker push ${{ variables.repoImageName }}:$(windowsImageTag)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -176,7 +176,7 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        export WINDOWS_VERSION=ltsc2019
+        WINDOWS_VERSION=ltsc2019
         windows2019ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2019ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .
@@ -219,7 +219,7 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        export WINDOWS_VERSION=ltsc2022
+        WINDOWS_VERSION=ltsc2022
         windows2022ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2022ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -147,7 +147,7 @@ jobs:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
     windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-
+    windowsBaseImageVersion: ltsc2019
   steps:
   - task: PowerShell@2
     inputs:
@@ -176,10 +176,9 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        WINDOWS_VERSION=ltsc2019
-        windows2019ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
+        windows2019ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2019ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2019ImageTag) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 
         if ("$(Build.Reason)" -ne "PullRequest") {
           docker push ${{ variables.repoImageName }}:$(windows2019ImageTag)
@@ -190,6 +189,7 @@ jobs:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
     windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windowsBaseImageVersion: ltsc2022
 
   steps:
   - task: PowerShell@2
@@ -219,10 +219,9 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        WINDOWS_VERSION=ltsc2022
-        windows2022ImageTag=$(windowsImageTag)-$(WINDOWS_VERSION)
+        windows2022ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2022ImageTag) --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windows2022ImageTag) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 
         if ("$(Build.Reason)" -ne "PullRequest") {
           docker push ${{ variables.repoImageName }}:$(windows2022ImageTag)

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -141,9 +141,95 @@ jobs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
 
-- job: build_windows
+- job: build_windows_2019
   dependsOn:
   -  common
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2019BaseImageVersion: ltsc2019
+  steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    displayName: 'install prereqs'
+
+  - script: |
+      setlocal enabledelayedexpansion
+      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+      endlocal
+      exit /B %ERRORLEVEL%
+    displayName: 'build base'
+
+  - task: AzureCLI@2
+    displayName: "Docker windows build for ltsc2019"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        if ("$(Build.Reason)" -ne "PullRequest") {
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+        }
+
+- job: build_windows_2022
+  dependsOn:
+  -  common
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2022BaseImageVersion: ltsc2022
+  steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    displayName: 'install prereqs'
+
+  - script: |
+      setlocal enabledelayedexpansion
+      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+      endlocal
+      exit /B %ERRORLEVEL%
+    displayName: 'build base'
+
+  - task: AzureCLI@2
+    displayName: "Docker windows build for ltsc2022"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        if ("$(Build.Reason)" -ne "PullRequest") {
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+        }
+
+- job: build_windows
+  dependsOn:
+  - common
+  - build_windows_2019
+  - build_windows_2022
   pool:
     name: Azure-Pipelines-Windows-CI-Test-EO
   variables:
@@ -181,11 +267,7 @@ jobs:
 
         @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
         if ("$(Build.Reason)" -ne "PullRequest") {
-           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
-           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
            docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
            docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
         }

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -176,7 +176,6 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        windows2019ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 
@@ -217,7 +216,6 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
-        windows2022ImageTag=$(windowsImageTag)-$(windowsBaseImageVersion)
 
         docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windowsBaseImageVersion) --build-arg WINDOWS_VERSION=$(windowsBaseImageVersion) IMAGE_TAG=$(windowsImageTag) .
 

--- a/.pipelines/azure_pipeline_dev.yaml
+++ b/.pipelines/azure_pipeline_dev.yaml
@@ -223,6 +223,7 @@ jobs:
 
 - job: build_windows_multi_arc
   dependsOn:
+  -  common
   -  build_windows_2019
   -  build_windows_2022
   pool:

--- a/.pipelines/azure_pipeline_prod.yaml
+++ b/.pipelines/azure_pipeline_prod.yaml
@@ -183,7 +183,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) .
         if ("$(Build.Reason)" -ne "PullRequest") {
            docker push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
         }
@@ -225,7 +225,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) .
         if ("$(Build.Reason)" -ne "PullRequest") {
            docker push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
         }

--- a/.pipelines/azure_pipeline_prod.yaml
+++ b/.pipelines/azure_pipeline_prod.yaml
@@ -95,7 +95,7 @@ jobs:
   pool:
     name: Azure-Pipelines-CI-Prod-EO
   variables:
-    linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]  
+    linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
 
   steps:
   - task: AzureCLI@2
@@ -146,13 +146,14 @@ jobs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
 
-- job: build_windows
-  dependsOn: common
+- job: build_windows_2019
+  dependsOn:
+  -  common
   pool:
     name: Azure-Pipelines-Windows-CI-Prod-EO
   variables:
-    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]  
-  
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2019BaseImageVersion: ltsc2019
   steps:
   - task: PowerShell@2
     inputs:
@@ -168,7 +169,7 @@ jobs:
     displayName: 'build base'
 
   - task: AzureCLI@2
-    displayName: "Docker windows build"
+    displayName: "Docker windows build for ltsc2019"
     inputs:
       azureSubscription: ${{ variables.armServiceConnectionName }}
       scriptType: ps
@@ -182,28 +183,99 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        @{"image.name"="${{ variables.repoImageNameWindows }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-
-        docker build --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag) .
-
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
         if ("$(Build.Reason)" -ne "PullRequest") {
-          docker push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
         }
 
+- job: build_windows_2022
+  dependsOn:
+  -  common
+  pool:
+    name: Azure-Pipelines-Windows-CI-Prod-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2022BaseImageVersion: ltsc2022
+  steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    displayName: 'install prereqs'
+
+  - script: |
+      setlocal enabledelayedexpansion
+      powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+      endlocal
+      exit /B %ERRORLEVEL%
+    displayName: 'build base'
+
+  - task: AzureCLI@2
+    displayName: "Docker windows build for ltsc2022"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        if ("$(Build.Reason)" -ne "PullRequest") {
+           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+        }
+
+- job: build_windows_multi_arc
+  dependsOn:
+  - common
+  - build_windows_2019
+  - build_windows_2022
+  pool:
+    name: Azure-Pipelines-Windows-CI-Prod-EO
+  variables:
+    windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    windows2019BaseImageVersion: ltsc2019
+    windows2022BaseImageVersion: ltsc2022
+  steps:
+  - task: AzureCLI@2
+    displayName: "Docker windows build for multi-arc image"
+    inputs:
+      azureSubscription: ${{ variables.armServiceConnectionName }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/windows
+        cd kubernetes/windows
+
+        az --version
+        az account show
+        az account set -s ${{ variables.subscription }}
+        az acr login -n ${{ variables.containerRegistry }}
+
+        @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+
+        if ("$(Build.Reason)" -ne "PullRequest") {
+           docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+           docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+        }
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, true)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019'
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, false)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, ${{ variables.repoImageNameWindows }}:$(windowsImageTag)'
-
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022, ${{ variables.repoImageName }}:$(windowsImageTag)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/.pipelines/azure_pipeline_prod.yaml
+++ b/.pipelines/azure_pipeline_prod.yaml
@@ -183,9 +183,9 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
         if ("$(Build.Reason)" -ne "PullRequest") {
-           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+           docker push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
         }
 
 - job: build_windows_2022
@@ -225,9 +225,9 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion) --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsImageTag) .
         if ("$(Build.Reason)" -ne "PullRequest") {
-           docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+           docker push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
         }
 
 - job: build_windows_multi_arc
@@ -257,11 +257,11 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+        @{"image.name"="${{ variables.repoImageNameWindows }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
 
         if ("$(Build.Reason)" -ne "PullRequest") {
-           docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-           docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+           docker manifest create ${{ variables.repoImageNameWindows }}:$(windowsImageTag) ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageNameWindows }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+           docker manifest push ${{ variables.repoImageNameWindows }}:$(windowsImageTag)
         }
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'

--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ For the subsequent builds, you can just run -
 
 ```
 .\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> # trigger build code and image and publish docker hub or acr
+By default, multi-arc docker image will be built, but if you want generate test image either with ltsc2019 or ltsc2022 base image, then you can follow the instructions below
+
+For building image with base image version ltsc2019
+.\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> -windowsBaseImageVersion ltsc2019
+
+For building image with base image version ltsc2022
+.\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> -windowsBaseImageVersion ltsc2022
 ```
 ###### Note - If you have changes in setup.ps1 and want to test those changes, uncomment the section consisting of setup.ps1 in the Dockerfile-dev-image file.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ powershell -ExecutionPolicy bypass  # switch to powershell if you are not on pow
 And then run the script to build the image consisting of code and conf changes.
 ```
 .\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> # trigger build code and image and publish docker hub or acr
+By default, multi-arc docker image will be built, but if you want generate test image either with ltsc2019 or ltsc2022 base image, then you can follow the instructions below
+
+For building image with base image version ltsc2019
+.\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> -windowsBaseImageVersion ltsc2019
+
+For building image with base image version ltsc2022
+.\build-and-publish-dev-docker-image.ps1 -image <repo>/<imagename>:<imagetag> -windowsBaseImageVersion ltsc2022
+
+
 ```
 
 For the subsequent builds, you can just run -

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -1,4 +1,4 @@
-# Supported values of windows version is ltsc2019 or ltsc2022 which are being passed by the build script or build pipeline
+# Supported values of windows version are ltsc2019 or ltsc2022 which are being passed by the build script or build pipeline
 ARG WINDOWS_VERSION=
 FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 MAINTAINER OMSContainers@microsoft.com

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+# Supported values of windows version is ltsc2019 or ltsc2022 which are being passed by the build script or build pipeline
+ARG WINDOWS_VERSION=
+FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"

--- a/kubernetes/windows/Dockerfile-dev-base-image
+++ b/kubernetes/windows/Dockerfile-dev-base-image
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ARG WINDOWS_VERSION=
+FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 MAINTAINER OMSContainers@microsoft.com
 LABEL vendor=Microsoft\ Corp \
     com.microsoft.product="Azure Monitor for containers"

--- a/kubernetes/windows/dockerbuild/build-and-publish-dev-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-dev-docker-image.ps1
@@ -7,7 +7,8 @@
 #>
 param(
     [Parameter(mandatory = $true)]
-    [string]$image
+    [string]$image,
+    [string]$windowsBaseImageVersion="" # Supported values are ltsc2019 or ltsc2022. Default is multi-arc image unless this value specified
 )
 
 $currentdir =  $PSScriptRoot
@@ -55,10 +56,50 @@ Write-Host "changing directory to DockerFile dir: $dockerFileDir"
 Set-Location -Path $dockerFileDir
 
 $updateImage = ${imagerepo} + ":" + ${imageTag}
-Write-Host "STAT:Triggering docker image build: $image"
-docker build -t $updateImage  --build-arg IMAGE_TAG=$imageTag -f Dockerfile-dev-image .
-Write-Host "END:Triggering docker image build: $updateImage"
+if ([string]::IsNullOrEmpty($windowsBaseImageVersion)) {
+    Write-Host "START:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
 
-Write-Host "STAT:pushing docker image : $updateImage"
-docker push  $updateImage
-Write-Host "EnD:pushing docker image : $updateImage"
+    $WINDOWS_VERSION="ltsc2019"
+    $updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    Write-Host "START:Triggering docker image build for ltsc2019: $updateImageLTSC2019"
+    docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag -f Dockerfile-dev-image  .
+    Write-Host "END:Triggering docker image build for ltsc2019: $updateImageLTSC2019"
+
+    $WINDOWS_VERSION="ltsc2022"
+    $updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    Write-Host "START:Triggering docker image build for ltsc2022: $updateImageLTSC2022"
+    docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag -f Dockerfile-dev-image .
+    Write-Host "END:Triggering docker image build for ltsc2022: $updateImageLTSC2022"
+
+    Write-Host "START:pushing docker image with base image ltsc2019 : $updateImageLTSC2019"
+    docker push  $updateImageLTSC2019
+    Write-Host "END:pushing docker image : $updateImageLTSC2019"
+
+    Write-Host "START:pushing docker image with base image ltsc2022 : $updateImageLTSC2022"
+    docker push  $updateImageLTSC2022
+    Write-Host "END:pushing docker image : $updateImageLTSC2022"
+
+    Write-Host "START:Triggering manigest for multi-arc docker image: $updateImage"
+    docker manifest create $updateImage $updateImageLTSC2019 $updateImageLTSC2022
+    docker manifest push $updateImage
+    Write-Host "END:Triggering manifest for multi-arc docker image: $updateImage"
+
+    Write-Host "END:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
+
+} else {
+
+    if (($windowsBaseImageVersion -eq "ltsc2019") -or ($windowsBaseImageVersion -eq "ltsc2022")) {
+        Write-Host "Provided baseimage version valid and supported: ${windowsBaseImageVersion}"
+    } else {
+        Write-Host "Provided baseimage version neither valid nor supported: ${windowsBaseImageVersion}" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "STAT:Triggering docker image build: $image with base image version: $windowsBaseImageVersion"
+    docker build -t $updateImage  --build-arg WINDOWS_VERSION=$windowsBaseImageVersion --build-arg IMAGE_TAG=$imageTag -f Dockerfile-dev-image .
+    Write-Host "END:Triggering docker image build: $updateImage"
+
+    Write-Host "STAT:pushing docker image : $updateImage"
+    docker push  $updateImage
+    Write-Host "EnD:pushing docker image : $updateImage"
+}

--- a/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
@@ -55,8 +55,20 @@ Write-Host "changing directory to DockerFile dir: $dockerFileDir"
 Set-Location -Path $dockerFileDir
 
 $updateImage = ${imagerepo} + ":" + ${imageTag}
-Write-Host "STAT:Triggering docker image build: $image"
-docker build -t $updateImage  --build-arg IMAGE_TAG=$imageTag  .
+Write-Host "START:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
+
+Write-Host "START:Triggering docker image build for ltsc2019: $image"
+$WINDOWS_VERSION="ltsc2019"
+$updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+Write-Host "END:Triggering docker image build for ltsc2019: $image"
+
+Write-Host "START:Triggering docker image build for ltsc2022: $image"
+$WINDOWS_VERSION="ltsc2022"
+$updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+Write-Host "END:Triggering docker image build for ltsc2022: $image"
+
 Write-Host "END:Triggering docker image build: $updateImage"
 
 Write-Host "STAT:pushing docker image : $updateImage"

--- a/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
@@ -8,8 +8,7 @@
 param(
     [Parameter(mandatory = $true)]
     [string]$image,
-    [Parameter(mandatory = $true)]
-    [bool]$multiArc= $true
+    [string]$windowsBaseImageVersion="" # Supported values are ltsc2019 or ltsc2022. Default is multi-arc image unless this value specified
 )
 
 $currentdir =  $PSScriptRoot
@@ -57,19 +56,20 @@ Write-Host "changing directory to DockerFile dir: $dockerFileDir"
 Set-Location -Path $dockerFileDir
 
 $updateImage = ${imagerepo} + ":" + ${imageTag}
-if ($multiArc) {
+if ([string]::IsNullOrEmpty($windowsBaseImageVersion)) {
     Write-Host "START:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
-    Write-Host "START:Triggering docker image build for ltsc2019: $image"
+
     $WINDOWS_VERSION="ltsc2019"
     $updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    Write-Host "START:Triggering docker image build for ltsc2019: $updateImageLTSC2019"
     docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag  .
-    Write-Host "END:Triggering docker image build for ltsc2019: $image"
+    Write-Host "END:Triggering docker image build for ltsc2019: $updateImageLTSC2019"
 
-    Write-Host "START:Triggering docker image build for ltsc2022: $image"
     $WINDOWS_VERSION="ltsc2022"
     $updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    Write-Host "START:Triggering docker image build for ltsc2022: $updateImageLTSC2022"
     docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag  .
-    Write-Host "END:Triggering docker image build for ltsc2022: $image"
+    Write-Host "END:Triggering docker image build for ltsc2022: $updateImageLTSC2022"
 
     Write-Host "START:pushing docker image with base image ltsc2019 : $updateImageLTSC2019"
     docker push  $updateImageLTSC2019
@@ -86,9 +86,16 @@ if ($multiArc) {
 
     Write-Host "END:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
 } else {
+    if (($windowsBaseImageVersion -eq "ltsc2019") -or ($windowsBaseImageVersion -eq "ltsc2022")) {
+        Write-Host "Provided baseimage version valid and supported: ${windowsBaseImageVersion}"
+    } else {
+        Write-Host "Provided baseimage version neither valid nor supported: ${windowsBaseImageVersion}" -ForegroundColor Red
+        exit 1
+    }
 
-    Write-Host "START:Triggering docker image build: $image"
-    docker build -t $updateImage  --build-arg IMAGE_TAG=$imageTag  .
+    $WINDOWS_VERSION=$windowsBaseImageVersion
+    Write-Host "START:Triggering docker image build: $image with baseImage version: ${windowsBaseImageVersion}"
+    docker build --isolation=hyperv -t $updateImage  --build-arg WINDOWS_VERSION=$windowsBaseImageVersion  --build-arg IMAGE_TAG=$imageTag  .
     Write-Host "END:Triggering docker image build: $updateImage"
 
     Write-Host "START:pushing docker image : $updateImage"

--- a/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
@@ -7,7 +7,9 @@
 #>
 param(
     [Parameter(mandatory = $true)]
-    [string]$image
+    [string]$image,
+    [Parameter(mandatory = $true)]
+    [bool]$multiArc= $true
 )
 
 $currentdir =  $PSScriptRoot
@@ -55,22 +57,42 @@ Write-Host "changing directory to DockerFile dir: $dockerFileDir"
 Set-Location -Path $dockerFileDir
 
 $updateImage = ${imagerepo} + ":" + ${imageTag}
-Write-Host "START:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
+if ($multiArc) {
+    Write-Host "START:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
+    Write-Host "START:Triggering docker image build for ltsc2019: $image"
+    $WINDOWS_VERSION="ltsc2019"
+    $updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+    Write-Host "END:Triggering docker image build for ltsc2019: $image"
 
-Write-Host "START:Triggering docker image build for ltsc2019: $image"
-$WINDOWS_VERSION="ltsc2019"
-$updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
-docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
-Write-Host "END:Triggering docker image build for ltsc2019: $image"
+    Write-Host "START:Triggering docker image build for ltsc2022: $image"
+    $WINDOWS_VERSION="ltsc2022"
+    $updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
+    docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+    Write-Host "END:Triggering docker image build for ltsc2022: $image"
 
-Write-Host "START:Triggering docker image build for ltsc2022: $image"
-$WINDOWS_VERSION="ltsc2022"
-$updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
-docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
-Write-Host "END:Triggering docker image build for ltsc2022: $image"
+    Write-Host "START:pushing docker image with base image ltsc2019 : $updateImageLTSC2019"
+    docker push  $updateImageLTSC2019
+    Write-Host "END:pushing docker image : $updateImageLTSC2019"
 
-Write-Host "END:Triggering docker image build: $updateImage"
+    Write-Host "START:pushing docker image with base image ltsc2022 : $updateImageLTSC2022"
+    docker push  $updateImageLTSC2022
+    Write-Host "END:pushing docker image : $updateImageLTSC2022"
 
-Write-Host "STAT:pushing docker image : $updateImage"
-docker push  $updateImage
-Write-Host "EnD:pushing docker image : $updateImage"
+    Write-Host "START:Triggering manigest for multi-arc docker image: $updateImage"
+    docker manifest create $updateImage $updateImageLTSC2019 $updateImageLTSC2022
+    docker manifest push $updateImage
+    Write-Host "END:Triggering manifest for multi-arc docker image: $updateImage"
+
+    Write-Host "END:Triggering multi-arc docker image build for ltsc2019 & ltsc2022: $image"
+} else {
+
+    Write-Host "START:Triggering docker image build: $image"
+    docker build -t $updateImage  --build-arg IMAGE_TAG=$imageTag  .
+    Write-Host "END:Triggering docker image build: $updateImage"
+
+    Write-Host "START:pushing docker image : $updateImage"
+    docker push  $updateImage
+    Write-Host "END:pushing docker image : $updateImage"
+}
+

--- a/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
@@ -62,13 +62,13 @@ if ($multiArc) {
     Write-Host "START:Triggering docker image build for ltsc2019: $image"
     $WINDOWS_VERSION="ltsc2019"
     $updateImageLTSC2019 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
-    docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+    docker build --isolation=hyperv -t $updateImageLTSC2019  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag  .
     Write-Host "END:Triggering docker image build for ltsc2019: $image"
 
     Write-Host "START:Triggering docker image build for ltsc2022: $image"
     $WINDOWS_VERSION="ltsc2022"
     $updateImageLTSC2022 = ${imagerepo} + ":" + ${imageTag} + "-" + ${WINDOWS_VERSION}
-    docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION IMAGE_TAG=$imageTag  .
+    docker build --isolation=hyperv -t $updateImageLTSC2022  --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --build-arg IMAGE_TAG=$imageTag  .
     Write-Host "END:Triggering docker image build for ltsc2022: $image"
 
     Write-Host "START:pushing docker image with base image ltsc2019 : $updateImageLTSC2019"

--- a/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
+++ b/kubernetes/windows/dockerbuild/build-and-publish-docker-image.ps1
@@ -93,7 +93,6 @@ if ([string]::IsNullOrEmpty($windowsBaseImageVersion)) {
         exit 1
     }
 
-    $WINDOWS_VERSION=$windowsBaseImageVersion
     Write-Host "START:Triggering docker image build: $image with baseImage version: ${windowsBaseImageVersion}"
     docker build --isolation=hyperv -t $updateImage  --build-arg WINDOWS_VERSION=$windowsBaseImageVersion  --build-arg IMAGE_TAG=$imageTag  .
     Write-Host "END:Triggering docker image build: $updateImage"

--- a/test/prometheus-scraping/win-prometheus-ref-app-ltsc2019.yml
+++ b/test/prometheus-scraping/win-prometheus-ref-app-ltsc2019.yml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: win-prometheus-reference-app-ltsc2019
+spec:
+  selector:
+    matchLabels:
+      app: win-prometheus-reference-app-ltsc2019
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '2112'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: win-prometheus-reference-app-ltsc2019
+    spec:
+      containers:
+        - name: win-prometheus-reference-app-golang
+          image: mcr.microsoft.com/azuremonitor/containerinsights/cidev:win-prometheus-reference-app-golang
+          env:
+            - name: RUN_PERF_TEST
+              value: "false"
+            - name: SCRAPE_INTERVAL
+              value: "60"
+            - name: METRIC_COUNT
+              value: "125000"
+          ports:
+            - containerPort: 2112
+              protocol: TCP
+            - containerPort: 2113
+              protocol: TCP
+        - name: win-prometheus-reference-app-python
+          image: mcr.microsoft.com/azuremonitor/containerinsights/cidev:win-prometheus-reference-app-python
+          ports:
+          - containerPort: 2114
+            protocol: TCP
+      affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+           - matchExpressions:
+             - key: kubernetes.io/os
+               operator: In
+               values:
+               - windows
+             - key: kubernetes.azure.com/os-sku
+               operator: NotIn
+               values:
+               - Windows2022

--- a/test/prometheus-scraping/win-prometheus-ref-app-ltsc2022.yml
+++ b/test/prometheus-scraping/win-prometheus-ref-app-ltsc2022.yml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: win-prometheus-reference-app-ltsc2022
+spec:
+  selector:
+    matchLabels:
+      app: win-prometheus-reference-app-ltsc2022
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '2112'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: win-prometheus-reference-app-ltsc2022
+    spec:
+      containers:
+        - name: win-prometheus-reference-app-golang
+          image: mcr.microsoft.com/azuremonitor/containerinsights/cidev:win-prometheus-reference-app-golang
+          env:
+            - name: RUN_PERF_TEST
+              value: "false"
+            - name: SCRAPE_INTERVAL
+              value: "60"
+            - name: METRIC_COUNT
+              value: "125000"
+          ports:
+            - containerPort: 2112
+              protocol: TCP
+            - containerPort: 2113
+              protocol: TCP
+        - name: win-prometheus-reference-app-python
+          image: mcr.microsoft.com/azuremonitor/containerinsights/cidev:win-prometheus-reference-app-python
+          ports:
+          - containerPort: 2114
+            protocol: TCP
+      affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+           - matchExpressions:
+             - key: kubernetes.io/os
+               operator: In
+               values:
+               - windows
+             - key: kubernetes.azure.com/os-sku
+               operator: In
+               values:
+               - Windows2022

--- a/test/scenario/log-app-win-ltsc2019.yml
+++ b/test/scenario/log-app-win-ltsc2019.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-log-ltsc2019
+  labels:
+    name: windows-log-ltsc2019
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second-log-app
+  namespace: windows-log-ltsc2019
+spec:
+  replicas: 1
+  selector:
+   matchLabels:
+    app: second-log-app
+  template:
+   metadata:
+    labels:
+     app: second-log-app
+   spec:
+    volumes:
+    - name: html
+      emptyDir: {}
+    containers:
+    - name: second-log-app
+      image: mcr.microsoft.com/windows/servercore:ltsc2019
+      command: ["powershell", "-c"]
+      args:
+        - "$counter = 1; For(;;) { echo $counter; $counter++; Start-Sleep -Seconds 1; }"
+      env:
+      - name: RANOMD_ENV_VAR_1
+        value: "#123312'@$98"
+      - name: RANOMD_ENV_VAR_2
+        value: "test"
+    affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+           - matchExpressions:
+             - key: kubernetes.io/os
+               operator: In
+               values:
+               - windows
+             - key: kubernetes.azure.com/os-sku
+               operator: NotIn
+               values:
+               - Windows2022

--- a/test/scenario/log-app-win-ltsc2022.yml
+++ b/test/scenario/log-app-win-ltsc2022.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-log-ltsc2022
+  labels:
+    name: windows-log-ltsc2022
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second-log-app
+  namespace: windows-log-ltsc2022
+spec:
+  replicas: 1
+  selector:
+   matchLabels:
+    app: second-log-app
+  template:
+   metadata:
+    labels:
+     app: second-log-app
+   spec:
+    volumes:
+    - name: html
+      emptyDir: {}
+    containers:
+    - name: second-log-app
+      image: mcr.microsoft.com/windows/servercore:ltsc2022
+      command: ["powershell", "-c"]
+      args:
+        - "$counter = 1; For(;;) { echo $counter; $counter++; Start-Sleep -Seconds 1; }"
+      env:
+      - name: RANOMD_ENV_VAR_1
+        value: "#123312'@$98"
+      - name: RANOMD_ENV_VAR_2
+        value: "test"
+    affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+           - matchExpressions:
+             - key: kubernetes.io/os
+               operator: In
+               values:
+               - windows
+             - key: kubernetes.azure.com/os-sku
+               operator: In
+               values:
+               - Windows2022


### PR DESCRIPTION
This PR has following changes
  -  Updates for building (local & pipeline) of multi-arc image for windows agent (ltsc2019 & ltsc2022)
  -  Readme updates for the local builds of the windows agent
  -  Test yamls for testing of container logs and prometheus scraping ltsc2019 & ltsc2022 
  
  **> Note - No code changes** 

Validation 
   -  Validate all the supported functionalities ( container logs, Prometheus metrics & MDM perf metrics) side by side with ltsc2019 & ltsc2022
   - Validate all the functionalities from Ux
   -  Verified no errors in the logs 
   
Telemetry
   -  No changes required since we already collect OS Image as part of NodeCoreCapacity metric 
   -  Added Telemetry Dashboards to track number of AKS clusters & cores by windows OS Image 

Cluster with WS2019 nodepool & WS2022 nodepool

https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/b4b0cbab-64dc-42bc-9d95-ea7c8d0cf188/resourceGroups/gangams-aks-win22-multi-arc/providers/Microsoft.ContainerService/managedClusters/gangams-aks-win22-multi-arc/overview

Perf Reports
  -    https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/dashboard/arm/subscriptions/692aea0b-2d89-4e7e-ae30-fffe40782ee2/resourcegroups/dashboards/providers/microsoft.portal/dashboards/b4716bba-c37e-42d4-b1ad-9de527f87df6