### PR TITLE
update to use GA labels in place of deprecated beta labels 

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset-windows.yaml
@@ -37,7 +37,7 @@ spec:
       kubernetes.io/os: windows
 {{- else }}
    nodeSelector:
-      beta.kubernetes.io/os: windows
+      kubernetes.io/os: windows
 {{- end }}
    {{- if .Values.omsagent.rbac }}
    serviceAccountName: omsagent

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -112,7 +112,7 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: In
                   values:
                     - linux
@@ -120,7 +120,7 @@ omsagent:
                   operator: NotIn
                   values:
                     - virtual-kubelet
-                - key: beta.kubernetes.io/arch
+                - key: kubernetes.io/arch
                   operator: In
                   values:
                     - amd64
@@ -159,7 +159,7 @@ omsagent:
           nodeSelectorTerms:
             - labelSelector:
               matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: In
                   values:
                     - linux
@@ -171,7 +171,7 @@ omsagent:
                   operator: NotIn
                   values:
                     - master
-                - key: beta.kubernetes.io/arch
+                - key: kubernetes.io/arch
                   operator: In
                   values:
                     - amd64

--- a/kubernetes/omsagent.yaml
+++ b/kubernetes/omsagent.yaml
@@ -791,7 +791,7 @@ spec:
             nodeSelectorTerms:
               - labelSelector:
                 matchExpressions:
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                     - linux
@@ -970,7 +970,7 @@ spec:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
-             - key: beta.kubernetes.io/os
+             - key: kubernetes.io/os
                operator: In
                values:
                - windows

--- a/test/scenario/yamls/many-containers-in-pod.yaml
+++ b/test/scenario/yamls/many-containers-in-pod.yaml
@@ -1117,7 +1117,7 @@ spec:
             sleep 1;
           done
     nodeSelector:
-     beta.kubernetes.io/os: linux
+     kubernetes.io/os: linux
     tolerations:
      - key: "node-role.kubernetes.io/master"
        operator: "Equal"

--- a/test/scenario/yamls/nested-json.yaml
+++ b/test/scenario/yamls/nested-json.yaml
@@ -11,5 +11,5 @@ spec:
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo '{\"container_name\": \"nested-json\", \"pod_name\": \"nested-json\", \"pod_namespace\": \"nested-json\", \"environment\": \"test\", \"logmessage\": { \"msg\": \"hello, world\", \"level\": \"info\"} }'; sleep 30; done"]
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   restartPolicy: OnFailure

--- a/test/scenario/yamls/simple-json.yaml
+++ b/test/scenario/yamls/simple-json.yaml
@@ -11,5 +11,5 @@ spec:
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo '{\"container_name\": \"simple-json\", \"pod_name\": \"simple-json\",\"pod_namespace\": \"simple-json\",\"environment\": \"test\"}'; sleep 30; done"]
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   restartPolicy: OnFailure

--- a/test/scenario/yamls/two-containers-in-pod.yaml
+++ b/test/scenario/yamls/two-containers-in-pod.yaml
@@ -24,4 +24,4 @@ spec:
           sleep 1;
         done
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux


### PR DESCRIPTION
https://kubernetes.io/docs/reference/labels-annotations-taints/

beta.kubernetes.io/arch (deprecated)
This label has been deprecated. Please use kubernetes.io/arch instead.

beta.kubernetes.io/os (deprecated)
This label has been deprecated. Please use kubernetes.io/os instead.
