### PR TITLE
remove labelSelector

### DIFF
--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -538,17 +538,16 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - labelSelector:
-                matchExpressions:
-      # kubernetes.io/os label doesnt exist in k8s versions < 1.14  so make sure to choose label based on k8s version in aks yaml
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                    - linux
-                  - key: type
-                    operator: NotIn
-                    values:
-                      - virtual-kubelet
+            - matchExpressions:
+              # kubernetes.io/os label doesnt exist in k8s versions < 1.14  so make sure to choose label based on k8s version in aks yaml
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: type
+                operator: NotIn
+                values:
+                  - virtual-kubelet
       # Tolerate a NoSchedule taint on master that ACS Engine sets.
       tolerations:
         - operator: "Exists"
@@ -794,21 +793,20 @@ spec:
                 - managed
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - labelSelector:
-                matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                    - linux
-                  - key: type
-                    operator: NotIn
-                    values:
-                      - virtual-kubelet
-      # The following label selector is removed for AKS, this is only required for non AKS
-                  - key: kubernetes.io/role
-                    operator: NotIn
-                    values:
-                      - master
+            - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                  - linux
+                - key: type
+                  operator: NotIn
+                  values:
+                    - virtual-kubelet
+                # The following label selector is removed for AKS, this is only required for non AKS
+                - key: kubernetes.io/role
+                  operator: NotIn
+                  values:
+                    - master
       # The following tolerations are removed for AKS, this is only required for non AKS
       tolerations:
         - operator: "Exists"


### PR DESCRIPTION
- removes labelSelector from yaml


labelSelector was showing up as null in Request calls to K8s API and this was causing CI/CD pipeline to break. I don't think we need it anyway

Error:

