### PR TITLE
Fixing MUTE_PROM_SIDECAR variable when no config applied

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,3 +17,6 @@ CVE-2021-33621
 CVE-2022-41717
 #https://avd.aquasec.com/nvd/cve-2022-41721
 CVE-2022-41721
+
+GHSA-hxp2-xqf3-v83h
+GHSA-4xgv-j62q-h3rj

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -531,6 +531,8 @@ if [ -e "telemetry_prom_config_env_var" ]; then
             echo $line >>~/.bashrc
       done
       source telemetry_prom_config_env_var
+else
+      setGlobalEnvVar TELEMETRY_CUSTOM_PROM_MONITOR_PODS false
 fi
 
 #Parse sidecar agent settings for custom configuration
@@ -576,13 +578,15 @@ if [[ ( ( ! -e "/etc/config/kube.conf" ) && ( "${CONTAINER_TYPE}" == "Prometheus
                   echo $line >>~/.bashrc
             done
             source integration_osm_config_env_var
+      else
+            setGlobalEnvVar TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT 0
       fi
 fi
 
 # If the prometheus sidecar isn't doing anything then there's no need to run mdsd and telegraf in it.
 if [[ ( "${CONTAINER_TYPE}" == "PrometheusSidecar" ) &&
-      ( "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "false"  || "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "" ) &&
-      ( "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" -eq 0 || "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" == "" ) ]]; then
+      ( "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "false" ) &&
+      ( "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" -eq 0 ) ]]; then
       setGlobalEnvVar MUTE_PROM_SIDECAR true
 else
       setGlobalEnvVar MUTE_PROM_SIDECAR false

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -581,8 +581,8 @@ fi
 
 # If the prometheus sidecar isn't doing anything then there's no need to run mdsd and telegraf in it.
 if [[ ( "${CONTAINER_TYPE}" == "PrometheusSidecar" ) &&
-      ( "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "false" ) &&
-      ( "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" -eq 0 ) ]]; then
+      ( "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "false"  || "${TELEMETRY_CUSTOM_PROM_MONITOR_PODS}" == "" ) &&
+      ( "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" -eq 0 || "${TELEMETRY_OSM_CONFIGURATION_NAMESPACES_COUNT}" == "" ) ]]; then
       setGlobalEnvVar MUTE_PROM_SIDECAR true
 else
       setGlobalEnvVar MUTE_PROM_SIDECAR false


### PR DESCRIPTION
The MUTE_PROM_SIDECAR variable was false even when no config was applied. Fixed it to consider empty variable names as well.

![fix-mute_prom](https://user-images.githubusercontent.com/18661789/219221648-2c70d58a-04ef-415e-8d4e-b88b3e1b7329.png)

