### PR TITLE
Gangams/implement timebound token and token refresh

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -102,8 +102,8 @@ spec:
        - name: SIDECAR_SCRAPING_ENABLED
          value: {{ .Values.amalogs.sidecarscraping | quote }}
        volumeMounts:
-        - name: token
-          mountPath: C:\var\run\secrets\kubernetes.io\serviceaccount
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
         - mountPath: C:\ProgramData\docker\containers
           name: docker-windows-containers
@@ -139,12 +139,23 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
-    - name: token
-      projected:
-        sources:
-        - serviceAccountToken:
-            path: token
-            expirationSeconds: 3600
+     - name: kube-api-access
+       projected:
+         sources:
+         - serviceAccountToken:
+             path: token
+             expirationSeconds: 3600
+         - configMap:
+             items:
+             - key: ca.crt
+               path: ca.crt
+             name: kube-root-ca.crt
+         - downwardAPI:
+             items:
+             - fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.namespace
+               path: namespace    
     - name: docker-windows-kuberenetes-container-logs
       hostPath:
         path: C:\var

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -139,9 +139,9 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
-     - name: kube-api-access
-       projected:
-         sources:
+    - name: kube-api-access
+      projected:
+        sources:
          - serviceAccountToken:
              path: token
              expirationSeconds: 3600
@@ -155,7 +155,7 @@ spec:
              - fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
-               path: namespace    
+               path: namespace
     - name: docker-windows-kuberenetes-container-logs
       hostPath:
         path: C:\var

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -102,6 +102,9 @@ spec:
        - name: SIDECAR_SCRAPING_ENABLED
          value: {{ .Values.amalogs.sidecarscraping | quote }}
        volumeMounts:
+        - name: token
+          mountPath: C:\var\run\secrets\kubernetes.io\serviceaccount
+          readOnly: true
         - mountPath: C:\ProgramData\docker\containers
           name: docker-windows-containers
           readOnly: true
@@ -136,6 +139,12 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
     - name: docker-windows-kuberenetes-container-logs
       hostPath:
         path: C:\var

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -229,6 +229,9 @@ spec:
        securityContext:
          privileged: true
        volumeMounts:
+         - name: token
+           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+           readOnly: true
          - mountPath: /etc/kubernetes/host
            name: azure-json-path
          - mountPath: /etc/ama-logs-secret
@@ -269,6 +272,12 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
     - name: host-root
       hostPath:
        path: /

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -137,6 +137,9 @@ spec:
        - containerPort: 25224
          protocol: UDP
        volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
         - mountPath: /hostfs
           name: host-root
           readOnly: true
@@ -229,7 +232,7 @@ spec:
        securityContext:
          privileged: true
        volumeMounts:
-         - name: token
+         - name: kube-api-access
            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
            readOnly: true
          - mountPath: /etc/kubernetes/host
@@ -272,12 +275,23 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
-    - name: token
-      projected:
-        sources:
-        - serviceAccountToken:
-            path: token
-            expirationSeconds: 3600
+     - name: kube-api-access
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                expirationSeconds: 3600
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace               
     - name: host-root
       hostPath:
        path: /

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -275,23 +275,23 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
-     - name: kube-api-access
-          projected:
-            sources:
-            - serviceAccountToken:
-                path: token
-                expirationSeconds: 3600
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace               
+    - name: kube-api-access
+      projected:
+        sources:
+         - serviceAccountToken:
+             path: token
+             expirationSeconds: 3600
+         - configMap:
+             items:
+             - key: ca.crt
+               path: ca.crt
+             name: kube-root-ca.crt
+         - downwardAPI:
+             items:
+             - fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.namespace
+               path: namespace
     - name: host-root
       hostPath:
        path: /

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -128,6 +128,9 @@ spec:
        - containerPort: 25224
          protocol: UDP
        volumeMounts:
+        - name: token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
         - mountPath: /var/run/host
           name: docker-sock
         - mountPath: /var/log
