### PR TITLE
Gangams/make infra geneva config optional in multi tenancy

### DIFF
--- a/build/common/installer/scripts/tomlparser-geneva-config.rb
+++ b/build/common/installer/scripts/tomlparser-geneva-config.rb
@@ -227,7 +227,7 @@ end
 
 def is_configure_geneva_env_vars()
   is_configure = false
-  if (@geneva_logs_integration && !@multi_tenancy) || (@geneva_logs_integration && @multi_tenancy && !@infra_namespaces.empty?)
+  if (@geneva_logs_integration && (!@multi_tenancy || !@infra_namespaces.empty?))
     is_configure = true
   end
   return is_configure

--- a/build/common/installer/scripts/tomlparser-geneva-config.rb
+++ b/build/common/installer/scripts/tomlparser-geneva-config.rb
@@ -225,6 +225,14 @@ def get_command_windows(env_variable_name, env_variable_value)
   return "[System.Environment]::SetEnvironmentVariable(\"#{env_variable_name}\", \"#{env_variable_value}\", \"Process\")" + "\n" + "[System.Environment]::SetEnvironmentVariable(\"#{env_variable_name}\", \"#{env_variable_value}\", \"Machine\")" + "\n"
 end
 
+def is_configure_geneva_env_vars()
+  is_configure = false
+  if (@geneva_logs_integration && !@multi_tenancy) || (@geneva_logs_integration && @multi_tenancy && !@infra_namespaces.empty?)
+    is_configure = true
+  end
+  return is_configure
+end
+
 @configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
 puts "****************Start Agent Integrations Config Processing********************"
 if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version , so hardcoding it
@@ -254,7 +262,7 @@ if !file.nil?
     file.write("export ENABLE_FBIT_THREADING=#{@enable_fbit_threading}\n")
   end
 
-  if @geneva_logs_integration
+  if is_configure_geneva_env_vars()
     file.write("export MONITORING_GCS_ENVIRONMENT=#{@geneva_account_environment}\n")
     file.write("export MONITORING_GCS_NAMESPACE=#{@geneva_account_namespace}\n")
     file.write("export MONITORING_GCS_ACCOUNT=#{@geneva_account_name}\n")
@@ -290,7 +298,7 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
       file.write(commands)
     end
 
-    if @geneva_logs_integration
+    if is_configure_geneva_env_vars()
       commands = get_command_windows("MONITORING_GCS_ENVIRONMENT", @geneva_account_environment)
       file.write(commands)
       commands = get_command_windows("MONITORING_GCS_NAMESPACE", @geneva_account_namespace_windows)

--- a/build/linux/installer/conf/fluent-bit-geneva-telemetry-svc.conf
+++ b/build/linux/installer/conf/fluent-bit-geneva-telemetry-svc.conf
@@ -18,7 +18,7 @@
 
 [INPUT]
     Name              forward
-    Alias             input_forward
+    Alias             input_${GENEVA_TELEMETRY_SERVICE_POD_NAMESPACE}_forward
     Listen            0.0.0.0
     Port              24224
     Buffer_Chunk_Size ${FBIT_INPUT_FORWARD_BUFFER_CHUNK_SIZE}
@@ -26,7 +26,7 @@
 
 [OUTPUT]
     Name                            oms
-    Alias                           output_geneva
+    Alias                           output_${GENEVA_TELEMETRY_SERVICE_POD_NAMESPACE}_geneva
     EnableTelemetry                 true
     Retry_Limit                     10
     TelemetryPushIntervalSeconds    300

--- a/charts/azuremonitor-containers-geneva/templates/deployment.yaml
+++ b/charts/azuremonitor-containers-geneva/templates/deployment.yaml
@@ -18,8 +18,6 @@ spec:
     metadata:
      annotations:
        agentVersion: {{ .Values.image.agentVersion }}
-       prometheus.io/scrape: "true"
-       prometheus.io/port: "9102"
      labels:
        rsName: "ama-logs-geneva"
        aadpodidbinding: {{ .Values.genevaLogsConfig.aadpodidbinding }}

--- a/charts/azuremonitor-containers-geneva/templates/deployment.yaml
+++ b/charts/azuremonitor-containers-geneva/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
          resources:
           {{- toYaml .Values.resources | nindent 12 }}
          env:
