### PR TITLE
update wording for Prometheus scrape pods with configmap

### DIFF
--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -75,8 +75,7 @@ data:
 
         # When monitor_kubernetes_pods = true, replicaset will scrape Kubernetes pods for the following prometheus annotations:
         # - prometheus.io/scrape: Enable scraping for this pod
-        # - prometheus.io/scheme: If the metrics endpoint is secured then you will need to
-        #     set this to `https` & most likely set the tls config.
+        # - prometheus.io/scheme: Default is http
         # - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
         # - prometheus.io/port: If port is not 9102 use this annotation
         monitor_kubernetes_pods = false


### PR DESCRIPTION
update wording for Prometheus http config stating that the default is http, we currently do not support https