@@ -182,6 +185,12 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
     - name: docker-sock
       hostPath:
        path: /var/run

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -128,7 +128,7 @@ spec:
        - containerPort: 25224
          protocol: UDP
        volumeMounts:
-        - name: token
+        - name: kube-api-access
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
         - mountPath: /var/run/host
@@ -185,12 +185,23 @@ spec:
    {{- end }}
    {{- end }}
    volumes:
-    - name: token
+    - name: kube-api-access
       projected:
         sources:
         - serviceAccountToken:
             path: token
             expirationSeconds: 3600
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+              path: namespace                    
     - name: docker-sock
       hostPath:
        path: /var/run

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -452,6 +452,9 @@ spec:
             - containerPort: 25224
               protocol: UDP
           volumeMounts:
+            - name: token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
             - mountPath: /var/run/mdsd-PrometheusSidecar
               name: mdsd-prometheus-sock
             - mountPath: /hostfs
@@ -547,6 +550,9 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
             - mountPath: /var/run/mdsd-PrometheusSidecar
               name: mdsd-prometheus-sock
             - mountPath: /etc/kubernetes/host
@@ -597,6 +603,12 @@ spec:
         - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
+        - name: token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
         - name: mdsd-prometheus-sock
           emptyDir: {}
         - name: host-root
@@ -804,6 +816,9 @@ spec:
             - containerPort: 25224
               protocol: UDP
           volumeMounts:
+            - name: token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
             - mountPath: /var/run/host
               name: docker-sock
             - mountPath: /var/log
@@ -873,6 +888,12 @@ spec:
         - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
+        - name: token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
         - name: docker-sock
           hostPath:
             path: /var/run
@@ -993,6 +1014,9 @@ spec:
           # - name: USING_AAD_MSI_AUTH
           #   value: "true"
          volumeMounts:
+          - name: token
+            mountPath: C:\var\run\secrets\kubernetes.io\serviceaccount
+            readOnly: true
           - mountPath: C:\ProgramData\docker\containers
             name: docker-windows-containers
             readOnly: true
@@ -1050,6 +1074,12 @@ spec:
      - operator: "Exists"
        effect: PreferNoSchedule
      volumes:
+      - name: token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
       - name: docker-windows-kuberenetes-container-logs
         hostPath:
           path: C:\var

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -452,7 +452,7 @@ spec:
             - containerPort: 25224
               protocol: UDP
           volumeMounts:
-            - name: token
+            - name: kube-api-access
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
             - mountPath: /var/run/mdsd-PrometheusSidecar
@@ -550,7 +550,7 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-            - name: token
+            - name: kube-api-access
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
             - mountPath: /var/run/mdsd-PrometheusSidecar
@@ -603,12 +603,23 @@ spec:
         - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
-        - name: token
+        - name: kube-api-access
           projected:
             sources:
-              - serviceAccountToken:
-                  path: token
-                  expirationSeconds: 3600
+            - serviceAccountToken:
+                path: token
+                expirationSeconds: 3600
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace        
         - name: mdsd-prometheus-sock
           emptyDir: {}
         - name: host-root
@@ -816,7 +827,7 @@ spec:
             - containerPort: 25224
               protocol: UDP
           volumeMounts:
-            - name: token
+            - name: kube-api-access
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
             - mountPath: /var/run/host
@@ -888,12 +899,23 @@ spec:
         - operator: "Exists"
           effect: "PreferNoSchedule"
       volumes:
-        - name: token
+        - name: kube-api-access
           projected:
             sources:
-              - serviceAccountToken:
-                  path: token
-                  expirationSeconds: 3600
+            - serviceAccountToken:
+                path: token
+                expirationSeconds: 3600
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace            
         - name: docker-sock
           hostPath:
             path: /var/run
@@ -1014,8 +1036,8 @@ spec:
           # - name: USING_AAD_MSI_AUTH
           #   value: "true"
          volumeMounts:
-          - name: token
-            mountPath: C:\var\run\secrets\kubernetes.io\serviceaccount
+          - name: kube-api-access
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             readOnly: true
           - mountPath: C:\ProgramData\docker\containers
             name: docker-windows-containers
