### PR TITLE
remove workaround since images are fixed

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -193,9 +193,6 @@ jobs:
         mkdir -p $(Build.ArtifactStagingDirectory)/windows
         cd kubernetes/windows
 
-        # workaround for https://github.com/actions/runner-images/issues/6181
-        New-Item -ItemType SymbolicLink -Path "C:\Windows\SysWOW64\docker.exe" -Target "C:\Windows\System32\docker.exe"
-
         az --version
         az account show
         az account set -s ${{ variables.subscription }}
@@ -238,9 +235,6 @@ jobs:
         mkdir -p $(Build.ArtifactStagingDirectory)/windows
         cd kubernetes/windows
 
-        # workaround for https://github.com/actions/runner-images/issues/6181
-        New-Item -ItemType SymbolicLink -Path "C:\Windows\SysWOW64\docker.exe" -Target "C:\Windows\System32\docker.exe"
-
         az --version
         az account show
         az account set -s ${{ variables.subscription }}
@@ -272,9 +266,6 @@ jobs:
       inlineScript: |
         mkdir -p $(Build.ArtifactStagingDirectory)/windows
         cd kubernetes/windows
-
-        # workaround for https://github.com/actions/runner-images/issues/6181
-        New-Item -ItemType SymbolicLink -Path "C:\Windows\SysWOW64\docker.exe" -Target "C:\Windows\System32\docker.exe"
 
         az --version
         az account show


### PR DESCRIPTION
-  https://github.com/actions/runner-images/pull/6287 fixes the issue behind the workaround