### PR TITLE
[ArcA environment only] Add autonomous fqdn to metricsendpoint

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -110,6 +110,9 @@ spec:
        {{- if ne .Values.amalogs.metricsEndpoint "<your_metrics_endpoint>" }}
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
+       {{- else if ne .Values.Azure.proxySettings.autonomousFqdn "<arca_autonomous_fqdn>" }}
+       - name: CUSTOM_METRICS_ENDPOINT
+         value: "https://metricsingestiongateway.monitoring.{{ .Values.Azure.proxySettings.autonomousFqdn }}"
        {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -101,6 +101,9 @@ spec:
        {{- if ne .Values.amalogs.metricsEndpoint "<your_metrics_endpoint>" }}
        - name: CUSTOM_METRICS_ENDPOINT
          value: {{ .Values.amalogs.metricsEndpoint | quote }}
+       {{- else if ne .Values.Azure.proxySettings.autonomousFqdn "<arca_autonomous_fqdn>" }}
+       - name: CUSTOM_METRICS_ENDPOINT
+         value: "https://metricsingestiongateway.monitoring.{{ .Values.Azure.proxySettings.autonomousFqdn }}"
        {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -20,6 +20,7 @@ Azure:
     noProxy: ""
     proxyCert: ""
     isCustomCert: false
+    autonomousFqdn: "<arca_autonomous_fqdn>"
 amalogs:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"


### PR DESCRIPTION
For cloud other than public Azure, like ArcAutonomous, a different metrics endpoint is used. This PR adds another way which provides ArcA FQDN rather than metricsEndpoint directly. This feature provides an common way from ArcA K8s agent to update service endpoints in extension.