### PR TITLE
Add support to custom cert

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -111,6 +111,8 @@ spec:
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
        {{- end }}
+       - name: IS_CUSTOM_CERT
+         value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -102,6 +102,8 @@ spec:
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
        {{- end }}
+       - name: IS_CUSTOM_CERT
+         value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
        securityContext:
          privileged: true
        ports:

--- a/charts/azuremonitor-containers/templates/ama-logs-secret.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-secret.yaml
@@ -20,7 +20,7 @@ data:
   {{- else if ne .Values.amalogs.proxy "<your_proxy_config>" }}
   PROXY: {{ .Values.amalogs.proxy | b64enc | quote }}
   {{- end }}
-  {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.proxyCert) (not .Values.amalogs.ignoreExtensionProxySettings) }}
+  {{- if and (or .Values.Azure.proxySettings.isProxyEnabled .Values.Azure.proxySettings.isCustomCert) (.Values.Azure.proxySettings.proxyCert) (not .Values.amalogs.ignoreExtensionProxySettings) }}
   PROXYCERT.crt: {{.Values.Azure.proxySettings.proxyCert | b64enc | quote}}
   {{- end }}
 {{- end }}

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -19,6 +19,7 @@ Azure:
     httpsProxy: ""
     noProxy: ""
     proxyCert: ""
+    isCustomCert: false
 amalogs:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -433,11 +433,14 @@ fi
 # These need to be copied to a different location for Mariner vs Ubuntu containers.
 # OS_ID here is the container distro.
 # Adding Mariner now even though the elif will never currently evaluate.
-if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
+if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ $IS_CUSTOM_CERT == "true" ]; then
   OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f2 | tr -d '"' | tr -d "'")
   if [ $OS_ID == "mariner" ]; then
     cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
     cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
+    if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
+      cp /etc/ama-logs-secret/PROXYCERT.crt /etc/pki/ca-trust/source/PROXYCERT.crt
+    fi
     update-ca-trust
   else
     if [ $OS_ID != "ubuntu" ]; then
@@ -445,6 +448,9 @@ if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ]; then
     fi
     cp /anchors/ubuntu/* /usr/local/share/ca-certificates/
     cp /anchors/mariner/* /usr/local/share/ca-certificates/
+    if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
+      cp /etc/ama-logs-secret/PROXYCERT.crt /usr/local/share/ca-certificates/PROXYCERT.crt
+    fi
     update-ca-certificates
     cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
   fi


### PR DESCRIPTION
- Add `.Values.Azure.proxySettings.isCustomCert` to `values.yaml`.
- Mount proxy cert if `.Values.Azure.proxySettings.isCustomCert` is set to `true`.
- Trust proxy cert in Linux pods/containers if `Values.Azure.proxySettings.isCustomCert` is set to `true`.