@@ -1074,12 +1096,23 @@ spec:
      - operator: "Exists"
        effect: PreferNoSchedule
      volumes:
-      - name: token
+      - name: kube-api-access
         projected:
           sources:
           - serviceAccountToken:
               path: token
               expirationSeconds: 3600
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace    
       - name: docker-windows-kuberenetes-container-logs
         hostPath:
           path: C:\var

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -95,6 +95,7 @@ fluentd --setup ./fluent
 gem install gyoku iso8601 bigdecimal --no-doc
 gem install tomlrb -v "2.0.1" --no-document
 gem install ipaddress --no-document
+gem install jwt -v "2.7.1" --no-document
 
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -95,7 +95,6 @@ fluentd --setup ./fluent
 gem install gyoku iso8601 bigdecimal --no-doc
 gem install tomlrb -v "2.0.1" --no-document
 gem install ipaddress --no-document
-gem install jwt -v "2.7.1" --no-document
 
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -32,7 +32,6 @@ RUN refreshenv \
 && gem install tomlrb -v 2.0.1 \
 && gem install gyoku -v 1.3.1 \
 && gem install ipaddress -v 0.8.3 \
-&& gem install jwt -v 2.7.1 \
 && gem sources --clear-all
 
 # Remove gem cache and chocolatey

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -32,6 +32,7 @@ RUN refreshenv \
 && gem install tomlrb -v 2.0.1 \
 && gem install gyoku -v 1.3.1 \
 && gem install ipaddress -v 0.8.3 \
+&& gem install jwt -v 2.7.1 \
 && gem sources --clear-all
 
 # Remove gem cache and chocolatey

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -117,7 +117,7 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs < 900) # refresh token from token file if it is going to expire in 15 mins
+        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs <= Constants::SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS) # refresh token from token file if it is going if its near expiry
           if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
             @@TokenStr = File.read(@@TokenFileName).strip
             token_info = JWT.decode(@@TokenStr, nil, false)

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -125,7 +125,7 @@ class KubernetesApiClient
               @@TokenExpiry = token_info[0]["exp"]
             rescue JWT::DecodeError => e
               @Log.warn("The token is not a JWT.")
-              @@TokenExpiry = DateTime.now.to_time.to_i + (60 * 60) # 1 hour token expiry for legacy tokens
+              @@TokenExpiry = DateTime.now.to_time.to_i + Constants::LEGACY_SERVICE_ACCOUNT_TOKEN_EXPIRY_SECONDS
             end
           else
             @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -9,7 +9,6 @@ class KubernetesApiClient
   require "uri"
   require "time"
   require "ipaddress"
-  require "jwt"
 
   require_relative "oms_common"
   require_relative "constants"
@@ -40,7 +39,6 @@ class KubernetesApiClient
   @Log = Logger.new(@LogPath, 2, 10 * 1048576) #keep last 2 files, max log file size = 10M
   @@TokenFileName = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   @@TokenStr = nil
-  @@TokenExpiry = DateTime.now.to_time.to_i
   @@cpuLimitsTelemetryTimeTracker = DateTime.now.to_time.to_i
   @@cpuRequestsTelemetryTimeTracker = DateTime.now.to_time.to_i
   @@memoryLimitsTelemetryTimeTracker = DateTime.now.to_time.to_i
@@ -117,16 +115,10 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs < 900) # refresh token from token file if it is going to expire in 15 mins
-          if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
-            @@TokenStr = File.read(@@TokenFileName).strip
-            token_info = JWT.decode(@@TokenStr, nil, false)
-            @@TokenExpiry = token_info[0]["exp"]
-          else
-            @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")
-            @@TokenExpiry = DateTime.now.to_time.to_i
-            @@TokenStr = nil
-          end
+        if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
+          @@TokenStr = File.read(@@TokenFileName).strip
+        else
+          @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")
         end
       rescue => error
         @Log.warn("getTokenStr failed: #{error}")

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -9,6 +9,7 @@ class KubernetesApiClient
   require "uri"
   require "time"
   require "ipaddress"