`2022-12-12T21:43:23.8632026Z ##[error]{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"component\":\"ama-logs-agent\",\"tier\":\"node\"},\"name\":\"ama-logs\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"component\":\"ama-logs-agent\",\"tier\":\"node\"}},\"template\":{\"metadata\":{\"annotations\":{\"agentVersion\":\"azure-mdsd-1.17.0\",\"dockerProviderVersion\":\"18.0.1-0\",\"schema-versions\":\"v1\"},\"labels\":{\"component\":\"ama-logs-agent\",\"tier\":\"node\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"labelSelector\":null,\"matchExpressions\":[{\"key\":\"kubernetes.io/os\",\"operator\":\"In\",\"values\":[\"linux\"]},{\"key\":\"type\",\"operator\":\"NotIn\",\"values\":[\"virtual-kubelet\"]}]}]}}},\"containers\":[{\"env\":[{\"name\":\"FBIT_SERVICE_FLUSH_INTERVAL\",\"value\":\"15\"},{\"name\":\"FBIT_TAIL_BUFFER_CHUNK_SIZE\",\"value\":\"1\"},{\"name\":\"FBIT_TAIL_BUFFER_MAX_SIZE\",\"value\":\"1\"},{\"name\":\"AKS_RESOURCE_ID\",\"value\":\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-dev-aks-wcus-rg/providers/Microsoft.ContainerService/managedClusters/ci-dev-aks-wcus\"},{\"name\":\"AKS_REGION\",\"value\":\"westcentralus\"},{\"name\":\"ISTEST\",\"value\":\"true\"},{\"name\":\"EMIT_CACHE_TELEMETRY\",\"value\":\"false\"},{\"name\":\"CONTROLLER_TYPE\",\"value\":\"DaemonSet\"},{\"name\":\"NODE_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.hostIP\"}}},{\"name\":\"USER_ASSIGNED_IDENTITY_CLIENT_ID\",\"value\":\"9be36544-5c79-441d-8edd-2f45b9279b7d\"},{\"name\":\"AZMON_CONTAINERLOGS_ONEAGENT_REGIONS\",\"value\":\"koreacentral,norwayeast,eastus2\"}],\"image\":\"mcr.microsoft.com/azuremonitor/containerinsights/cidev:12082022-742037cc\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"exec\":{\"command\":[\"/bin/bash\",\"-c\",\"/opt/livenessprobe.sh\"]},\"initialDelaySeconds\":60,\"periodSeconds\":60,\"timeoutSeconds\":15},\"name\":\"ama-logs\",\"ports\":[{\"containerPort\":25225,\"protocol\":\"TCP\"},{\"containerPort\":25224,\"protocol\":\"UDP\"}],\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"750Mi\"},\"requests\":{\"cpu\":\"75m\",\"memory\":\"325Mi\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/hostfs\",\"name\":\"host-root\",\"readOnly\":true},{\"mountPath\":\"/var/run/host\",\"name\":\"docker-sock\"},{\"mountPath\":\"/var/run/mdsd-ci\",\"name\":\"mdsd-sock\"},{\"mountPath\":\"/var/log\",\"name\":\"host-log\"},{\"mountPath\":\"/var/lib/docker/containers\",\"name\":\"containerlog-path\",\"readOnly\":true},{\"mountPath\":\"/mnt/docker\",\"name\":\"containerlog-path-2\",\"readOnly\":true},{\"mountPath\":\"/mnt/containers\",\"name\":\"containerlog-path-3\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes/host\",\"name\":\"azure-json-path\"},{\"mountPath\":\"/etc/ama-logs-secret\",\"name\":\"ama-logs-secret\",\"readOnly\":true},{\"mountPath\":\"/etc/config/settings\",\"name\":\"settings-vol-config\",\"readOnly\":true},{\"mountPath\":\"/etc/config/settings/adx\",\"name\":\"ama-logs-adx-secret\",\"readOnly\":true}]},{\"env\":[{\"name\":\"AKS_CLUSTER_NAME\",\"value\":\"VALUE_AKS_CLUSTER_NAME\"},{\"name\":\"AKS_RESOURCE_ID\",\"value\":\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-dev-aks-wcus-rg/providers/Microsoft.ContainerService/managedClusters/ci-dev-aks-wcus\"},{\"name\":\"AKS_REGION\",\"value\":\"westcentralus\"},{\"name\":\"AKS_NODE_RESOURCE_GROUP\",\"value\":\"VALUE_AKS_NODE_RESOURCE_GROUP\"},{\"name\":\"CONTAINER_TYPE\",\"value\":\"PrometheusSidecar\"},{\"name\":\"CONTROLLER_TYPE\",\"value\":\"DaemonSet\"},{\"name\":\"NODE_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.hostIP\"}}},{\"name\":\"USER_ASSIGNED_IDENTITY_CLIENT_ID\",\"value\":\"9be36544-5c79-441d-8edd-2f45b9279b7d\"}],\"image\":\"mcr.microsoft.com/azuremonitor/containerinsights/cidev:12082022-742037cc\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"exec\":{\"command\":[\"/bin/bash\",\"-c\",\"/opt/livenessprobe.sh\"]},\"initialDelaySeconds\":60,\"periodSeconds\":60,\"timeoutSeconds\":15},\"name\":\"ama-logs-prometheus\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"1Gi\"},\"requests\":{\"cpu\":\"75m\",\"memory\":\"225Mi\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/etc/kubernetes/host\",\"name\":\"azure-json-path\"},{\"mountPath\":\"/etc/ama-logs-secret\",\"name\":\"ama-logs-secret\",\"readOnly\":true},{\"mountPath\":\"/etc/config/settings\",\"name\":\"settings-vol-config\",\"readOnly\":true},{\"mountPath\":\"/etc/config/osm-settings\",\"name\":\"osm-settings-vol-config\",\"readOnly\":true}]}],\"dnsConfig\":{\"options\":[{\"name\":\"ndots\",\"value\":\"3\"}]},\"serviceAccountName\":\"ama-logs\",\"tolerations\":[{\"effect\":\"NoSchedule\",\"operator\":\"Exists\"},{\"effect\":\"NoExecute\",\"operator\":\"Exists\"},{\"effect\":\"PreferNoSchedule\",\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/\"},\"name\":\"host-root\"},{\"hostPath\":{\"path\":\"/var/run\"},\"name\":\"docker-sock\"},{\"hostPath\":{\"path\":\"/var/run/mdsd-ci\"},\"name\":\"mdsd-sock\"},{\"hostPath\":{\"path\":\"/etc/hostname\"},\"name\":\"container-hostname\"},{\"hostPath\":{\"path\":\"/var/log\"},\"name\":\"host-log\"},{\"hostPath\":{\"path\":\"/var/lib/docker/containers\"},\"name\":\"containerlog-path\"},{\"hostPath\":{\"path\":\"/mnt/docker\"},\"name\":\"containerlog-path-2\"},{\"hostPath\":{\"path\":\"/mnt/containers\"},\"name\":\"containerlog-path-3\"},{\"hostPath\":{\"path\":\"/etc/kubernetes\"},\"name\":\"azure-json-path\"},{\"name\":\"ama-logs-secret\",\"secret\":{\"secretName\":\"ama-logs-secret\"}},{\"configMap\":{\"name\":\"container-azm-ms-agentconfig\",\"optional\":true},\"name\":\"settings-vol-config\"},{\"name\":\"ama-logs-adx-secret\",\"secret\":{\"optional\":true,\"secretName\":\"ama-logs-adx-secret\"}},{\"configMap\":{\"name\":\"container-azm-ms-osmconfig\",\"optional\":true},\"name\":\"osm-settings-vol-config\"}]}},\"updateStrategy\":{\"type\":\"RollingUpdate\"}}}\n"}},"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"labelSelector":null,"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"type","operator":"NotIn","values":["virtual-kubelet"]}]}]}}}}}}}
`


labelSelector with null value in k8s api call:

```[fasty:/datadrive/ … /arm64-config] % kubectl -v=8 apply -f test.yaml  2>&1 | grep labelSelector                                                                                                                                                                              I1212 22:05:22.956313  587398 request.go:1181] Request Body: {"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"labelSelector":null,"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"type","operator":"NotIn","values":["virtual-kubelet"]}]}]}}}}}}}                                                                                                                                                                               I1212 22:05:22.991713  587398 round_trippers.go:580]     Warning: 299 - "unknown field \"spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].labelSelector\""                                                        Warning: unknown field "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].labelSelector"                                                                                                                           I1212 22:05:23.024814  587398 request.go:1181] Request Body: {"spec":{"strategy":{"$retainKeys":["type"]},"template":{"spec":{"$setElementOrder/containers":[{"name":"ama-logs"}],"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"labelSelector":null,"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"type","operator":"NotIn","values":["virtual-kubelet"]},{"key":"kubernetes.io/role","operator":"NotIn","values":["master"]}]}]}}},"containers":[{"name":"ama-logs","resources":{"limits":{"cpu":1,"memory":"1.25Gi"}}}]}}}}```