### PR TITLE
add integration for azure subnet ip usage

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -16,4 +16,4 @@ CVE-2021-31799
 CVE-2021-28965
 
 #dpkg vulnerability in ubuntu
-CVE-2022-1664
+CVE-2022-1304

--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -806,3 +806,22 @@
 #     ClusterType = "$TELEMETRY_CLUSTER_TYPE"
 #     Computer = "placeholder_hostname"
 #     ControllerType = "$CONTROLLER_TYPE"
+
+## ip subnet usage
+[[inputs.prometheus]]
+  #name_prefix="container.azm.ms/"
+  ## An array of urls to scrape metrics from.
+  urls = $AZMON_INTEGRATION_SUBNET_IP_USAGE_METRICS_URL_LIST_NODE
+
+  metric_version = 2
+  url_tag = "scrapeUrl"
+
+  ## Use bearer token for authorization. ('bearer_token' takes priority)
+  bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  ## Specify timeout duration for slower prometheus clients (default is 3s)
+  response_timeout = "15s"
+
+  ## Optional TLS Config
+  tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  insecure_skip_verify = true

--- a/build/linux/installer/scripts/tomlparser-npm-config.rb
+++ b/build/linux/installer/scripts/tomlparser-npm-config.rb
@@ -18,6 +18,9 @@ require_relative "ConfigParseErrorLogger"
 @npm_node_urls = "[\"http://$NODE_IP:10091/node-metrics\"]"
 @npm_cluster_urls="[\"http://npm-metrics-cluster-service.kube-system:9000/cluster-metrics\"]"
 @npm_basic_drop_metrics_cluster = "[\"npm_ipset_counts\"]"
+@collect_subnet_ip_usage_metrics = false
+@azure_subnet_ip_usage_metrics_node_urls = "[\"http://$NODE_IP:10092/metrics\"]"
+@azure_subnet_ip_usage_default_setting = "[]"
 @tgfConfigFileDS = "/etc/opt/microsoft/docker-cimprov/telegraf.conf"
 @tgfConfigFileRS = "/etc/opt/microsoft/docker-cimprov/telegraf-rs.conf"
 @replicaset = "replicaset"
@@ -43,6 +46,21 @@ end
 
 # Use the ruby structure created after config parsing to set the right values to be used as environment variables
 def populateSettingValuesFromConfigMap(parsedConfig)
+  begin
+    if !parsedConfig.nil? && !parsedConfig[:integrations].nil? && !parsedConfig[:integrations][:azure_subnet_ip_usage].nil? && !parsedConfig[:integrations][:azure_subnet_ip_usage][:enabled].nil?
+        azure_subnet_ip_usage_metrics = parsedConfig[:integrations][:azure_subnet_ip_usage][:enabled].to_s
+        puts "config::azure_subnet_ip_usage::got:integrations.azure_subnet_ip_usage.enabled='#{azure_subnet_ip_usage_metrics}'"
+        if !azure_subnet_ip_usage_metrics.nil? && azure_subnet_ip_usage_metrics.strip.casecmp("true") == 0
+            @collect_azure_subnet_ip_usage_metrics = true
+        else
+            @collect_azure_subnet_ip_usage_metrics = false
+        end
+        puts "config::azure_subnet_ip_usage::got:integrations.azure_subnet_ip_usage.enabled=#{@collect_azure_subnet_ip_usage_metrics}"
+    end
+  rescue => errorStr
+    puts "config::npm::error:Exception while reading config settings for azure_subnet_ip_usage setting - #{errorStr}, using defaults"
+    @collect_azure_subnet_ip_usage_metrics = false
+  end
   begin
     if !parsedConfig.nil? && !parsedConfig[:integrations].nil? && !parsedConfig[:integrations][:azure_network_policy_manager].nil? && !parsedConfig[:integrations][:azure_network_policy_manager][:collect_advanced_metrics].nil?
         advanced_npm_metrics = parsedConfig[:integrations][:azure_network_policy_manager][:collect_advanced_metrics].to_s
@@ -76,7 +94,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
 end
 
 @configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
-puts "****************Start NPM Config Processing********************"
+puts "****************Start NPM & subnet ip usage integrations Config Processing********************"
 if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version , so hardcoding it
   configMapSettings = parseConfigMap
   if !configMapSettings.nil?
@@ -84,10 +102,11 @@ if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVe
   end
 else
   if (File.file?(@configMapMountPath))
