### PR TITLE
Make custom metrics endpoint configurable to be adapted to edge environments

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -103,6 +103,14 @@ spec:
        {{- end }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
+       {{ if .Values.omsagent.isArcACluster }}
+       - name: IS_ARCA_CLUSTER
+         value: {{ .Values.omsagent.isArcACluster | quote }}
+       {{- end }}
+       {{- if ne .Values.omsagent.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: CUSTOM_METRICS_ENDPOINT
+         value: {{ .Values.omsagent.metricsEndpoint | quote }}
+       {{- end }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -89,6 +89,14 @@ spec:
          value: {{ .Values.omsagent.sidecarscraping | quote }}
        - name: ISTEST
          value: {{ .Values.omsagent.ISTEST | quote }}
+       {{ if .Values.omsagent.isArcACluster }}
+       - name: IS_ARCA_CLUSTER
+         value: {{ .Values.omsagent.isArcACluster | quote }}
+       {{- end }}
+       {{- if ne .Values.omsagent.metricsEndpoint "<your_metrics_endpoint>" }}
+       - name: CUSTOM_METRICS_ENDPOINT
+         value: {{ .Values.omsagent.metricsEndpoint | quote }}
+       {{- end }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -49,6 +49,9 @@ omsagent:
   # This flag used to determine whether to use AAD MSI auth or not for Arc K8s cluster
   useAADAuth: false
 
+  # This flag used to determine whether this cluster is connected to ArcA control plane. This value will be setup before pushed into on-premise ArcA ACR.
+  isArcACluster: false
+
   ## To get your workspace id and key do the following
   ## You can create a Azure Loganalytics workspace from portal.azure.com and get its ID & PRIMARY KEY from 'Advanced Settings' tab in the Ux.
 
@@ -57,6 +60,8 @@ omsagent:
     key: <your_workspace_key>
   domain: opinsights.azure.com
   proxy: <your_proxy_config>
+  # This metricsEndpoint used to define the endpoint custom metrics emit to. If not defined, default public Azure monitoring endpoint '{aks_region}.monitoring.azure.com' will be used.
+  metricsEndpoint: <your_metrics_endpoint>
   env:
     clusterName: <your_cluster_name>
     ## Applicable for only managed clusters hosted in Azure

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -13,6 +13,11 @@ class CustomMetricsUtils
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
+            # If this is cluster is connected to ArcA control plane and metrics endpoint provided, custom metrics shall be emitted.
+            is_arca_cluster = ENV['IS_ARCA_CLUSTER']
+            if is_arca_cluster.to_s.downcase == "true" && !ENV['CUSTOM_METRICS_ENDPOINT'].to_s.empty?
+                return true
+            end
 
             return aks_cloud_environment.to_s.downcase == 'azurepubliccloud'
         end


### PR DESCRIPTION
This changes make custom metrics endpoint configurable, so that extension connected to edge control plane service could emit metrics into monitoring services on edge. This PR containing the following changes:
- Custom metrics endpoint param was added in values.yaml, then be set into environment variables in omsagent yaml files.
- Read metrics endpoint settings from environment variable in out_mdm.rb.
- Make custom metrics check pass on edge env when ArcA (the edge environment product name) flag is set to true.

Ps: The two values will be set by environment admin, rather that end users, so it's not placed in "Azure" section of values.
