### PR TITLE
Add support to specify resource endpoint for metrics

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-arc-k8s-crd.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-arc-k8s-crd.yaml
@@ -25,6 +25,8 @@ spec:
   audience: https://monitor.azure.cn/
   {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "azureusgovernmentcloud" }}
   audience: https://monitor.azure.us/
+  {{- else if and .Values.amalogs.isArcACluster (ne .Values.amalogs.tokenAudience "<your_token_audience>") }}
+  audience: {{ .Values.amalogs.tokenAudience | quote }}
   {{- else }}
   audience: https://monitor.azure.com/
   {{- end }}

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -111,6 +111,10 @@ spec:
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
        {{- end }}
+       {{- if ne .Values.amalogs.tokenAudience "<your_token_audience>" }}
+       - name: customResourceEndpoint
+         value: {{ .Values.amalogs.tokenAudience | quote }}
+       {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
        securityContext:

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -102,6 +102,10 @@ spec:
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
        {{- end }}
+       {{- if ne .Values.amalogs.tokenAudience "<your_token_audience>" }}
+       - name: customResourceEndpoint
+         value: {{ .Values.amalogs.tokenAudience | quote }}
+       {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
        securityContext:

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -66,6 +66,7 @@ amalogs:
   proxy: <your_proxy_config>
   # This metricsEndpoint used to define the endpoint custom metrics emit to. If not defined, default public Azure monitoring endpoint '{aks_region}.monitoring.azure.com' will be used.
   metricsEndpoint: <your_metrics_endpoint>
+  tokenAudience: <your_token_audience>
   env:
     clusterName: <your_cluster_name>
     ## Applicable for only managed clusters hosted in Azure

--- a/source/plugins/ruby/out_mdm.rb
+++ b/source/plugins/ruby/out_mdm.rb
@@ -122,6 +122,10 @@ module Fluent::Plugin
             if @isAADMSIAuth && !@isWindows
               @log.info "using IMDS sidecar endpoint for MSI token since its Arc k8s and Linux node"
               @useMsi = true
+              custom_resource_endpoint = ENV["customResourceEndpoint"]
+              if !custom_resource_endpoint.nil? && !custom_resource_endpoint.empty?
+                @@token_resource_audience = custom_resource_endpoint.strip
+              end
               msi_endpoint = @@imds_msi_endpoint_template % { resource: @@token_resource_audience }
               @parsed_token_uri = URI.parse(msi_endpoint)
             else


### PR DESCRIPTION
For cloud other than public Azure, a different resource endpoint for MSI retrieving might be used. This PR adds a method to override the default one used when sending metrics.