-    ConfigParseErrorLogger.logError("config::npm::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
+    ConfigParseErrorLogger.logError("config::integrations::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
   end
   @collect_basic_npm_metrics = false
   @collect_advanced_npm_metrics = false
+  @collect_azure_subnet_ip_usage_metrics = false
 end
 
 
@@ -99,7 +118,7 @@ if controller.casecmp(@replicaset) == 0
   tgfConfigFile = @tgfConfigFileRS
 end
 
-#replace place holders in configuration file
+#replace place holders in configuration file for npm integration
 tgfConfig = File.read(tgfConfigFile) #read returns only after closing the file
 
 if @collect_advanced_npm_metrics == true
@@ -116,8 +135,19 @@ else
   tgfConfig = tgfConfig.gsub("$AZMON_INTEGRATION_NPM_METRICS_DROP_LIST_CLUSTER", @npm_default_setting)
 end
 
+#replace place holders in configuration file for subnet ip usage integration
+if @collect_azure_subnet_ip_usage_metrics == true
+  tgfConfig = tgfConfig.gsub("$AZMON_INTEGRATION_SUBNET_IP_USAGE_METRICS_URL_LIST_NODE", @azure_subnet_ip_usage_metrics_node_urls)
+else
+  tgfConfig = tgfConfig.gsub("$AZMON_INTEGRATION_SUBNET_IP_USAGE_METRICS_URL_LIST_NODE", @azure_subnet_ip_usage_default_setting)
+end
+
 File.open(tgfConfigFile, "w") { |file| file.puts tgfConfig } # 'file' will be closed here after it goes out of scope
-puts "config::npm::Successfully substituted the NPM placeholders into #{tgfConfigFile} file for #{controller}"
+puts "config::integrations::Successfully substituted the placeholders for integrations into #{tgfConfigFile} file for #{controller}"
+
+
+File.open(tgfConfigFile, "w") { |file| file.puts tgfConfig } # 'file' will be closed here after it goes out of scope
+puts "config::integrations::Successfully substituted the integrations placeholders into #{tgfConfigFile} file for #{controller}"
 
 # Write the telemetry to file, so that they can be set as environment variables
 telemetryFile = File.open("integration_npm_config_env_var", "w")
@@ -128,9 +158,12 @@ if !telemetryFile.nil?
   elsif @collect_basic_npm_metrics == true
     telemetryFile.write("export TELEMETRY_NPM_INTEGRATION_METRICS_BASIC=1\n")
   end
+  if @collect_azure_subnet_ip_usage_metrics == true
+    telemetryFile.write("export TELEMETRY_SUBNET_IP_USAGE_INTEGRATION_METRICS=1\n")
+  end
   # Close file after writing all environment variables
   telemetryFile.close
 else
-  puts "config::npm::Exception while opening file for writing NPM telemetry environment variables"
+  puts "config::integrations::Exception while opening file for writing Integrations telemetry environment variables"
   puts "****************End NPM Config Processing********************"
 end

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -141,6 +141,8 @@ data:
     [integrations.azure_network_policy_manager]
         collect_basic_metrics = false
         collect_advanced_metrics = false
+    [integrations.azure_subnet_ip_usage]
+        enabled = false
 
 # Doc - https://github.com/microsoft/Docker-Provider/blob/ci_prod/Documentation/AgentSettings/ReadMe.md
   agent-settings: |-

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -36,6 +36,7 @@ class CAdvisorMetricsAPIClient
   @containerLogsRoute = ENV["AZMON_CONTAINER_LOGS_ROUTE"]
   @npmIntegrationBasic = ENV["TELEMETRY_NPM_INTEGRATION_METRICS_BASIC"]
   @npmIntegrationAdvanced = ENV["TELEMETRY_NPM_INTEGRATION_METRICS_ADVANCED"]
+  @subnetIpUsageMetrics = ENV["TELEMETRY_SUBNET_IP_USAGE_INTEGRATION_METRICS"]
 
   @os_type = ENV["OS_TYPE"]
   if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
@@ -281,6 +282,10 @@ class CAdvisorMetricsAPIClient
                       telemetryProps["int-npm-a"] = "1"
                     elsif (!@npmIntegrationBasic.nil? && !@npmIntegrationBasic.empty?)
                       telemetryProps["int-npm-b"] = "1"
+                    end
+                    # telemetry for subnet ip usage integration
+                    if (!@subnetIpUsageMetrics.nil? && !@subnetIpUsageMetrics.empty?)
+                      telemetryProps["int-ipsubnetusage"] = "1"
                     end
                     #telemetry for Container log schema version clusterContainerLogSchemaVersion
                     if (!@clusterContainerLogSchemaVersion.nil? && !@clusterContainerLogSchemaVersion.empty?)


### PR DESCRIPTION
* Add integration for collecting Subnets IP usage metrics for Azure CNI (turned OFF by default)
* You can see the data in this work book from a sample cluster in my sub - https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/8f6da2d9-ff10-4800-9239-c7e0e8b3407f/resourceGroups/vishwasip/providers/Microsoft.ContainerService/managedClusters/vishwasip/workbooks
* Also added a telemetry point for the integration (to get number of clusters that has this turned ON)
* We need to update our docs (i will create a separate PR after we roll this out) along with Azure network team's doc (they will be updating their docs after we roll out) for this