### PR TITLE
Moving the thread pool env var to dockerfile

### DIFF
--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -41,6 +41,7 @@ SHELL ["powershell"]
 
 ENV tmpdir /opt/amalogswindows/scripts/powershell
 ENV WINDOWS_AMA_URL ${WINDOWS_AMA_URL}
+ENV COMPlus_ThreadPool_UnfairSemaphoreSpinLimit 0
 
 WORKDIR /opt/amalogswindows/scripts/powershell
 

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -739,8 +739,6 @@ function IsGenevaMode() {
     return $false
 }
 
-Set-ProcessAndMachineEnvVariables "COMPlus_ThreadPool_UnfairSemaphoreSpinLimit" "0"
-
 Start-Transcript -Path main.txt
 
 Remove-WindowsServiceIfItExists "fluentdwinaks"


### PR DESCRIPTION
Cosmic team mentioned that if inside main.ps1, this variable doesn't work for the ongoing main.ps1 process. Moving the variable setting to Dockerfile instead. 