### PR TITLE
Improve container-azm-ms-agentconfig  configMap comments

### DIFF
--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -66,6 +66,9 @@ data:
         # An array of urls to scrape metrics from.
         # urls = ["http://myurl:9101/metrics"]
 
+        # Example: to scrape the metrics from the Kubernetes API uncomment this line
+        # urls = ["https://kubernetes.default.svc.cluster.local/metrics"]
+
         # An array of Kubernetes services to scrape metrics from.
         # kubernetes_services = ["http://my-service-dns.my-namespace:9102/metrics"]
 

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -102,7 +102,12 @@ data:
 
         ## Uncomment the following settings with valid string arrays for prometheus scraping
 
-        # An array of urls to scrape metrics from. $NODE_IP (all upper case) will substitute of running Node's IP address
+        # An array of urls to scrape metrics from. The string $NODE_IP (all upper case) will make sure the agent will scrape all the Kubernetes nodes in the cluster. Do NOT change the string with actual IP addresses.
+
+        # Example: Scrape the default kubelet prometheus endpoints:
+        # urls = ["https://$NODE_IP:10250/metrics","https://$NODE_IP:10250/metrics/cadvisor","https://$NODE_IP:10250/metrics/probes"]
+
+        # Example: Scrape your custom DaemonSet endpoint:
         # urls = ["http://$NODE_IP:9103/metrics"]
 
         #fieldpass = ["metric_to_pass1", "metric_to_pass12"]


### PR DESCRIPTION
I am updating the configMap template with examples of Prometheus scraping points that are available by default in Kubernetes, so that just uncommenting the examples the configuration is working.