### PR TITLE
Windows AMA <> Container Log/LogV2 integration

### DIFF
--- a/build/windows/installer/livenessprobe/livenessprobe.cpp
+++ b/build/windows/installer/livenessprobe/livenessprobe.cpp
@@ -15,6 +15,7 @@
 #define FILESYSTEM_WATCHER_FILE_EXISTS 0x00000002
 #define CERTIFICATE_RENEWAL_REQUIRED 0x00000003
 #define FLUENTDWINAKS_SERVICE_NOT_RUNNING 0x00000004
+#define NO_WINDOWS_AMA_MONAGENTCORE_PROCESS 0x00000005
 #define UNEXPECTED_ERROR 0xFFFFFFFF
 
 /*
@@ -131,6 +132,14 @@ int _tmain(int argc, wchar_t *argv[])
     {
         wprintf_s(L"INFO:File:%s exists indicates Certificate needs to be renewed.\n", argv[4]);
         return CERTIFICATE_RENEWAL_REQUIRED;
+    }
+
+    if (argc > 5) {
+        if (!IsProcessRunning(argv[5]))
+        {
+            wprintf_s(L"ERROR:Process:%s is not running\n", argv[5]);
+            return NO_WINDOWS_AMA_MONAGENTCORE_PROCESS;
+        }
     }
 
     return SUCCESS;

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -984,6 +984,33 @@ spec:
           - name: ndots
             value: "3"
      containers:
+      # Uncomment below lines for MSI Auth Mode  testing
+      #  - name: addon-token-adapter-win
+      #    command:
+      #     - addon-token-adapter-win
+      #    args:
+      #     - --secret-namespace=kube-system
+      #     - --secret-name=aad-msi-auth-token
+      #     - --token-server-listening-port=7777
+      #     - --health-server-listening-port=9999
+      #    image: "mcr.microsoft.com/aks/hcp/addon-token-adapter:20230120winbeta"
+      #    imagePullPolicy: Always
+      #    livenessProbe:
+      #     httpGet:
+      #       path: /healthz
+      #       port: 9999
+      #     initialDelaySeconds: 10
+      #     periodSeconds: 60
+      #    resources:
+      #     limits:
+      #       memory: 500Mi
+      #     requests:
+      #       cpu: 100m
+      #       memory: 100Mi
+      #    securityContext:
+      #     capabilities:
+      #       add:
+      #         - NET_ADMIN
        - name: ama-logs-windows
          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.13"
          imagePullPolicy: IfNotPresent
@@ -1074,6 +1101,8 @@ spec:
               - fluentdwinaks
               - "C:\\etc\\amalogswindows\\filesystemwatcher.txt"
               - "C:\\etc\\amalogswindows\\renewcertificate.txt"
+              # Uncomment below lines for MSI Auth Mode  testing
+              # - MonAgentCore.exe
           periodSeconds: 60
           initialDelaySeconds: 180
           timeoutSeconds: 15

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -831,7 +831,7 @@ if ($isGenevaModeVar) {
     #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
 } 
-if (!$isGenevaModeVar -eq $false -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
+if (!$isGenevaModeVar -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
     #start Windows AMA 

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -59,7 +59,8 @@ function Set-CommonAMAEnvironmentVariables {
 }
 
 function Set-AMA3PEnvironmentVariables {
-
+    $aksRegion = [System.Environment]::GetEnvironmentVariable("AKS_REGION", "process")
+    $aksResourceId = [System.Environment]::GetEnvironmentVariable("AKS_RESOURCE_ID", "process")
     Set-ProcessAndMachineEnvVariables "MONITORING_MCS_MODE" "1"
     Set-ProcessAndMachineEnvVariables "customRegion" $aksRegion
     Set-ProcessAndMachineEnvVariables "customResourceId" $aksResourceId

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -44,9 +44,9 @@ function Set-ProcessAndMachineEnvVariables($name, $value) {
     [System.Environment]::SetEnvironmentVariable($name, $value, "Machine")
 }
 
-function Set-GenevaAMAEnvironmentVariables {
+function Set-CommonAMAEnvironmentVariables {
     Set-ProcessAndMachineEnvVariables "MONITORING_DATA_DIRECTORY" "C:\\opt\\windowsazuremonitoragent\\datadirectory"
-    Set-ProcessAndMachineEnvVariables "MONITORING_ROLE_INSTANCE" "MONITORING_ROLE_INSTANCE"
+    Set-ProcessAndMachineEnvVariables "MONITORING_ROLE_INSTANCE" "cloudAgentRoleInstanceIdentity"
     Set-ProcessAndMachineEnvVariables "MA_RoleEnvironment_OsType" "Windows"
     Set-ProcessAndMachineEnvVariables "MONITORING_VERSION" "2.0"
     Set-ProcessAndMachineEnvVariables "MONITORING_ROLE" "cloudAgentRoleIdentity"
@@ -57,6 +57,51 @@ function Set-GenevaAMAEnvironmentVariables {
     Set-ProcessAndMachineEnvVariables "MA_RoleEnvironment_ResourceId" $aksResourceId
     Set-ProcessAndMachineEnvVariables "MA_ENABLE_LARGE_EVENTS" "1"
 }
+
+function Set-AMA3PEnvironmentVariables {
+
+    Set-ProcessAndMachineEnvVariables "MONITORING_MCS_MODE" "1"
+    Set-ProcessAndMachineEnvVariables "customRegion" $aksRegion
+    Set-ProcessAndMachineEnvVariables "customResourceId" $aksResourceId
+    Set-ProcessAndMachineEnvVariables "MCS_CUSTOM_RESOURCE_ID" $aksResourceId
+
+    $domain = "opinsights.azure.com"
+    $mcs_endpoint = "https://monitor.azure.com/"
+    $mcs_globalendpoint = "https://global.handler.control.monitor.azure.com"
+    if (Test-Path /etc/ama-logs-secret/DOMAIN) {
+        $domain = Get-Content /etc/ama-logs-secret/DOMAIN
+        if (![string]::IsNullOrEmpty($domain)) {
+            if ($domain -eq "opinsights.azure.cn") {
+                $mcs_globalendpoint = "https://global.handler.control.monitor.azure.cn"
+                $mcs_endpoint = "https://monitor.azure.cn/"
+            }
+            elseif ($domain -eq "opinsights.azure.us") {
+                $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us"
+                $mcs_endpoint = "https://monitor.azure.us/"
+            }
+            elseif ($domain -eq "opinsights.azure.eaglex.ic.gov") {
+                $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov"
+                $mcs_endpoint = "https://monitor.azure.eaglex.ic.gov/"
+            }
+            elseif ($domain -eq "opinsights.azure.microsoft.scloud") {
+                $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud"
+                $mcs_endpoint = "https://monitor.azure.microsoft.scloud/"
+            }
+            else {
+                Write-Host "Invalid or Unsupported domain name $($domain). EXITING....."
+                exit 1
+            }
+        }
+        else {
+            Write-Host "Domain name either null or empty. EXITING....."
+            exit 1
+        }
+    }
+    Set-ProcessAndMachineEnvVariables "MCS_AZURE_RESOURCE_ENDPOINT" $mcs_endpoint
+    Set-ProcessAndMachineEnvVariables "MCS_GLOBAL_ENDPOINT" $mcs_globalendpoint
+}
+
+
 
 function Generate-GenevaTenantNameSpaceConfig {
      $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
@@ -411,13 +456,19 @@ function Read-Configs {
     }
     if (![string]::IsNullOrEmpty($genevaLogsIntegration) -and $genevaLogsIntegration.ToLower() -eq 'true') {
         Write-Host "Setting Geneva Windows AMA Environment variables"
-        Set-GenevaAMAEnvironmentVariables
+        Set-CommonAMAEnvironmentVariables
         if (![string]::IsNullOrEmpty($genevaLogsMultitenancy) -and $genevaLogsMultitenancy.ToLower() -eq 'true') {
             ruby /opt/amalogswindows/scripts/ruby/fluent-bit-geneva-conf-customizer.rb "common"
             ruby /opt/amalogswindows/scripts/ruby/fluent-bit-geneva-conf-customizer.rb "tenant"
             ruby /opt/amalogswindows/scripts/ruby/fluent-bit-geneva-conf-customizer.rb "infra"
             Generate-GenevaTenantNameSpaceConfig
             Generate-GenevaInfraNameSpaceConfig
+        }
+    } else {
+        $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH", "process")
+        if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
+            Set-CommonAMAEnvironmentVariables
+            Set-AMA3PEnvironmentVariables
         }
     }
 
@@ -763,12 +814,18 @@ if (IsGenevaMode) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
-}
-
-if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
+} elseif (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
+
+    Set-ProcessAndMachineEnvVariables "MONITORING_GCS_AUTH_ID_TYPE" ""
+    #start Windows AMA 
+    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
+    $version = Get-Content -Path "C:\opt\windowsazuremonitoragent\version.txt"
+    Write-Host $version
 }
 else {
+    Write-Host "skipping starting windows ama agent"
+
     Generate-Certificates
     Test-CertificatePath
 }

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -824,13 +824,14 @@ if (![string]::IsNullOrEmpty($requiresCertBootstrap) -and `
 }
 
 $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
+$isGenevaModeVar = IsGenevaMode
 # Geneva mode supported on both AAD MSI Auth and Cert Auth
-if (IsGenevaMode) {
+if ($isGenevaModeVar) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
 } 
-if (!IsGenevaMode -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
+if (!$isGenevaModeVar -eq $false -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
     #start Windows AMA 

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -829,7 +829,8 @@ if (IsGenevaMode) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
-} elseif (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
+} 
+if (!IsGenevaMode -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
     #start Windows AMA 
@@ -838,8 +839,7 @@ if (IsGenevaMode) {
     Write-Host $version
 }
 else {
-    Write-Host "skipping starting windows ama agent"
-
+    Write-Host "Starting Windows in Cert Auth Mode"
     Generate-Certificates
     Test-CertificatePath
 }

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -51,9 +51,25 @@ function Set-CommonAMAEnvironmentVariables {
     Set-ProcessAndMachineEnvVariables "MONITORING_VERSION" "2.0"
     Set-ProcessAndMachineEnvVariables "MONITORING_ROLE" "cloudAgentRoleIdentity"
     Set-ProcessAndMachineEnvVariables "MONITORING_IDENTITY" "use_ip_address"
-    $aksRegion = [System.Environment]::GetEnvironmentVariable("AKS_REGION", "process")
-    Set-ProcessAndMachineEnvVariables "MA_RoleEnvironment_Location" $aksRegion
+
     $aksResourceId = [System.Environment]::GetEnvironmentVariable("AKS_RESOURCE_ID", "process")
+    if (![string]::IsNullOrEmpty($aksResourceId)) {
+        [System.Environment]::SetEnvironmentVariable("AKS_RESOURCE_ID", $aksResourceId, "machine")
+        Write-Host "Successfully set environment variable AKS_RESOURCE_ID - $($aksResourceId) for target 'machine'..."
+    }
+    else {
+        Write-Host "Failed to set environment variable AKS_RESOURCE_ID for target 'machine' since it is either null or empty"
+    }
+
+    $aksRegion = [System.Environment]::GetEnvironmentVariable("AKS_REGION", "process")
+    if (![string]::IsNullOrEmpty($aksRegion)) {
+        [System.Environment]::SetEnvironmentVariable("AKS_REGION", $aksRegion, "machine")
+        Write-Host "Successfully set environment variable AKS_REGION - $($aksRegion) for target 'machine'..."
+    }
+    else {
+        Write-Host "Failed to set environment variable AKS_REGION for target 'machine' since it is either null or empty"
+    }
+    Set-ProcessAndMachineEnvVariables "MA_RoleEnvironment_Location" $aksRegion
     Set-ProcessAndMachineEnvVariables "MA_RoleEnvironment_ResourceId" $aksResourceId
     Set-ProcessAndMachineEnvVariables "MA_ENABLE_LARGE_EVENTS" "1"
 }
@@ -101,8 +117,6 @@ function Set-AMA3PEnvironmentVariables {
     Set-ProcessAndMachineEnvVariables "MCS_AZURE_RESOURCE_ENDPOINT" $mcs_endpoint
     Set-ProcessAndMachineEnvVariables "MCS_GLOBAL_ENDPOINT" $mcs_globalendpoint
 }
-
-
 
 function Generate-GenevaTenantNameSpaceConfig {
      $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
@@ -818,7 +832,6 @@ if (IsGenevaMode) {
 } elseif (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
-    Set-ProcessAndMachineEnvVariables "MONITORING_GCS_AUTH_ID_TYPE" ""
     #start Windows AMA 
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
     $version = Get-Content -Path "C:\opt\windowsazuremonitoragent\version.txt"

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -70,13 +70,19 @@ Write-Host ('Finished Extracting Certificate Generator Package')
 $windowsazuremonitoragent = [System.Environment]::GetEnvironmentVariable('WINDOWS_AMA_URL')
 if ([string]::IsNullOrEmpty($windowsazuremonitoragent)) {
     Write-Host ('Environment variable WINDOWS_AMA_URL is not set. Using default value')
-    $windowsazuremonitoragent = "https://github.com/microsoft/Docker-Provider/releases/download/windows-ama-bits/genevamonitoringagent.46.3.2.zip"
+    $windowsazuremonitoragent = "https://github.com/microsoft/Docker-Provider/releases/download/windows-ama-bits/GenevaMonitoringAgent.46.9.43.zip"
 }
 Write-Host ('Installing Windows Azure Monitor Agent: ' + $windowsazuremonitoragent)
 try {
     Invoke-WebRequest -Uri $windowsazuremonitoragent -OutFile /installation/windowsazuremonitoragent.zip
     Expand-Archive -Path /installation/windowsazuremonitoragent.zip -Destination /installation/windowsazuremonitoragent
     Move-Item -Path /installation/windowsazuremonitoragent -Destination /opt/windowsazuremonitoragent/ -ErrorAction SilentlyContinue
+    if ($windowsazuremonitoragent -match 'https://.*genevamonitoringagent.(.*).zip') {
+        $version = $matches[1]
+        echo "Monitoring Agent Version - $version" > /opt/windowsazuremonitoragent/version.txt
+    } else {
+        echo "Monitoring Agent Version not found" > /opt/windowsazuremonitoragent/version.txt
+    }
 }
 catch {
     $ex = $_.Exception

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -77,11 +77,11 @@ try {
     Invoke-WebRequest -Uri $windowsazuremonitoragent -OutFile /installation/windowsazuremonitoragent.zip
     Expand-Archive -Path /installation/windowsazuremonitoragent.zip -Destination /installation/windowsazuremonitoragent
     Move-Item -Path /installation/windowsazuremonitoragent -Destination /opt/windowsazuremonitoragent/ -ErrorAction SilentlyContinue
-    if ($windowsazuremonitoragent -match 'https://.*genevamonitoringagent.(.*).zip') {
-        $version = $matches[1]
-        echo "Monitoring Agent Version - $version" > /opt/windowsazuremonitoragent/version.txt
-    } else {
+    $version = (Get-Item C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentCore.exe).VersionInfo.ProductVersion
+    if ([string]::IsNullOrEmpty($version)) {
         echo "Monitoring Agent Version not found" > /opt/windowsazuremonitoragent/version.txt
+    } else {
+        echo "Monitoring Agent Version - $version" > /opt/windowsazuremonitoragent/version.txt
     }
 }
 catch {

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -38,18 +38,23 @@ func GetInstance(flbLogger *log.Logger, containertype string) *Extension {
 
 func getExtensionData() (TaggedData, error) {
 	guid := uuid.New()
+	var extensionData TaggedData
 	taggedData := map[string]interface{}{"Request": "AgentTaggedData", "RequestId": guid.String(), "Tag": "ContainerInsights", "Version": "1"}
 	jsonBytes, err := json.Marshal(taggedData)
+	if err != nil {
+		logger.Printf("Error::mdsd/ama::Failed to marshal taggedData data. Error message: %s", string(err.Error()))
+		return extensionData, err
+	}
 
 	responseBytes, err := getExtensionConfigResponse(jsonBytes)
-	var extensionData TaggedData
 	if err != nil {
+		logger.Printf("Error::mdsd/ama::Failed to get config response data. Error message: %s", string(err.Error()))
 		return extensionData, err
 	}
 	var responseObject AgentTaggedDataResponse
 	err = json.Unmarshal(responseBytes, &responseObject)
 	if err != nil {
-		logger.Printf("Error::mdsd/ama::Failed to unmarshal config data. Error message: %s", string(err.Error()))
+		logger.Printf("Error::mdsd/ama::Failed to unmarshal config response data. Error message: %s", string(err.Error()))
 		return extensionData, err
 	}
 

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -53,7 +53,6 @@ func getExtensionData() (TaggedData, error) {
 		return extensionData, err
 	}
 
-	logger.Printf("Info::mdsd/ama::Response from extension: %s", string(responseObject.TaggedData))
 	err = json.Unmarshal([]byte(responseObject.TaggedData), &extensionData)
 
 	return extensionData, err

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 
 	uuid "github.com/google/uuid"
-	"github.com/ugorji/go/codec"
 )
 
 type Extension struct {
 	datatypeStreamIdMap    map[string]string
 	dataCollectionSettings map[string]string
+	datatypeNamedPipeMap   map[string]string
 }
 
 var singleton *Extension
@@ -27,6 +27,7 @@ func GetInstance(flbLogger *log.Logger, containertype string) *Extension {
 		singleton = &Extension{
 			datatypeStreamIdMap:    make(map[string]string),
 			dataCollectionSettings: make(map[string]string),
+			datatypeNamedPipeMap:   make(map[string]string),
 		}
 		flbLogger.Println("Extension Instance created")
 	})
@@ -35,38 +36,33 @@ func GetInstance(flbLogger *log.Logger, containertype string) *Extension {
 	return singleton
 }
 
-func getExtensionConfigs() ([]ExtensionConfig, error) {
+func getExtensionData() (TaggedData, error) {
 	guid := uuid.New()
 	taggedData := map[string]interface{}{"Request": "AgentTaggedData", "RequestId": guid.String(), "Tag": "ContainerInsights", "Version": "1"}
 	jsonBytes, err := json.Marshal(taggedData)
 
-	var data []byte
-	enc := codec.NewEncoderBytes(&data, new(codec.MsgpackHandle))
-	if err := enc.Encode(string(jsonBytes)); err != nil {
-		return nil, err
-	}
-
-	fs := &FluentSocket{}
-	fs.sockAddress = "/var/run/mdsd-ci/default_fluent.socket"
-	if containerType != "" && strings.Compare(strings.ToLower(containerType), "prometheussidecar") == 0 {
-		fs.sockAddress = fmt.Sprintf("/var/run/mdsd-%s/default_fluent.socket", containerType)
-	}
-	
-	responseBytes, err := FluentSocketWriter.writeAndRead(fs, data)
-	defer FluentSocketWriter.disconnect(fs)
+	responseBytes, err := getExtensionConfigResponse(jsonBytes)
+	var extensionData TaggedData
 	if err != nil {
-		return nil, err
+		return extensionData, err
 	}
 	var responseObject AgentTaggedDataResponse
 	err = json.Unmarshal(responseBytes, &responseObject)
 	if err != nil {
-		logger.Printf("Error::mdsd::Failed to unmarshal config data. Error message: %s", string(err.Error()))
-		return nil, err
+		logger.Printf("Error::mdsd/ama::Failed to unmarshal config data. Error message: %s", string(err.Error()))
+		return extensionData, err
 	}
 
-	var extensionData TaggedData
-	json.Unmarshal([]byte(responseObject.TaggedData), &extensionData)
+	err = json.Unmarshal([]byte(responseObject.TaggedData), &extensionData)
 
+	return extensionData, err
+}
+
+func getExtensionConfigs() ([]ExtensionConfig, error) {
+	extensionData, err := getExtensionData()
+	if err != nil {
+		return nil, err
+	}
 	return extensionData.ExtensionConfigs, nil
 }
 
@@ -105,17 +101,29 @@ func getDataCollectionSettings() (map[string]string, error) {
 	return dataCollectionSettings, nil
 }
 
-func getDataTypeToStreamIdMapping() (map[string]string, error) {
+func getDataTypeToStreamIdMapping(hasNamedPipe bool) (map[string]string, error) {
 	datatypeOutputStreamMap := make(map[string]string)
 
 	extensionConfigs, err := getExtensionConfigs()
 	if err != nil {
 		return datatypeOutputStreamMap, err
 	}
+	outputStreamDefinitions := make(map[string]StreamDefinition)
+	if hasNamedPipe == true {
+		extensionData, err := getExtensionData()
+		if err != nil {
+			return datatypeOutputStreamMap, err
+		}
+		outputStreamDefinitions = extensionData.OutputStreamDefinitions
+	}
 	for _, extensionConfig := range extensionConfigs {
 		outputStreams := extensionConfig.OutputStreams
 		for dataType, outputStreamID := range outputStreams {
-			datatypeOutputStreamMap[dataType] = outputStreamID.(string)
+			if hasNamedPipe {
+				datatypeOutputStreamMap[dataType] = outputStreamDefinitions[outputStreamID.(string)].NamedPipe
+			} else {
+				datatypeOutputStreamMap[dataType] = outputStreamID.(string)
+			}
 		}
 	}
 	return datatypeOutputStreamMap, nil
@@ -143,10 +151,25 @@ func (e *Extension) GetOutputStreamId(datatype string, useFromCache bool) string
 		return e.datatypeStreamIdMap[datatype]
 	}
 	var err error
-	e.datatypeStreamIdMap, err = getDataTypeToStreamIdMapping()
+	e.datatypeStreamIdMap, err = getDataTypeToStreamIdMapping(false)
 	if err != nil {
 		message := fmt.Sprintf("Error getting datatype to streamid mapping: %s", err.Error())
 		logger.Printf(message)
 	}
 	return e.datatypeStreamIdMap[datatype]
+}
+
+func (e *Extension) GetOutputNamedPipe(datatype string) string {
+	extensionconfiglock.Lock()
+	defer extensionconfiglock.Unlock()
+	if len(e.datatypeNamedPipeMap) > 0 && e.datatypeNamedPipeMap[datatype] != "" {
+		return e.datatypeNamedPipeMap[datatype]
+	}
+	var err error
+	e.datatypeNamedPipeMap, err = getDataTypeToStreamIdMapping(true)
+	if err != nil {
+		message := fmt.Sprintf("Error getting datatype to named pipe mapping: %s", err.Error())
+		logger.Printf(message)
+	}
+	return e.datatypeNamedPipeMap[datatype]
 }

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -159,10 +159,10 @@ func (e *Extension) GetOutputStreamId(datatype string, useFromCache bool) string
 	return e.datatypeStreamIdMap[datatype]
 }
 
-func (e *Extension) GetOutputNamedPipe(datatype string) string {
+func (e *Extension) GetOutputNamedPipe(datatype string, useFromCache bool) string {
 	extensionconfiglock.Lock()
 	defer extensionconfiglock.Unlock()
-	if len(e.datatypeNamedPipeMap) > 0 && e.datatypeNamedPipeMap[datatype] != "" {
+	if useFromCache && len(e.datatypeNamedPipeMap) > 0 && e.datatypeNamedPipeMap[datatype] != "" {
 		return e.datatypeNamedPipeMap[datatype]
 	}
 	var err error

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -53,6 +53,7 @@ func getExtensionData() (TaggedData, error) {
 		return extensionData, err
 	}
 
+	logger.Printf("Info::mdsd/ama::Response from extension: %s", string(responseObject.TaggedData))
 	err = json.Unmarshal([]byte(responseObject.TaggedData), &extensionData)
 
 	return extensionData, err

--- a/source/plugins/go/src/extension/extension.go
+++ b/source/plugins/go/src/extension/extension.go
@@ -129,10 +129,10 @@ func getDataTypeToStreamIdMapping(hasNamedPipe bool) (map[string]string, error) 
 	return datatypeOutputStreamMap, nil
 }
 
-func (e *Extension) IsContainerLogV2() bool {
+func (e *Extension) IsContainerLogV2(useFromCache bool) bool {
 	extensionconfiglock.Lock()
 	defer extensionconfiglock.Unlock()
-	if len(e.dataCollectionSettings) > 0 && e.dataCollectionSettings["enablecontainerlogv2"] != "" {
+	if useFromCache && len(e.dataCollectionSettings) > 0 && e.dataCollectionSettings["enablecontainerlogv2"] != "" {
 		return e.dataCollectionSettings["enablecontainerlogv2"] == "true"
 	}
 	var err error

--- a/source/plugins/go/src/extension/extension_linux.go
+++ b/source/plugins/go/src/extension/extension_linux.go
@@ -24,7 +24,7 @@ func getExtensionConfigResponse(jsonBytes []byte) ([]byte, error) {
 	defer FluentSocketWriter.disconnect(fs)
 	logger.Printf("Info::mdsd::Making call to FluentSocket: %s to write and read the config data", fs.sockAddress)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	logger.Printf("extensionconfig::getExtensionConfigResponse:: getting extension config from fluent socket-end")
 

--- a/source/plugins/go/src/extension/extension_linux.go
+++ b/source/plugins/go/src/extension/extension_linux.go
@@ -24,6 +24,7 @@ func getExtensionConfigResponse(jsonBytes []byte) ([]byte, error) {
 	defer FluentSocketWriter.disconnect(fs)
 	logger.Printf("Info::mdsd::Making call to FluentSocket: %s to write and read the config data", fs.sockAddress)
 	if err != nil {
+		logger.Printf("Error::mdsd::Failed to write and read the config data. Error message: %s", string(err.Error()))
 		return nil, err
 	}
 	logger.Printf("extensionconfig::getExtensionConfigResponse:: getting extension config from fluent socket-end")

--- a/source/plugins/go/src/extension/extension_linux.go
+++ b/source/plugins/go/src/extension/extension_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package extension
+
+import (
+	"fmt"
+	"github.com/ugorji/go/codec"
+	"strings"
+)
+
+func getExtensionConfigResponse(jsonBytes []byte) ([]byte, error) {
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, new(codec.MsgpackHandle))
+	if err := enc.Encode(string(jsonBytes)); err != nil {
+		return nil, err
+	}
+
+	fs := &FluentSocket{}
+	fs.sockAddress = "/var/run/mdsd-ci/default_fluent.socket"
+	if containerType != "" && strings.Compare(strings.ToLower(containerType), "prometheussidecar") == 0 {
+		fs.sockAddress = fmt.Sprintf("/var/run/mdsd-%s/default_fluent.socket", containerType)
+	}
+	responseBytes, err := FluentSocketWriter.writeAndRead(fs, data)
+	defer FluentSocketWriter.disconnect(fs)
+	logger.Printf("Info::mdsd::Making call to FluentSocket: %s to write and read the config data", fs.sockAddress)
+	if err != nil {
+		return "", err
+	}
+	logger.Printf("extensionconfig::getExtensionConfigResponse:: getting extension config from fluent socket-end")
+
+	return responseBytes, nil
+}

--- a/source/plugins/go/src/extension/extension_windows.go
+++ b/source/plugins/go/src/extension/extension_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package extension
+
+import (
+	winio "github.com/Microsoft/go-winio"
+)
+
+func getExtensionConfigResponse(jsonBytes []byte) ([]byte, error) {
+	pipePath := "\\\\.\\\\pipe\\\\CAgentStream_CloudAgentInfo_AzureMonitorAgent"
+	config_namedpipe, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		logger.Printf("AMA::extensionconfig::getExtensionConfigResponse:: error opening pipe %s: %v", pipePath, err)
+		return nil, err
+	}
+	defer config_namedpipe.Close()
+	number_bytes, err := config_namedpipe.Write(jsonBytes)
+	if err != nil {
+		logger.Printf("AMA::extensionconfig::getExtensionConfigResponse:: write error: %v", err)
+		return nil, err
+	}
+
+	read_buffer := make([]byte, ReadBufferSize)
+	number_bytes, err = config_namedpipe.Read(read_buffer)
+	if err != nil {
+		logger.Printf("AMA::extensionconfig::getExtensionConfigResponse:: read error: %v", err)
+		return nil, err
+	}
+	read_buffer = read_buffer[:number_bytes]
+
+	return read_buffer, nil
+}

--- a/source/plugins/go/src/extension/interfaces.go
+++ b/source/plugins/go/src/extension/interfaces.go
@@ -13,7 +13,7 @@ type AgentTaggedDataResponse struct {
 // TaggedData structure for respone
 type TaggedData struct {
 	SchemaVersion           int                         `json:"schemaVersion"`
-	Version                 int                         `json:"version"`
+	Version                 string                      `json:"version"`
 	ExtensionName           string                      `json:"extensionName"`
 	ExtensionConfigs        []ExtensionConfig           `json:"extensionConfigurations"`
 	OutputStreamDefinitions map[string]StreamDefinition `json:"outputStreamDefinitions"`
@@ -26,9 +26,9 @@ type StreamDefinition struct {
 
 // ExtensionConfig structure for extension definition in DCR
 type ExtensionConfig struct {
-	ID                string                 `json:"id"`
-	OriginIds         []string               `json:"originIds"`
+	ID                string                            `json:"id"`
+	OriginIds         []string                          `json:"originIds"`
 	ExtensionSettings map[string]map[string]interface{} `json:"extensionSettings"`
-	InputStreams      map[string]interface{} `json:"inputStreams"`
-	OutputStreams     map[string]interface{} `json:"outputStreams"`
+	InputStreams      map[string]interface{}            `json:"inputStreams"`
+	OutputStreams     map[string]interface{}            `json:"outputStreams"`
 }

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1162,8 +1162,8 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 		logEntry := ToString(record["log"])
 		logEntryTimeStamp := ToString(record["time"])
 
-		if !IsWindows && !ContainerLogV2ConfigMap && IsAADMSIAuthMode == true && !IsGenevaLogsIntegrationEnabled {
-			if MdsdMsgpUnixSocketClient == nil {
+		if !ContainerLogV2ConfigMap && IsAADMSIAuthMode == true && !IsGenevaLogsIntegrationEnabled {
+			if !IsWindows && MdsdMsgpUnixSocketClient == nil {
 				Log("Error::mdsd::mdsd connection does not exist. re-connecting ...")
 				CreateMDSDClient(ContainerLogV2, ContainerType)
 				if MdsdMsgpUnixSocketClient == nil {

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1174,7 +1174,8 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 					return output.FLB_RETRY
 				}
 			}
-			ContainerLogSchemaV2 = extension.GetInstance(FLBLogger, ContainerType).IsContainerLogV2()
+			useFromCache := checkIfUseFromCache(&MdsdContainerLogTagRefreshTracker)
+			ContainerLogSchemaV2 = extension.GetInstance(FLBLogger, ContainerType).IsContainerLogV2(useFromCache)
 		}
 
 		//ADX Schema & LAv2 schema are almost the same (except resourceId)

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -34,7 +34,7 @@ import (
 // DataType for Container Log
 const ContainerLogDataType = "CONTAINER_LOG_BLOB"
 
-//DataType for Container Log v2
+// DataType for Container Log v2
 const ContainerLogV2DataType = "CONTAINERINSIGHTS_CONTAINERLOGV2"
 
 // DataType for Insights metric
@@ -43,13 +43,13 @@ const InsightsMetricsDataType = "INSIGHTS_METRICS_BLOB"
 // DataType for KubeMonAgentEvent
 const KubeMonAgentEventDataType = "KUBE_MON_AGENT_EVENTS_BLOB"
 
-//env variable which has ResourceId for LA
+// env variable which has ResourceId for LA
 const ResourceIdEnv = "AKS_RESOURCE_ID"
 
-//env variable which has ResourceName for NON-AKS
+// env variable which has ResourceName for NON-AKS
 const ResourceNameEnv = "ACS_RESOURCE_NAME"
 
-//env variable which has container run time name
+// env variable which has container run time name
 const ContainerRuntimeEnv = "CONTAINER_RUNTIME"
 
 // Origin prefix for telegraf Metrics (used as prefix for origin field & prefix for azure monitor specific tags and also for custom-metrics telemetry )
@@ -92,30 +92,30 @@ const kubeMonAgentConfigEventFlushInterval = 60
 const defaultIngestionAuthTokenRefreshIntervalSeconds = 3600
 const agentConfigRefreshIntervalSeconds = 300
 
-//Eventsource name in mdsd
+// Eventsource name in mdsd
 const MdsdContainerLogSourceName = "ContainerLogSource"
 const MdsdContainerLogV2SourceName = "ContainerLogV2Source"
 const MdsdKubeMonAgentEventsSourceName = "KubeMonAgentEventsSource"
 const MdsdInsightsMetricsSourceName = "InsightsMetricsSource"
 
-//container logs route (v2=flush to oneagent, adx= flush to adx ingestion, v1 for ODS Direct)
+// container logs route (v2=flush to oneagent, adx= flush to adx ingestion, v1 for ODS Direct)
 const ContainerLogsV2Route = "v2"
 
 const ContainerLogsADXRoute = "adx"
 
-//container logs schema (v2=ContainerLogsV2 table in LA, anything else ContainerLogs table in LA. This is applicable only if Container logs route is NOT ADX)
+// container logs schema (v2=ContainerLogsV2 table in LA, anything else ContainerLogs table in LA. This is applicable only if Container logs route is NOT ADX)
 const ContainerLogV2SchemaVersion = "v2"
 
-//env variable for AAD MSI Auth mode
+// env variable for AAD MSI Auth mode
 const AADMSIAuthMode = "AAD_MSI_AUTH_MODE"
 
 // Tag prefix of mdsd output streamid for AMA in MSI auth mode
 const MdsdOutputStreamIdTagPrefix = "dcr-"
 
-//env variable to container type
+// env variable to container type
 const ContainerTypeEnv = "CONTAINER_TYPE"
 
-//Default ADX destination database name, can be overriden through configuration
+// Default ADX destination database name, can be overriden through configuration
 const DefaultAdxDatabaseName = "containerinsights"
 
 var (
@@ -329,7 +329,7 @@ type MsgPackEntry struct {
 	Record map[string]string `msg:"record"`
 }
 
-//MsgPackForward represents a series of messagepack events in Forward Mode
+// MsgPackForward represents a series of messagepack events in Forward Mode
 type MsgPackForward struct {
 	Tag     string         `msg:"tag"`
 	Entries []MsgPackEntry `msg:"entries"`
@@ -500,7 +500,7 @@ func populateExcludedStderrNamespaces() {
 	}
 }
 
-//Azure loganalytics metric values have to be numeric, so string values are dropped
+// Azure loganalytics metric values have to be numeric, so string values are dropped
 func convert(in interface{}) (float64, bool) {
 	switch v := in.(type) {
 	case int64:
@@ -844,7 +844,7 @@ func flushKubeMonAgentEventRecords() {
 	}
 }
 
-//Translates telegraf time series to one or more Azure loganalytics metric(s)
+// Translates telegraf time series to one or more Azure loganalytics metric(s)
 func translateTelegrafMetrics(m map[interface{}]interface{}) ([]*laTelegrafMetric, error) {
 
 	var laMetrics []*laTelegrafMetric
@@ -1341,31 +1341,35 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			msgpBytes = msgp.AppendInt64(msgpBytes, batchTime)
 			msgpBytes = msgp.AppendMapStrStr(msgpBytes, fluentForward.Entries[entry].Record)
 		}
-		if IsWindows && IsGenevaLogsIntegrationEnabled {
-			if ContainerLogNamedPipe == nil {
-				Log("Error::AMA:: The connection to named pipe was nil. re-connecting...")
-				CreateWindowsNamedPipesClient(getGenevaWindowsNamedPipeName())
-			}
-			if ContainerLogNamedPipe == nil {
-				Log("Error::AMA::Cannot create the named pipe connection")
-				ContainerLogTelemetryMutex.Lock()
-				defer ContainerLogTelemetryMutex.Unlock()
-				ContainerLogsWindowsAMAClientCreateErrors += 1
-				return output.FLB_RETRY
-			}
-			Log("Info::AMA::Starting to write container logs to named pipe")
-			deadline := 10 * time.Second
-			ContainerLogNamedPipe.SetWriteDeadline(time.Now().Add(deadline))
-			n, err := ContainerLogNamedPipe.Write(msgpBytes)
-			if err != nil {
-				Log("Error::AMA::Failed to write to AMA %d records. Will retry ... error : %s", len(msgPackEntries), err.Error())
-				ContainerLogTelemetryMutex.Lock()
-				defer ContainerLogTelemetryMutex.Unlock()
-				ContainerLogsSendErrorsToWindowsAMAFromFluent += 1
-				return output.FLB_RETRY
+
+		if IsWindows {
+			var datatype string
+			if ContainerLogSchemaV2 {
+				datatype = ContainerLogV2DataType
 			} else {
-				numContainerLogRecords = len(msgPackEntries)
-				Log("Success::AMA::Successfully flushed %d container log records that was %d bytes to AMA ", numContainerLogRecords, n)
+				datatype = ContainerLogDataType
+			}
+			if CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled) {
+				Log("Info::AMA::Starting to write container logs to named pipe")
+				deadline := 10 * time.Second
+				ContainerLogNamedPipe.SetWriteDeadline(time.Now().Add(deadline))
+				n, err := ContainerLogNamedPipe.Write(msgpBytes)
+				if err != nil {
+					Log("Error::AMA::Failed to write to AMA %d records. Will retry ... error : %s", len(msgPackEntries), err.Error())
+					if ContainerLogNamedPipe != nil {
+						ContainerLogNamedPipe.Close()
+						ContainerLogNamedPipe = nil
+					}
+					ContainerLogTelemetryMutex.Lock()
+					defer ContainerLogTelemetryMutex.Unlock()
+					ContainerLogsSendErrorsToWindowsAMAFromFluent += 1
+					return output.FLB_RETRY
+				} else {
+					numContainerLogRecords = len(msgPackEntries)
+					Log("Success::AMA::Successfully flushed %d container log records that was %d bytes to AMA ", numContainerLogRecords, n)
+				}
+			} else {
+				return output.FLB_RETRY
 			}
 		} else {
 			if MdsdMsgpUnixSocketClient == nil {
@@ -1502,18 +1506,6 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			req.Header.Set("x-ms-AzureResourceId", ResourceID)
 		}
 
-		if IsAADMSIAuthMode == true {
-			IngestionAuthTokenUpdateMutex.Lock()
-			ingestionAuthToken := ODSIngestionAuthToken
-			IngestionAuthTokenUpdateMutex.Unlock()
-			if ingestionAuthToken == "" {
-				Log("Error::ODS Ingestion Auth Token is empty. Please check error log.")
-				return output.FLB_RETRY
-			}
-			// add authorization header to the req
-			req.Header.Set("Authorization", "Bearer "+ingestionAuthToken)
-		}
-
 		resp, err := HTTPClient.Do(req)
 		elapsed = time.Since(start)
 
@@ -1528,21 +1520,17 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			return output.FLB_RETRY
 		}
 
-		if resp != nil && resp.Body != nil {
-			defer resp.Body.Close()
-		}
-
-		if resp == nil || IsRetriableError(resp.StatusCode) {
+		if resp == nil || resp.StatusCode != 200 {
 			if resp != nil {
-				Log("PostDataHelper::Warn::Failed with retriable error code hence retrying .RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
+				Log("RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
 			}
 			return output.FLB_RETRY
-		} else if IsSuccessStatusCode(resp.StatusCode) {
-			numContainerLogRecords = loglinesCount
-			Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
-		} else {
-			Log("PostDataHelper::Error:: Failed with non-retriable error::RequestId %s Status %s Status Code %d", reqId, resp.Status, resp.StatusCode)
 		}
+
+		defer resp.Body.Close()
+		numContainerLogRecords = loglinesCount
+		Log("PostDataHelper::Info::Successfully flushed %d %s records to ODS in %s", numContainerLogRecords, recordType, elapsed)
+
 	}
 
 	ContainerLogTelemetryMutex.Lock()
@@ -1865,33 +1853,10 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 			Log("Routing container logs thru %s route...", ContainerLogsADXRoute)
 			fmt.Fprintf(os.Stdout, "Routing container logs thru %s route...\n", ContainerLogsADXRoute)
 		}
-	} else if strings.Compare(strings.ToLower(osType), "windows") != 0 { //for linux, oneagent will be default route
+	} else if IsWindows == false || IsAADMSIAuthMode { //for linux and windows AadMSIAuth, oneagent will be default route
 		ContainerLogsRouteV2 = true //default is mdsd route
 		Log("Routing container logs thru %s route...", ContainerLogsRoute)
 		fmt.Fprintf(os.Stdout, "Routing container logs thru %s route... \n", ContainerLogsRoute)
-	}
-
-	if ContainerLogsRouteV2 == true {
-		if IsWindows {
-			if IsGenevaLogsIntegrationEnabled {
-				CreateWindowsNamedPipesClient(getGenevaWindowsNamedPipeName())
-				Log("Creating HTTP Client for insights metrics since OS Platform is Windows and Configured in Geneva Logs Integration Mode")
-				CreateHTTPClient()
-			}
-		} else {
-			CreateMDSDClient(ContainerLogV2, ContainerType)
-		}
-	} else if ContainerLogsRouteADX == true {
-		CreateADXClient()
-	} else { // v1 or windows
-		Log("Creating HTTP Client since either OS Platform is Windows or configmap configured with fallback option for ODS direct")
-		CreateHTTPClient()
-	}
-
-	if IsWindows == false { // mdsd linux specific
-		Log("Creating MDSD clients for KubeMonAgentEvents & InsightsMetrics")
-		CreateMDSDClient(KubeMonAgentEvents, ContainerType)
-		CreateMDSDClient(InsightsMetrics, ContainerType)
 	}
 
 	ContainerLogSchemaVersion := strings.TrimSpace(strings.ToLower(os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION")))
@@ -1904,6 +1869,34 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		ContainerLogSchemaV2 = true
 		Log("Container logs schema=%s", ContainerLogV2SchemaVersion)
 		fmt.Fprintf(os.Stdout, "Container logs schema=%s... \n", ContainerLogV2SchemaVersion)
+	}
+
+	if ContainerLogsRouteV2 == true {
+		if IsWindows {
+			var datatype string
+			if ContainerLogSchemaV2 {
+				datatype = ContainerLogV2DataType
+			} else {
+				datatype = ContainerLogDataType
+			}
+			CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled)
+		} else {
+			CreateMDSDClient(ContainerLogV2, ContainerType)
+		}
+	} else if ContainerLogsRouteADX == true {
+		CreateADXClient()
+	}
+	if IsWindows || (!ContainerLogsRouteV2 && !ContainerLogsRouteADX) {
+		// windows for both Geneva and 3P for insights metrics and for ContainerLog in legacy auth
+		// configmap configured for direct ODS route
+		Log("Creating HTTP Client since either OS Platform is Windows or configmap configured with fallback option for ODS direct")
+		CreateHTTPClient()
+	}
+
+	if IsWindows == false { // mdsd linux specific
+		Log("Creating MDSD clients for KubeMonAgentEvents & InsightsMetrics")
+		CreateMDSDClient(KubeMonAgentEvents, ContainerType)
+		CreateMDSDClient(InsightsMetrics, ContainerType)
 	}
 
 	if strings.Compare(strings.ToLower(os.Getenv("CONTROLLER_TYPE")), "daemonset") == 0 {

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1349,7 +1349,7 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			} else {
 				datatype = ContainerLogDataType
 			}
-			if CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled) {
+			if CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker) {
 				Log("Info::AMA::Starting to write container logs to named pipe")
 				deadline := 10 * time.Second
 				ContainerLogNamedPipe.SetWriteDeadline(time.Now().Add(deadline))
@@ -1875,6 +1875,12 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		fmt.Fprintf(os.Stdout, "Container logs schema=%s... \n", ContainerLogV2SchemaVersion)
 	}
 
+	MdsdInsightsMetricsTagName = MdsdInsightsMetricsSourceName
+	MdsdKubeMonAgentEventsTagName = MdsdKubeMonAgentEventsSourceName
+	MdsdKubeMonAgentEventsTagRefreshTracker = time.Now()
+	MdsdInsightsMetricsTagRefreshTracker = time.Now()
+	MdsdContainerLogTagRefreshTracker = time.Now()
+
 	if ContainerLogsRouteV2 == true {
 		if IsWindows {
 			var datatype string
@@ -1883,7 +1889,7 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 			} else {
 				datatype = ContainerLogDataType
 			}
-			CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled)
+			CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker)
 		} else {
 			CreateMDSDClient(ContainerLogV2, ContainerType)
 		}
@@ -1920,11 +1926,6 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		Log("Running in replicaset. Disabling container enrichment caching & updates \n")
 	}
 
-	MdsdInsightsMetricsTagName = MdsdInsightsMetricsSourceName
-	MdsdKubeMonAgentEventsTagName = MdsdKubeMonAgentEventsSourceName
-	MdsdKubeMonAgentEventsTagRefreshTracker = time.Now()
-	MdsdInsightsMetricsTagRefreshTracker = time.Now()
-	MdsdContainerLogTagRefreshTracker = time.Now()
 	Log("ContainerLogsRouteADX: %v, IsWindows: %v, IsAADMSIAuthMode = %v IsGenevaLogsIntegrationEnabled = %v \n", ContainerLogsRouteADX, IsWindows, IsAADMSIAuthMode, IsGenevaLogsIntegrationEnabled)
 	if !ContainerLogsRouteADX && IsWindows && IsAADMSIAuthMode {
 		Log("defaultIngestionAuthTokenRefreshIntervalSeconds = %d \n", defaultIngestionAuthTokenRefreshIntervalSeconds)

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1350,7 +1350,7 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			} else {
 				datatype = ContainerLogDataType
 			}
-			if CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker) {
+			if EnsureGenevaOr3PNamedPipeExists(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker) {
 				Log("Info::AMA::Starting to write container logs to named pipe")
 				deadline := 10 * time.Second
 				ContainerLogNamedPipe.SetWriteDeadline(time.Now().Add(deadline))
@@ -1890,7 +1890,7 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 			} else {
 				datatype = ContainerLogDataType
 			}
-			CreateGenevaOr3PNamedPipe(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker)
+			EnsureGenevaOr3PNamedPipeExists(&ContainerLogNamedPipe, datatype, &ContainerLogsWindowsAMAClientCreateErrors, IsGenevaLogsIntegrationEnabled, &MdsdContainerLogTagRefreshTracker)
 		} else {
 			CreateMDSDClient(ContainerLogV2, ContainerType)
 		}

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -160,6 +160,8 @@ func SendContainerLogPluginMetrics(telemetryPushIntervalProperty string) {
 		AgentLogProcessingMaxLatencyMsContainer = ""
 		ContainerLogsSendErrorsToMDSDFromFluent = 0.0
 		ContainerLogsMDSDClientCreateErrors = 0.0
+		ContainerLogsSendErrorsToWindowsAMAFromFluent = 0.0
+		ContainerLogsWindowsAMAClientCreateErrors = 0.0
 		ContainerLogsSendErrorsToADXFromFluent = 0.0
 		ContainerLogsSendErrorsToWindowsAMAFromFluent = 0.0
 		ContainerLogsWindowsAMAClientCreateErrors = 0.0

--- a/source/plugins/go/src/utils.go
+++ b/source/plugins/go/src/utils.go
@@ -122,7 +122,7 @@ func ToString(s interface{}) string {
 	}
 }
 
-//mdsdSocketClient to write msgp messages
+// mdsdSocketClient to write msgp messages
 func CreateMDSDClient(dataType DataType, containerType string) {
 	mdsdfluentSocket := "/var/run/mdsd-ci/default_fluent.socket"
 	if containerType != "" && strings.Compare(strings.ToLower(containerType), "prometheussidecar") == 0 {
@@ -186,7 +186,7 @@ func CreateMDSDClient(dataType DataType, containerType string) {
 	}
 }
 
-//ADX client to write to ADX
+// ADX client to write to ADX
 func CreateADXClient() {
 
 	if ADXIngestor != nil {
@@ -270,7 +270,7 @@ func convertMsgPackEntriesToMsgpBytes(fluentForwardTag string, msgPackEntries []
 	return msgpBytes
 }
 
-//namedpipe format => CAgentStream_<pipeNamedDefinedXMLConfig>_<genevaNamespace>
+// namedpipe format => CAgentStream_<pipeNamedDefinedXMLConfig>_<genevaNamespace>
 func getGenevaWindowsNamedPipeName() string {
 	gcsNameSpace := os.Getenv("MONITORING_GCS_NAMESPACE")
 	var namedPipeName string
@@ -293,6 +293,23 @@ func getOutputStreamIdTag(dataType string, streamIdTagName string, refreshTracke
 		}
 	} else {
 		Log("getOutputStreamIdTag: refreshTracker is nil")
+		useFromCache = false
 	}
 	return extension.GetInstance(FLBLogger, ContainerType).GetOutputStreamId(dataType, useFromCache)
+}
+
+func GetOutputNamedPipe(datatype string, refreshTracker *time.Time) string {
+	useFromCache := true
+	if refreshTracker != nil {
+		elapsed := time.Now().Sub(*refreshTracker)
+		//No need to check the tag name as for Windows this will always be called when AMA windows.
+		if elapsed.Seconds() >= agentConfigRefreshIntervalSeconds {
+			useFromCache = false
+			*refreshTracker = time.Now()
+		}
+	} else {
+		Log("GetOutputNamedPipe: refreshTracker is nil")
+		useFromCache = false
+	}
+	return extension.GetInstance(FLBLogger, ContainerType).GetOutputNamedPipe(datatype, useFromCache)
 }

--- a/source/plugins/go/src/utils_linux.go
+++ b/source/plugins/go/src/utils_linux.go
@@ -9,7 +9,7 @@ func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Con
 	Log("Error::CreateWindowsNamedPipeClient not implemented for Linux")
 }
 
-func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool) bool {
+func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
 	//function unimplemented
 	Log("Error::CreateGenevaOr3PNamedPipe not implemented for Linux")
 	return false

--- a/source/plugins/go/src/utils_linux.go
+++ b/source/plugins/go/src/utils_linux.go
@@ -2,7 +2,15 @@
 
 package main
 
-func CreateWindowsNamedPipesClient(namedPipe string) {
+import "net"
+
+func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Conn) {
 	//function unimplemented
-	Log("Error::CreateWindowsNamedPipesClient not implemented for Linux")
+	Log("Error::CreateWindowsNamedPipeClient not implemented for Linux")
+}
+
+func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool) bool {
+	//function unimplemented
+	Log("Error::CreateGenevaOr3PNamedPipe not implemented for Linux")
+	return false
 }

--- a/source/plugins/go/src/utils_linux.go
+++ b/source/plugins/go/src/utils_linux.go
@@ -3,6 +3,7 @@
 package main
 
 import "net"
+import "time"
 
 func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Conn) {
 	//function unimplemented

--- a/source/plugins/go/src/utils_linux.go
+++ b/source/plugins/go/src/utils_linux.go
@@ -10,8 +10,8 @@ func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Con
 	Log("Error::CreateWindowsNamedPipeClient not implemented for Linux")
 }
 
-func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
+func EnsureGenevaOr3PNamedPipeExists(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
 	//function unimplemented
-	Log("Error::CreateGenevaOr3PNamedPipe not implemented for Linux")
+	Log("Error::EnsureGenevaOr3PNamedPipeExists not implemented for Linux")
 	return false
 }

--- a/source/plugins/go/src/utils_windows.go
+++ b/source/plugins/go/src/utils_windows.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"Docker-Provider/source/plugins/go/src/extension"
 	"context"
 	"net"
 	"syscall"
@@ -32,13 +31,13 @@ func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Con
 	}
 }
 
-func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool) bool {
+func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
 	if *namedPipeConnection == nil {
 		Log("Error::AMA:: The connection to named pipe was nil. re-connecting...")
 		if isGenevaLogsIntegrationEnabled {
 			CreateWindowsNamedPipeClient(getGenevaWindowsNamedPipeName(), namedPipeConnection)
 		} else {
-			CreateWindowsNamedPipeClient(extension.GetInstance(FLBLogger, ContainerType).GetOutputNamedPipe(datatype), namedPipeConnection)
+			CreateWindowsNamedPipeClient(GetOutputNamedPipe(datatype, refreshTracker), namedPipeConnection)
 		}
 		if namedPipeConnection == nil {
 			Log("Error::AMA::Cannot create the named pipe connection for %s.", datatype)

--- a/source/plugins/go/src/utils_windows.go
+++ b/source/plugins/go/src/utils_windows.go
@@ -3,21 +3,23 @@
 package main
 
 import (
+	"Docker-Provider/source/plugins/go/src/extension"
 	"context"
+	"net"
 	"syscall"
 	"time"
 
 	"github.com/Microsoft/go-winio"
 )
 
-func CreateWindowsNamedPipesClient(namedPipe string) {
+func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Conn) {
 	if namedPipe == "" {
-		Log("Error::AMA::CreateWindowsNamedPipesClient::namedPipe is empty")
+		Log("Error::AMA::CreateWindowsNamedPipeClient::namedPipe is empty")
 		return
 	}
 	containerLogPipePath := "\\\\.\\\\pipe\\\\" + namedPipe
 
-	Log("AMA::CreateWindowsNamedPipesClient::The named pipe is: %s", containerLogPipePath)
+	Log("AMA::CreateWindowsNamedPipeClient::The named pipe is: %s", containerLogPipePath)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := winio.DialPipeAccess(ctx, containerLogPipePath, syscall.GENERIC_WRITE)
@@ -26,6 +28,25 @@ func CreateWindowsNamedPipesClient(namedPipe string) {
 		Log("Error::AMA::Unable to open Named Pipe %s", err.Error())
 	} else {
 		Log("Windows Named Pipe opened without any errors")
-		ContainerLogNamedPipe = conn
+		*namedPipeConnection = conn
 	}
+}
+
+func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool) bool {
+	if *namedPipeConnection == nil {
+		Log("Error::AMA:: The connection to named pipe was nil. re-connecting...")
+		if isGenevaLogsIntegrationEnabled {
+			CreateWindowsNamedPipeClient(getGenevaWindowsNamedPipeName(), namedPipeConnection)
+		} else {
+			CreateWindowsNamedPipeClient(extension.GetInstance(FLBLogger, ContainerType).GetOutputNamedPipe(datatype), namedPipeConnection)
+		}
+		if namedPipeConnection == nil {
+			Log("Error::AMA::Cannot create the named pipe connection for %s.", datatype)
+			ContainerLogTelemetryMutex.Lock()
+			defer ContainerLogTelemetryMutex.Unlock()
+			*errorCount += 1
+			return false
+		}
+	}
+	return true
 }

--- a/source/plugins/go/src/utils_windows.go
+++ b/source/plugins/go/src/utils_windows.go
@@ -31,7 +31,7 @@ func CreateWindowsNamedPipeClient(namedPipe string, namedPipeConnection *net.Con
 	}
 }
 
-func CreateGenevaOr3PNamedPipe(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
+func EnsureGenevaOr3PNamedPipeExists(namedPipeConnection *net.Conn, datatype string, errorCount *float64, isGenevaLogsIntegrationEnabled bool, refreshTracker *time.Time) bool {
 	if *namedPipeConnection == nil {
 		Log("Error::AMA:: The connection to named pipe was nil. re-connecting...")
 		if isGenevaLogsIntegrationEnabled {


### PR DESCRIPTION
Windows AMA - CI integration for Container Log and Container LogV2
- Fixed the DCR ContainerLogV2 updation scenario
- Updated the Windows AMA to the latest version I received

Testing Scenarios
- [x] ContainerLog is working for both Linux and Windows [DONE]
- [x] ContainerLogV2 is working for both Linux and Windows [DONE - enabled using DCR]
- [x] Change from ContainerLog to ContainerLogV2(and vice versa) from config map is working for both Linux and Windows [DONE]
- [x] Change from ContainerLog to ContainerLogV2(and vice versa) from DCR is working for both Linux and Windows [DONE]
- [x] DCR updation is not working even for Linux - Fixed
- [x] Other datatypes are working as is:
- [x] InsightsMetrics [DONE]
- [x] KubeMonAgent [DONE]
- [x] Datatypes with legacy auth
- [x] Geneva integration

Memory working set of Windows Pods: 
![image](https://github.com/microsoft/Docker-Provider/assets/18661789/1de22a89-f247-4716-a697-c56e668ff7ea)

CPU usage of windows pods:
![image](https://github.com/microsoft/Docker-Provider/assets/18661789/38f6e66b-fd9f-437e-b3da-4e2b8bacc6ab)
