### PR TITLE
Changing ifconfig.co to MCR url

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -12,3 +12,6 @@ CVE-2022-2526
 
 #https://avd.aquasec.com/nvd/cve-2021-33621
 CVE-2021-33621
+
+#https://avd.aquasec.com/nvd/2022/cve-2022-41717/
+CVE-2022-41717

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -353,8 +353,10 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 
       if [ $? -ne 0 ]; then
             registry="https://mcr.microsoft.com/v2/"
-            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
-                  registry=$MCR_URL
+            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ $CLOUD_ENVIRONMENT == "azurechinacloud" ]; then
+                  if [ ! -z "$MCR_URL" ]; then
+                        registry=$MCR_URL
+                  fi
             fi
             echo "The registry is: $registry"
             if [ ! -z "$PROXY_ENDPOINT" ]; then

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -353,10 +353,11 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 
       if [ $? -ne 0 ]; then
             registry="https://mcr.microsoft.com/v2/"
-            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ $CLOUD_ENVIRONMENT == "azurechinacloud" ]; then
-                  if [ ! -z "$MCR_URL" ]; then
-                        registry=$MCR_URL
-                  fi
+            if [ $CLOUD_ENVIRONMENT == "azurechinacloud" ]; then
+                  registry="https://mcr.azk8s.cn/v2/"
+            fi
+            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+                  registry=$MCR_URL
             fi
             if [ -z $registry ]; then
                   echo "The environment variable MCR_URL is not set for CLOUD_ENVIRONMENT: $CLOUD_ENVIRONMENT"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -355,8 +355,7 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
             registry="https://mcr.microsoft.com/v2/"
             if [ $CLOUD_ENVIRONMENT == "azurechinacloud" ]; then
                   registry="https://mcr.azk8s.cn/v2/"
-            fi
-            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+            elif [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
                   registry=$MCR_URL
             fi
             if [ -z $registry ]; then
@@ -364,13 +363,13 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
                   RET=000
             else
                   if [ ! -z "$PROXY_ENDPOINT" ]; then
-                  if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
-                        echo "Making curl request to MCR url with proxy and proxy CA cert"
-                        RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
-                  else
-                        echo "Making curl request to MCR url with proxy"
-                        RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT`
-                  fi
+                        if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
+                              echo "Making curl request to MCR url with proxy and proxy CA cert"
+                              RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
+                        else
+                              echo "Making curl request to MCR url with proxy"
+                              RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT`
+                        fi
                   else
                         echo "Making curl request to MCR url"
                         RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry)

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -334,17 +334,20 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
       fi
 
       if [ $? -ne 0 ]; then
