### PR TITLE
Longw/prometheus namespace

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -16,3 +16,5 @@ CVE-2021-33621
 
 #https://avd.aquasec.com/nvd/2022/cve-2022-41717/
 CVE-2022-41717
+#https://avd.aquasec.com/nvd/cve-2022-41721
+CVE-2022-41721

--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -111,6 +111,7 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
           pluginConfigsWithNamespaces += "\n[[inputs.prometheus]]
   interval = \"#{interval}\"
   monitor_kubernetes_pods = true
+  pod_namespace_label_name = \"#{pod_namespace}\"
   pod_scrape_scope = \"#{(@controller.casecmp(@replicaset) == 0) ? "cluster" : "node"}\"
   monitor_kubernetes_pods_namespace = \"#{namespace}\"
   kubernetes_label_selector = \"#{kubernetesLabelSelectors}\"

--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -38,6 +38,7 @@ require "fileutils"
 @responseTimeout = "15s"
 @tlsCa = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 @insecureSkipVerify = true
+@podNamespace = "pod_namespace"
 
 # Checking to see if this is the daemonset or replicaset to parse config accordingly
 @controller = ENV["CONTROLLER_TYPE"]
@@ -111,7 +112,7 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
           pluginConfigsWithNamespaces += "\n[[inputs.prometheus]]
   interval = \"#{interval}\"
   monitor_kubernetes_pods = true
-  pod_namespace_label_name = \"#{pod_namespace}\"
+  pod_namespace_label_name = \"#{@podNamespace}\"
   pod_scrape_scope = \"#{(@controller.casecmp(@replicaset) == 0) ? "cluster" : "node"}\"
   monitor_kubernetes_pods_namespace = \"#{namespace}\"
   kubernetes_label_selector = \"#{kubernetesLabelSelectors}\"


### PR DESCRIPTION
address the prometheus namespace overwritten due to the setting of monitor_kubernetes_pods_namespaces since telegraf only knows how to filter to a single namespace