+  require "jwt"
 
   require_relative "oms_common"
   require_relative "constants"
@@ -39,6 +40,7 @@ class KubernetesApiClient
   @Log = Logger.new(@LogPath, 2, 10 * 1048576) #keep last 2 files, max log file size = 10M
   @@TokenFileName = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   @@TokenStr = nil
+  @@TokenExpiry = DateTime.now.to_time.to_i
   @@cpuLimitsTelemetryTimeTracker = DateTime.now.to_time.to_i
   @@cpuRequestsTelemetryTimeTracker = DateTime.now.to_time.to_i
   @@memoryLimitsTelemetryTimeTracker = DateTime.now.to_time.to_i
@@ -115,10 +117,16 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
-          @@TokenStr = File.read(@@TokenFileName).strip
-        else
-          @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")
+        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs < 900) # refresh token from token file if it is going to expire in 15 mins
+          if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
+            @@TokenStr = File.read(@@TokenFileName).strip
+            token_info = JWT.decode(@@TokenStr, nil, false)
+            @@TokenExpiry = token_info[0]["exp"]
+          else
+            @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")
+            @@TokenExpiry = DateTime.now.to_time.to_i
+            @@TokenStr = nil
+          end
         end
       rescue => error
         @Log.warn("getTokenStr failed: #{error}")

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -124,7 +124,7 @@ class KubernetesApiClient
               token_info = JWT.decode(@@TokenStr, nil, false)
               @@TokenExpiry = token_info[0]["exp"]
             rescue JWT::DecodeError => e
-              puts "The token is not a JWT."
+              @Log.warn("The token is not a JWT.")
               @@TokenExpiry = DateTime.now.to_time.to_i + (60 * 60) # 1 hour token expiry for legacy tokens
             end
           else

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -117,7 +117,7 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs < 900) # renew token if it is going to expire in 15 mins
+        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs < 900) # refresh token from token file if it is going to expire in 15 mins
           if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
             @@TokenStr = File.read(@@TokenFileName).strip
             token_info = JWT.decode(@@TokenStr, nil, false)

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -117,7 +117,7 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs <= Constants::SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS) # refresh token from token file if it is going if its near expiry
+        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs <= Constants::SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS) # refresh token from token file if its near expiry
           if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
             @@TokenStr = File.read(@@TokenFileName).strip
             token_info = JWT.decode(@@TokenStr, nil, false)

--- a/source/plugins/ruby/constants.rb
+++ b/source/plugins/ruby/constants.rb
@@ -163,4 +163,7 @@ class Constants
   # interval to refresh in-memory service account token from file
   # service account token expiry is 1 hour and we refresh before 10 minutes expiry
   SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS = 600
+
+  # Legacy service account token is not in JWT and hence we cant infer expiry from token
+  LEGACY_SERVICE_ACCOUNT_TOKEN_EXPIRY_SECONDS = 3600
 end

--- a/source/plugins/ruby/constants.rb
+++ b/source/plugins/ruby/constants.rb
@@ -159,4 +159,8 @@ class Constants
   # min and max data collection interval minutes
   EXTENSION_SETTINGS_DATA_COLLECTION_SETTINGS_INTERVAL_MIN = 1
   EXTENSION_SETTINGS_DATA_COLLECTION_SETTINGS_INTERVAL_MAX = 30
+
+  # interval to refresh in-memory service account token from file
+  # service account token expiry is 1 hour and we refresh before 10 minutes expiry
+  SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS = 600
 end


### PR DESCRIPTION
Implementation of timebound service account and token refresh, and token expiry is 1hour and refreshed from file before 10 mins of the expiry. Verified on both Linux and windows. From k8s min version 1.20.13 and latest version 1.28.0. We dont have any AKS test clusters to valid older than 1.20.  and also validated HELM chart.

As per [KEP] , this feature introduced in 1.13 as beta - https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens#graduation-criteria

To avoid any breaking change on unsupported versions, we will add k8s version check in AKS yaml for manifest. Agent code agnostic to the yaml changes and it will support both legacy and JWT tokens.