+            registry="mcr.microsoft.com"
+            if  [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+                  registry=$MCR_URL
             if [ ! -z "$PROXY_ENDPOINT" ]; then
                if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
-                  echo "Making curl request to ifconfig.co with proxy and proxy CA cert"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" ifconfig.co --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
+                  echo "Making curl request to MCR url with proxy and proxy CA cert"
+                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/ --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
                else
-                  echo "Making curl request to ifconfig.co with proxy"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" ifconfig.co --proxy $PROXY_ENDPOINT`
+                  echo "Making curl request to MCR url with proxy"
+                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/ --proxy $PROXY_ENDPOINT`
                fi
             else
-                  echo "Making curl request to ifconfig.co"
-                  RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" ifconfig.co)
+                  echo "Making curl request to MCR url"
+                  RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/)
             fi
             if [ $RET -eq 000 ]; then
                   echo "-e error    Error resolving host during the onboarding request. Check the internet connectivity and/or network policy on the cluster"
@@ -352,14 +355,14 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
                   # Retrying here to work around network timing issue
                   if [ ! -z "$PROXY_ENDPOINT" ]; then
                     if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
-                        echo "ifconfig check succeeded, retrying oms endpoint with proxy and proxy CA cert..."
+                        echo "MCR url check succeeded, retrying oms endpoint with proxy and proxy CA cert..."
                         curl --max-time 10 https://$workspaceId.oms.$domain/AgentService.svc/LinuxAgentTopologyRequest --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt
                     else
-                       echo "ifconfig check succeeded, retrying oms endpoint with proxy..."
+                       echo "MCR url check succeeded, retrying oms endpoint with proxy..."
                        curl --max-time 10 https://$workspaceId.oms.$domain/AgentService.svc/LinuxAgentTopologyRequest --proxy $PROXY_ENDPOINT
                     fi
                   else
-                        echo "ifconfig check succeeded, retrying oms endpoint..."
+                        echo "MCR url check succeeded, retrying oms endpoint..."
                         curl --max-time 10 https://$workspaceId.oms.$domain/AgentService.svc/LinuxAgentTopologyRequest
                   fi
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -334,20 +334,21 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
       fi
 
       if [ $? -ne 0 ]; then
-            registry="mcr.microsoft.com"
+            registry="https://mcr.microsoft.com/v2/"
             if  [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
                   registry=$MCR_URL
+            fi
             if [ ! -z "$PROXY_ENDPOINT" ]; then
                if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
                   echo "Making curl request to MCR url with proxy and proxy CA cert"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/ --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
+                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
                else
                   echo "Making curl request to MCR url with proxy"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/ --proxy $PROXY_ENDPOINT`
+                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT`
                fi
             else
                   echo "Making curl request to MCR url"
-                  RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry/v2/)
+                  RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry)
             fi
             if [ $RET -eq 000 ]; then
                   echo "-e error    Error resolving host during the onboarding request. Check the internet connectivity and/or network policy on the cluster"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -358,18 +358,22 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
                         registry=$MCR_URL
                   fi
             fi
-            echo "The registry is: $registry"
-            if [ ! -z "$PROXY_ENDPOINT" ]; then
-               if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
-                  echo "Making curl request to MCR url with proxy and proxy CA cert"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
-               else
-                  echo "Making curl request to MCR url with proxy"
-                  RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT`
-               fi
+            if [ -z $registry ]; then
+                  echo "The environment variable MCR_URL is not set for CLOUD_ENVIRONMENT: $CLOUD_ENVIRONMENT"
+                  RET=000
             else
-                  echo "Making curl request to MCR url"
-                  RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry)
+                  if [ ! -z "$PROXY_ENDPOINT" ]; then
+                  if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
+                        echo "Making curl request to MCR url with proxy and proxy CA cert"
+                        RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT --proxy-cacert /etc/ama-logs-secret/PROXYCERT.crt`
+                  else
+                        echo "Making curl request to MCR url with proxy"
+                        RET=`curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry --proxy $PROXY_ENDPOINT`
+                  fi
+                  else
+                        echo "Making curl request to MCR url"
+                        RET=$(curl --max-time 10 -s -o /dev/null -w "%{http_code}" $registry)
+                  fi
             fi
             if [ $RET -eq 000 ]; then
                   echo "-e error    Error resolving host during the onboarding request. Check the internet connectivity and/or network policy on the cluster"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -263,23 +263,6 @@ if [[ ((! -e "/etc/config/kube.conf") && ("${CONTAINER_TYPE}" == "PrometheusSide
       fi
 fi
 
-# Set environment variable for if public cloud by checking the workspace domain.
-if [ -z $domain ]; then
-      ClOUD_ENVIRONMENT="unknown"
-elif [ $domain == "opinsights.azure.com" ]; then
-      CLOUD_ENVIRONMENT="azurepubliccloud"
-elif [ $domain == "opinsights.azure.cn" ]; then
-      CLOUD_ENVIRONMENT="azurechinacloud"
-elif [ $domain == "opinsights.azure.us" ]; then
-      CLOUD_ENVIRONMENT="azureusgovernmentcloud"
-elif [ $domain == "opinsights.azure.eaglex.ic.gov" ]; then
-      CLOUD_ENVIRONMENT="usnat"
-elif [ $domain == "opinsights.azure.microsoft.scloud" ]; then
-      CLOUD_ENVIRONMENT="ussec"
-fi
-export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
-echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >>~/.bashrc
-
 export PROXY_ENDPOINT=""
 # Check for internet connectivity or workspace deletion
 if [ -e "/etc/ama-logs-secret/WSID" ]; then
@@ -352,7 +335,7 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 
       if [ $? -ne 0 ]; then
             registry="https://mcr.microsoft.com/v2/"
-            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+            if [ ! -z "$MCR_URL" ]; then
                   registry=$MCR_URL
             fi
             echo "The registry is: $registry"
@@ -397,6 +380,23 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 else
       echo "LA Onboarding:Workspace Id not mounted, skipping the telemetry check"
 fi
+
+# Set environment variable for if public cloud by checking the workspace domain.
+if [ -z $domain ]; then
+      ClOUD_ENVIRONMENT="unknown"
+elif [ $domain == "opinsights.azure.com" ]; then
+      CLOUD_ENVIRONMENT="azurepubliccloud"
+elif [ $domain == "opinsights.azure.cn" ]; then
+      CLOUD_ENVIRONMENT="azurechinacloud"
+elif [ $domain == "opinsights.azure.us" ]; then
+      CLOUD_ENVIRONMENT="azureusgovernmentcloud"
+elif [ $domain == "opinsights.azure.eaglex.ic.gov" ]; then
+      CLOUD_ENVIRONMENT="usnat"
+elif [ $domain == "opinsights.azure.microsoft.scloud" ]; then
+      CLOUD_ENVIRONMENT="ussec"
+fi
+export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
+echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >>~/.bashrc
 
 # Copying over CA certs for airgapped clouds. This is needed for Mariner vs Ubuntu hosts.
 # We are unable to tell if the host is Mariner or Ubuntu,

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -335,9 +335,10 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 
       if [ $? -ne 0 ]; then
             registry="https://mcr.microsoft.com/v2/"
-            if  [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+            if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
                   registry=$MCR_URL
             fi
+            echo "The registry is: $registry"
             if [ ! -z "$PROXY_ENDPOINT" ]; then
                if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
                   echo "Making curl request to MCR url with proxy and proxy CA cert"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -263,6 +263,23 @@ if [[ ((! -e "/etc/config/kube.conf") && ("${CONTAINER_TYPE}" == "PrometheusSide
       fi
 fi
 
+# Set environment variable for if public cloud by checking the workspace domain.
+if [ -z $domain ]; then
+      ClOUD_ENVIRONMENT="unknown"
+elif [ $domain == "opinsights.azure.com" ]; then
+      CLOUD_ENVIRONMENT="azurepubliccloud"
+elif [ $domain == "opinsights.azure.cn" ]; then
+      CLOUD_ENVIRONMENT="azurechinacloud"
+elif [ $domain == "opinsights.azure.us" ]; then
+      CLOUD_ENVIRONMENT="azureusgovernmentcloud"
+elif [ $domain == "opinsights.azure.eaglex.ic.gov" ]; then
+      CLOUD_ENVIRONMENT="usnat"
+elif [ $domain == "opinsights.azure.microsoft.scloud" ]; then
+      CLOUD_ENVIRONMENT="ussec"
+fi
+export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
+echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >>~/.bashrc
+
 export PROXY_ENDPOINT=""
 # Check for internet connectivity or workspace deletion
 if [ -e "/etc/ama-logs-secret/WSID" ]; then
@@ -380,23 +397,6 @@ if [ -e "/etc/ama-logs-secret/WSID" ]; then
 else
       echo "LA Onboarding:Workspace Id not mounted, skipping the telemetry check"
 fi
-
-# Set environment variable for if public cloud by checking the workspace domain.
-if [ -z $domain ]; then
-      ClOUD_ENVIRONMENT="unknown"
-elif [ $domain == "opinsights.azure.com" ]; then
-      CLOUD_ENVIRONMENT="azurepubliccloud"
-elif [ $domain == "opinsights.azure.cn" ]; then
-      CLOUD_ENVIRONMENT="azurechinacloud"
-elif [ $domain == "opinsights.azure.us" ]; then
-      CLOUD_ENVIRONMENT="azureusgovernmentcloud"
-elif [ $domain == "opinsights.azure.eaglex.ic.gov" ]; then
-      CLOUD_ENVIRONMENT="usnat"
-elif [ $domain == "opinsights.azure.microsoft.scloud" ]; then
-      CLOUD_ENVIRONMENT="ussec"
-fi
-export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT
-echo "export CLOUD_ENVIRONMENT=$CLOUD_ENVIRONMENT" >>~/.bashrc
 
 # Copying over CA certs for airgapped clouds. This is needed for Mariner vs Ubuntu hosts.
 # We are unable to tell if the host is Mariner or Ubuntu,


### PR DESCRIPTION
- Updating the ifconfig.co with the mcr url to avoid curl requests on any external url

Testing steps: 
- Added the domain name to indicate usnat/ussec/azurechinacloud yaml
- Added the MCR_URLs as environment variables in yaml
- Correct URLs are being picked up as given in environment var for non-public clouds
- mcr.microsoft.com is picked up when domain is not provided. 