### PR TITLE
retry only retriable http status codes

### DIFF
--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -76,8 +76,8 @@ type AgentConfiguration struct {
 			} `json:"channels"`
 			Extensionconfigurations struct {
 				Containerinsights []struct {
-					ID            string   `json:"id"`
-					Originids     []string `json:"originIds"`
+					ID                string   `json:"id"`
+					Originids         []string `json:"originIds"`
 					Extensionsettings struct {
 						DataCollectionSettings struct {
 							Interval               string   `json:"interval"`
@@ -669,8 +669,8 @@ func refreshIngestionAuthToken() {
 	}
 }
 
+//true if httpStatusCode is retriable; otherwise, false.
 func IsRetriableError(httpStatusCode int) bool {
-    // Added 500 to retriable error code per Ingestion team
 	retryableStatusCodes := [6]int{408, 429, 500, 502, 503, 504}
 	for _, code := range retryableStatusCodes {
 		if code == httpStatusCode {
@@ -678,4 +678,9 @@ func IsRetriableError(httpStatusCode int) bool {
 		}
 	}
 	return false
+}
+
+//true if httpStatusCode was in the range 200-299; otherwise, false.
+func IsSuccessStatusCode(httpStatusCode int) bool {
+	return (httpStatusCode >= 200 && httpStatusCode < 300)
 }

--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -671,7 +671,7 @@ func refreshIngestionAuthToken() {
 
 func IsRetriableError(httpStatusCode int) bool {
     // Added 500 to retriable error code per Ingestion team
-	retryableStatusCodes := [6]int{408, 429, 502, 500, 503, 504}
+	retryableStatusCodes := [6]int{408, 429, 500, 502, 503, 504}
 	for _, code := range retryableStatusCodes {
 		if code == httpStatusCode {
 			return true

--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -670,7 +670,8 @@ func refreshIngestionAuthToken() {
 }
 
 func IsRetriableError(httpStatusCode int) bool {
-	retryableStatusCodes := [5]int{408, 429, 502, 503, 504}
+    // Added 500 to retriable error code per Ingestion team
+	retryableStatusCodes := [6]int{408, 429, 502, 500, 503, 504}
 	for _, code := range retryableStatusCodes {
 		if code == httpStatusCode {
 			return true

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1084,7 +1084,7 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 				UpdateNumTelegrafMetricsSentTelemetry(0, 1, 1, 0)
 			}
 			return output.FLB_RETRY
-		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		} else if IsSuccessStatusCode(resp.StatusCode) {
 			numMetrics := len(laMetrics)
 			UpdateNumTelegrafMetricsSentTelemetry(numMetrics, 0, 0, numWinMetricsWithTagsSize64KBorMore)
 			Log("PostTelegrafMetricsToLA::Info:Successfully flushed %v records in %v", numMetrics, elapsed)
@@ -1528,7 +1528,6 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			return output.FLB_RETRY
 		}
 
-		// If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close
 		if resp != nil && resp.Body != nil {
 			defer resp.Body.Close()
 		}
@@ -1538,7 +1537,7 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 				Log("PostDataHelper::Warn::Failed with retriable error code hence retrying .RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
 			}
 			return output.FLB_RETRY
-		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 { // Success is indicated with 2xx status codes
+		} else if IsSuccessStatusCode(resp.StatusCode) {
 			numContainerLogRecords = loglinesCount
 			Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
 		} else {

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1072,7 +1072,11 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 			return output.FLB_RETRY
 		}
 
-		if resp == nil || resp.StatusCode != 200 {
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+
+		if resp == nil || IsRetriableError(resp.StatusCode) {
 			if resp != nil {
 				Log("PostTelegrafMetricsToLA::Error:(retriable) RequestID %s Response Status %v Status Code %v", reqID, resp.Status, resp.StatusCode)
 			}
@@ -1080,13 +1084,13 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 				UpdateNumTelegrafMetricsSentTelemetry(0, 1, 1, 0)
 			}
 			return output.FLB_RETRY
+		} else if (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+			numMetrics := len(laMetrics)
+			UpdateNumTelegrafMetricsSentTelemetry(numMetrics, 0, 0, numWinMetricsWithTagsSize64KBorMore)
+			Log("PostTelegrafMetricsToLA::Info:Successfully flushed %v records in %v", numMetrics, elapsed)
+		} else {
+			Log("PostTelegrafMetricsToLA::Error:Failed with non-retriable error::RequestId %s Status %s Status Code %d", reqID, resp.Status, resp.StatusCode)
 		}
-
-		defer resp.Body.Close()
-
-		numMetrics := len(laMetrics)
-		UpdateNumTelegrafMetricsSentTelemetry(numMetrics, 0, 0, numWinMetricsWithTagsSize64KBorMore)
-		Log("PostTelegrafMetricsToLA::Info:Successfully flushed %v records in %v", numMetrics, elapsed)
 	}
 
 	return output.FLB_OK
@@ -1524,17 +1528,20 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			return output.FLB_RETRY
 		}
 
-		if resp == nil || resp.StatusCode != 200 {
-			if resp != nil {
-				Log("RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
-			}
-			return output.FLB_RETRY
+		// If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
 		}
 
-		defer resp.Body.Close()
-		numContainerLogRecords = loglinesCount
-		Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
-
+		if IsRetriableError(resp.StatusCode) {
+			Log("PostDataHelper::Warn::Failed with retriable error code hence retrying .RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
+			return output.FLB_RETRY
+		} else if (resp.StatusCode >= 200 && resp.StatusCode < 300) { // Success is indicated with 2xx status codes
+			numContainerLogRecords = loglinesCount
+			Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
+		} else {
+			Log("PostDataHelper::Error:: Failed with non-retriable error::RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
+		}
 	}
 
 	ContainerLogTelemetryMutex.Lock()

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1084,7 +1084,7 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 				UpdateNumTelegrafMetricsSentTelemetry(0, 1, 1, 0)
 			}
 			return output.FLB_RETRY
-		} else if (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			numMetrics := len(laMetrics)
 			UpdateNumTelegrafMetricsSentTelemetry(numMetrics, 0, 0, numWinMetricsWithTagsSize64KBorMore)
 			Log("PostTelegrafMetricsToLA::Info:Successfully flushed %v records in %v", numMetrics, elapsed)
@@ -1533,10 +1533,12 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			defer resp.Body.Close()
 		}
 
-		if IsRetriableError(resp.StatusCode) {
-			Log("PostDataHelper::Warn::Failed with retriable error code hence retrying .RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
+		if resp == nil || IsRetriableError(resp.StatusCode) {
+			if resp != nil {
+				Log("PostDataHelper::Warn::Failed with retriable error code hence retrying .RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
+			}
 			return output.FLB_RETRY
-		} else if (resp.StatusCode >= 200 && resp.StatusCode < 300) { // Success is indicated with 2xx status codes
+		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 { // Success is indicated with 2xx status codes
 			numContainerLogRecords = loglinesCount
 			Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
 		} else {


### PR DESCRIPTION
Existing implementation of Windows agent retries non 200 status codes. This can impact the ingestion endpoint for client side errors.  This PR fixes to only retry for the retriable http status codes.