### PR TITLE
Gangams/nov 2022 release tasks 1

### DIFF
--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -328,7 +328,7 @@ function Set-EnvironmentVariables {
 
 function Get-ContainerRuntime {
     # containerd is the default runtime on AKS windows
-    $containerRuntime =
+    $containerRuntime = "containerd"
     #Defaults to use secure port: 10250
     $cAdvisorIsSecure = "true"
     $response = ""

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -443,17 +443,15 @@ function Start-Fluent-Telegraf {
 
     $containerRuntime = Get-ContainerRuntime
 
-    # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
-    # Run fluent-bit as a background job. Switch this to a windows service once fluent-bit supports natively running as a windows service
-    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\fluent-bit\bin\fluent-bit.exe" -ArgumentList @("-c", "C:\etc\fluent-bit\fluent-bit.conf", "-e", "C:\opt\amalogswindows\out_oms.so") }
-
-    #register fluentd as a service and start
-    # there is a known issues with win32-service https://github.com/chef/win32-service/issues/70
     if (![string]::IsNullOrEmpty($containerRuntime) -and [string]$containerRuntime.StartsWith('docker') -eq $false) {
         # change parser from docker to cri if the container runtime is not docker
         Write-Host "changing parser from Docker to CRI since container runtime : $($containerRuntime) and which is non-docker"
         (Get-Content -Path C:/etc/fluent-bit/fluent-bit.conf -Raw) -replace 'docker', 'cri' | Set-Content C:/etc/fluent-bit/fluent-bit.conf
     }
+
+    # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
+    # Run fluent-bit as a background job. Switch this to a windows service once fluent-bit supports natively running as a windows service
+    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\fluent-bit\bin\fluent-bit.exe" -ArgumentList @("-c", "C:\etc\fluent-bit\fluent-bit.conf", "-e", "C:\opt\amalogswindows\out_oms.so") }
 
     # Start telegraf only in sidecar scraping mode
     $sidecarScrapingEnabled = [System.Environment]::GetEnvironmentVariable('SIDECAR_SCRAPING_ENABLED')


### PR DESCRIPTION
This PR has following changes

1.  Making containerd and secure port  as default for Windows which is similar to what we did for Linux.  
 On AKS Windows nodes, containerD available starting from k8s version 1.20 and default and only supported runtime starting from  k8s version 1.23 https://azure.microsoft.com/en-us/updates/generally-available-containerd-support-for-windows-in-aks/
From telemetry, 75% of the clusters with windows are nodes with ContainerD.  
2.  Moving the fluent-bit conf update before fluent-bit process start. 

Validated windows nodes with ContainerD and Docker.