### PR TITLE
flag to ignore proxy settings which are automatically set by arc k8s extension

### DIFF
--- a/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -133,7 +133,7 @@ spec:
         - mountPath: /etc/omsagent-secret
           name: omsagent-secret
           readOnly: true
-        {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) }}
+        {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) (not .Values.omsagent.ignoreExtensionProxySettings) }}
         - mountPath: /etc/ssl/certs/proxy-cert.crt
           subPath: PROXYCERT.crt
           name: omsagent-secret
@@ -207,7 +207,7 @@ spec:
          - mountPath: /etc/omsagent-secret
            name: omsagent-secret
            readOnly: true
-         {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) }}
+         {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) (not .Values.omsagent.ignoreExtensionProxySettings) }}
          - mountPath: /etc/ssl/certs/proxy-cert.crt
            subPath: PROXYCERT.crt
            name: omsagent-secret

--- a/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -121,7 +121,7 @@ spec:
         - mountPath: /etc/omsagent-secret
           name: omsagent-secret
           readOnly: true
-        {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) }}
+        {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) (not .Values.omsagent.ignoreExtensionProxySettings) }}
         - mountPath: /etc/ssl/certs/proxy-cert.crt
           subPath: PROXYCERT.crt
           name: omsagent-secret

--- a/charts/azuremonitor-containers/templates/omsagent-secret.yaml
+++ b/charts/azuremonitor-containers/templates/omsagent-secret.yaml
@@ -13,14 +13,14 @@ data:
   WSID: {{ required "A valid workspace id is required!" .Values.omsagent.secret.wsid | b64enc | quote }}
   KEY: {{ required "A valid workspace key is required!" .Values.omsagent.secret.key | b64enc | quote }}
   DOMAIN: {{ .Values.omsagent.domain | b64enc | quote }}
-  {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.httpsProxy) }}
+  {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.httpsProxy) (not .Values.omsagent.ignoreExtensionProxySettings) }}
   PROXY: {{ .Values.Azure.proxySettings.httpsProxy | b64enc | quote }}
-  {{- else if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.httpProxy) }}
+  {{- else if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.httpProxy) (not .Values.omsagent.ignoreExtensionProxySettings) }}
   PROXY: {{ .Values.Azure.proxySettings.httpProxy | b64enc | quote }}
   {{- else if ne .Values.omsagent.proxy "<your_proxy_config>" }}
   PROXY: {{ .Values.omsagent.proxy | b64enc | quote }}
   {{- end }}
-  {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) }}
+  {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) (not .Values.omsagent.ignoreExtensionProxySettings) }}
   PROXYCERT.crt: {{.Values.Azure.proxySettings.proxyCert | b64enc | quote}}
   {{- end }}
 {{- end }}

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -52,6 +52,9 @@ omsagent:
   # This flag used to determine whether this cluster is connected to ArcA control plane. This value will be setup before pushed into on-premise ArcA ACR.
   isArcACluster: false
 
+  # This flag used to ignore the proxy settings
+  ignoreExtensionProxySettings: false
+
   ## To get your workspace id and key do the following
   ## You can create a Azure Loganalytics workspace from portal.azure.com and get its ID & PRIMARY KEY from 'Advanced Settings' tab in the Ux.
 


### PR DESCRIPTION
flag to ignore proxy settings which are automatically set by arc k8s extension when the cluster has proxy. Incase of the AMPLS and Proxy scenario,  proxy server doesnt know about the AMPLS so added option to ignore proxy settings which customer can apply.  customer who asked this fix for this issue already validated and confirmed the fix working.