+         - name: GENEVA_TELEMETRY_SERVICE_POD_NAMESPACE
+           valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
          - name: ENABLE_FBIT_INTERNAL_METRICS
            value: {{ .Values.enableInternalMetrics | quote }}
          - name: FBIT_SERVICE_GRACE_INTERVAL_SECONDS

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -62,9 +62,7 @@ waitforlisteneronTCPport() {
 }
 
 isGenevaMode() {
-  if [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] && [ "${GENEVA_LOGS_MULTI_TENANCY}" == "false" ]; then
-   true
-  elif [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] && [ "${GENEVA_LOGS_MULTI_TENANCY}" == "true" ] && [ -n "${GENEVA_LOGS_INFRA_NAMESPACES}" ]; then
+  if [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] && { [ "${GENEVA_LOGS_MULTI_TENANCY}" == "false" ] || [ -n "${GENEVA_LOGS_INFRA_NAMESPACES}" ]; }; then
    true
   elif [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then
    true

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -61,6 +61,17 @@ waitforlisteneronTCPport() {
       fi
 }
 
+isGenevaMode() {
+  if [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] && [ "${GENEVA_LOGS_MULTI_TENANCY}" == "false" ]; then
+   true
+  elif [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] && [ "${GENEVA_LOGS_MULTI_TENANCY}" == "true" ] && [ -n "${GENEVA_LOGS_INFRA_NAMESPACES}" ]; then
+   true
+  elif [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then
+   true
+  else
+   false
+  fi
+}
 checkAgentOnboardingStatus() {
       local sleepdurationsecs=1
       local totalsleptsecs=0
@@ -80,7 +91,8 @@ checkAgentOnboardingStatus() {
                         successMessage="Loaded data sources"
                         failureMessage="Failed to load data sources into config"
                   fi
-                  if [ "${GENEVA_LOGS_INTEGRATION}" == "true" ] || [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then
+
+                  if isGenevaMode; then
                         successMessage="Config downloaded and parsed"
                         failureMessage="failed to download start up config"
                   fi
@@ -800,7 +812,7 @@ source /etc/mdsd.d/envmdsd
 MDSD_AAD_MSI_AUTH_ARGS=""
 # check if its AAD Auth MSI mode via USING_AAD_MSI_AUTH
 export AAD_MSI_AUTH_MODE=false
-if [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ] && [ "${GENEVA_LOGS_INTEGRATION}" == "true"  -o "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then
+if [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ] && isGenevaMode; then
     echo "Runnning AMA in Geneva Logs Integration Mode"
     export MONITORING_USE_GENEVA_CONFIG_SERVICE=true
     echo "export MONITORING_USE_GENEVA_CONFIG_SERVICE=true" >> ~/.bashrc

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -716,24 +716,24 @@ function Bootstrap-CACertificates {
     }
 }
 
-function IsGenevaMode {
-    $isgenevaLogsIntegration=$false
-    $isgenevaLogsMultitenancy=$false
+function IsGenevaMode() {
+    $isGenevaLogsIntegration=$false
+    $isGenevaLogsMultitenancy=$false
     $genevaLogsIntegration = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INTEGRATION")
     $genevaLogsMultitenancy = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY")
     $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES")
-    $isgenevaLogsInfraNameSpacesEmpty=$true
+    $isGenevaLogsInfraNameSpacesEmpty=$true
 
     if (![string]::IsNullOrEmpty($genevaLogsIntegration) -and $genevaLogsIntegration.ToLower() -eq 'true') {
-        $isgenevaLogsIntegration=$true
+        $isGenevaLogsIntegration=$true
     }
     if (![string]::IsNullOrEmpty($genevaLogsMultitenancy) -and $genevaLogsMultitenancy.ToLower() -eq 'true') {
-        $isgenevaLogsMultitenancy=$true
+        $isGenevaLogsMultitenancy=$true
     }
     if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
-        $isgenevaLogsInfraNameSpacesEmpty=$false
+        $isGenevaLogsInfraNameSpacesEmpty=$false
     }
-    if ($isgenevaLogsIntegration -and !$isgenevaLogsMultitenancy) -or ($isgenevaLogsIntegration -and $isgenevaLogsMultitenancy -and ! $isgenevaLogsInfraNameSpacesEmpty){
+    if (($isGenevaLogsIntegration -and !$isGenevaLogsMultitenancy) -or ($isGenevaLogsIntegration -and $isGenevaLogsMultitenancy -and ! $isGenevaLogsInfraNameSpacesEmpty)){
       return $true
     }
     return $false

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -733,7 +733,7 @@ function IsGenevaMode() {
     if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
         $isGenevaLogsInfraNameSpacesEmpty=$false
     }
-    if (($isGenevaLogsIntegration -and !$isGenevaLogsMultitenancy) -or ($isGenevaLogsIntegration -and $isGenevaLogsMultitenancy -and ! $isGenevaLogsInfraNameSpacesEmpty)){
+    if ($isGenevaLogsIntegration -and (!$isGenevaLogsMultitenancy -or !$isGenevaLogsInfraNameSpacesEmpty)){
       return $true
     }
     return $false


### PR DESCRIPTION
This PR has following changes ..

1.  Incase of Geneva multi-tenancy mode, if infra namespaces empty, dont start the AMA in 1P mode
2. Remove unused Prometheus scrape annotation ama-logs-geneva pod yaml
3. Add the namespace to alias of fluent-bit plugin in fluent-bit-geneva-telemetry-svc.conf