### PR TITLE
Move from omuxsock to omfwd for syslog

### DIFF
--- a/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
+++ b/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
@@ -1,5 +1,10 @@
-$ModLoad omuxsock 
-$OMUxSockSocket /var/run/mdsd-ci/default_syslog.socket 
 template(name="MDSD_RSYSLOG_TraditionalForwardFormat" type="string" string="<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
-$OMUxSockDefaultTemplate MDSD_RSYSLOG_TraditionalForwardFormat
-*.* :omuxsock:
+
+# Forwarding all events through TCP port
+*.* action(type="omfwd"
+template="MDSD_RSYSLOG_TraditionalForwardFormat"
+queue.type="LinkedList"
+action.resumeRetryCount="-1"
+queue.size="50000"
+queue.saveonshutdown="on"
+target="127.0.0.1" Port="28330" Protocol="tcp")

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -451,6 +451,10 @@ spec:
               protocol: TCP
             - containerPort: 25224
               protocol: UDP
+            - name: syslog
+              containerPort: 28330
+              hostPort: 28330
+              protocol: TCP
           volumeMounts:
             - mountPath: /var/run/mdsd-PrometheusSidecar
               name: mdsd-prometheus-sock

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -832,6 +832,8 @@ else
             echo "export MONITORING_USE_GENEVA_CONFIG_SERVICE=$MONITORING_USE_GENEVA_CONFIG_SERVICE" >> ~/.bashrc
             export MDSD_USE_LOCAL_PERSISTENCY="false"
             echo "export MDSD_USE_LOCAL_PERSISTENCY=$MDSD_USE_LOCAL_PERSISTENCY" >> ~/.bashrc
+            export MDSD_DEFAULT_TCP_SYSLOG_PORT=28330
+            echo "export MDSD_DEFAULT_TCP_SYSLOG_PORT=$MDSD_DEFAULT_TCP_SYSLOG_PORT" >> ~/.bashrc
       else
             echo "*** setting up oneagent in legacy auth mode ***"
             CIWORKSPACE_id="$(cat /etc/ama-logs-secret/WSID)"

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -40,9 +40,9 @@ gem uninstall time --version 0.2.0
 gem uninstall uri --version 0.11.0
 
 if [ "${ARCH}" != "arm64" ]; then
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.26.1/azure-mdsd-1.26.1-build.master.97.x86_64.rpm" -O azure-mdsd.rpm
+    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.x86_64.rpm" -O azure-mdsd.rpm
 else
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.26.1/azure-mdsd-1.26.1-build.master.97.aarch64.rpm" -O azure-mdsd.rpm
+    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.aarch64.rpm" -O azure-mdsd.rpm
 fi
 sudo tdnf install -y azure-mdsd.rpm
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d


### PR DESCRIPTION
- uses omfwd for syslog data on port 28330 (same as in VMs)
- updates to MDSD to 1.27.4 which has omfwd support