### PR TITLE
add nil check for non existence of the fields to avoid nil class exception

### DIFF
--- a/source/plugins/ruby/kubernetes_container_inventory.rb
+++ b/source/plugins/ruby/kubernetes_container_inventory.rb
@@ -327,7 +327,9 @@ class KubernetesContainerInventory
                 resourceFields = resource.split(".")
                 containerResources = container["resources"]
                 if !containerResources.nil? && !containerResources.empty? && resourceFields.length() == 2
-                  value = containerResources[resourceFields[0]][resourceFields[1]]
+                   if containerResources.key?(resourceFields[0]) && containerResources[resourceFields[0]].key?(resourceFields[1])
+                     value = containerResources[resourceFields[0]][resourceFields[1]]
+                   end
                 end
                 # https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
               elsif valueFrom.key?("secretKeyRef")


### PR DESCRIPTION
This is to address alert "426849077- Sev3:Fired Application Insights:Log Container Insights Agent - - AKS - allup exceptions-(auto-deployed)".

Issue here, if the pod spec has resourceFieldRef for the non-existence fields which can use nil exception. 

For example, no limits specified for the container under resources but the resourceFiledRef has resourceFieldRef  for the limits.

https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables
