### PR TITLE
address the podName missing bug for windows cluster for containerlogV2

### DIFF
--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1509,13 +1509,18 @@ func GetContainerIDK8sNamespacePodNameFromFileName(filename string) (string, str
 		containerName = filename[start+1 : end]
 	}
 
-	start = strings.Index(filename, "/containers/")
+	pattern := "/containers/"
+	if strings.Contains(filename, "\\containers\\") { // for windows
+		pattern = "\\containers\\"
+	}
+
+	start = strings.Index(filename, pattern)
 	end = strings.Index(filename, "_")
 
 	if start >= end || start == -1 || end == -1 {
 		podName = ""
 	} else {
-		podName = filename[(start + len("/containers/")):end]
+		podName = filename[(start + len(pattern)):end]
 	}
 
 	return id, ns, podName, containerName


### PR DESCRIPTION
address the podName missing bug for windows cluster for containerlogV2, set the pattern default with linux one and if windows is detected, change to windows