### PR TITLE
force 1hour expiry for default 1 year valid tokens

### DIFF
--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -127,6 +127,10 @@ class KubernetesApiClient
               @Log.warn("The token is not a JWT.")
               @@TokenExpiry = DateTime.now.to_time.to_i + Constants::LEGACY_SERVICE_ACCOUNT_TOKEN_EXPIRY_SECONDS
             end
+            # By default without explicit token mount, token expiry is one year so setting expiry to 1hour to refresh token periodically
+            if (@@TokenExpiry - DateTime.now.to_time.to_i).abs > Constants::LEGACY_SERVICE_ACCOUNT_TOKEN_EXPIRY_SECONDS
+              @@TokenExpiry = DateTime.now.to_time.to_i + Constants::LEGACY_SERVICE_ACCOUNT_TOKEN_EXPIRY_SECONDS
+            end
           else
             @Log.warn("Unable to read token string from #{@@TokenFileName}: #{error}")
             @@TokenExpiry = DateTime.now.to_time.to_i


### PR DESCRIPTION
force 1hour expiry for default 1 year valid tokens to refresh token periodically. This enables toggling image with or without manifest updates and have the same behavior.