### PR TITLE
Not install windows pods for arc extension

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -1,4 +1,4 @@
-{{- if or (and ( not (contains "microsoft.kubernetes/connectedclusters" (.Values.Azure.Cluster.ResourceId | lower))) ( not (contains "microsoft.hybridcontainerservice/provisionedclusters" (.Values.Azure.Cluster.ResourceId | lower)))) ( not (.Values.amalogs.useAADAuth)) }}
+{{- if not (.Values.amalogs.useAADAuth) }}
 {{- if and (ne .Values.amalogs.secret.key "<your_workspace_key>") (ne .Values.amalogs.secret.wsid "<your_workspace_id>") (or (ne .Values.amalogs.env.clusterName "<your_cluster_name>") (ne .Values.amalogs.env.clusterId "<your_cluster_id>") (ne .Values.Azure.Cluster.ResourceId "<your_cluster_id>") )}}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -1,4 +1,4 @@
-{{- if and ( not (contains "microsoft.kubernetes/connectedclusters" (.Values.Azure.Cluster.ResourceId | lower))) ( not (contains "microsoft.hybridcontainerservice/provisionedclusters" (.Values.Azure.Cluster.ResourceId | lower))) }}
+{{- if or (and ( not (contains "microsoft.kubernetes/connectedclusters" (.Values.Azure.Cluster.ResourceId | lower))) ( not (contains "microsoft.hybridcontainerservice/provisionedclusters" (.Values.Azure.Cluster.ResourceId | lower)))) ( not (.Values.amalogs.useAADAuth)) }}
 {{- if and (ne .Values.amalogs.secret.key "<your_workspace_key>") (ne .Values.amalogs.secret.wsid "<your_workspace_id>") (or (ne .Values.amalogs.env.clusterName "<your_cluster_name>") (ne .Values.amalogs.env.clusterId "<your_cluster_id>") (ne .Values.Azure.Cluster.ResourceId "<your_cluster_id>") )}}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -155,3 +155,4 @@ spec:
        secretName: ama-logs-adx-secret
        optional: true
 {{- end }}
+{{- end }}

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -1,3 +1,4 @@
+{{- if and ( not (contains "microsoft.kubernetes/connectedclusters" (.Values.Azure.Cluster.ResourceId | lower))) ( not (contains "microsoft.hybridcontainerservice/provisionedclusters" (.Values.Azure.Cluster.ResourceId | lower))) }}
 {{- if and (ne .Values.amalogs.secret.key "<your_workspace_key>") (ne .Values.amalogs.secret.wsid "<your_workspace_id>") (or (ne .Values.amalogs.env.clusterName "<your_cluster_name>") (ne .Values.amalogs.env.clusterId "<your_cluster_id>") (ne .Values.Azure.Cluster.ResourceId "<your_cluster_id>") )}}
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
**EDIT:  Updated to block only for Windows withaadauthmode**

There are 22 Arc clusters which have windows nodes running which will be affected by this change. 

[Query](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2F13d371f9-5a39-46d5-8e1b-60158c49db84%2FresourceGroups%2FContainerInsightsAgent-Prod%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FContainerInsightsAgent-Prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA3WOQWrDQAxF9z2F8CqBujfooiRZmAYKDl2bYUYkKh7JjDR1CTl8ZQgEErKU9P77shIi6ssF5hMWhFjVJG8pIysJK5yCQhOFGaNh2ox%252Bx6INSHnCTkV%252BaZmd3l%252Fpm36UmoZeRuxYLXD0lbAF8nQTcmhHOWo7EyeZtV1yrvvxajCv8USeXh96ncI%252FQ07Qo0otEbsE72CiVoiPq3v%252B7ePzMPS7w9d3v9kN3XbtgkRqxN5zU%252FhWa86h0Hn5srKt1v9w1H49LgEAAA%253D%253D/timespan/P1D)

traces
| where customDimensions has "connectedClusters" or customDimensions has "provisionedCLusters"
| where cloud_RoleInstance contains "ama-logs-windows-"
| project timestamp, customDimensions
| extend ResourceId = tostring(customDimensions.AKS_RESOURCE_ID)
| distinct ResourceId
| summarize count()

count_
--
22
