### PR TITLE
Fix component governance and sbom generation

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -178,7 +178,7 @@ jobs:
     condition: eq(variables.IS_PR, false)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
-      DockerImagesToScan: '$(GOLANG_BASE_IMAGE), $(CI_BASE_IMAGE), ${{ variables.repoImageName }}:$(linuxImagetag)'
+      DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
 
   - task: ComponentGovernanceComponentDetection@0
     condition: eq(variables.IS_PR, true)

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -171,7 +171,7 @@ jobs:
     condition: eq(variables.IS_PR, true)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
-      DockerImagesToScan: '$(GOLANG_BASE_IMAGE), $(CI_BASE_IMAGE)'
+      DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE)'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
@@ -183,7 +183,7 @@ jobs:
   - task: ComponentGovernanceComponentDetection@0
     condition: eq(variables.IS_PR, true)
     inputs:
-      DockerImagesToScan: '$(GOLANG_BASE_IMAGE), $(CI_BASE_IMAGE)'
+      DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE)'
 
   - task: ComponentGovernanceComponentDetection@0
     condition: eq(variables.IS_PR, false)
@@ -326,14 +326,14 @@ jobs:
     condition: eq(variables.IS_PR, true)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022'
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generation Task'
     condition: eq(variables.IS_PR, false)
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/servercore:ltsc2022, ${{ variables.repoImageName }}:$(windowsImageTag)'
+      DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022,${{ variables.repoImageName }}:$(windowsImageTag)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -188,7 +188,7 @@ jobs:
   - task: ComponentGovernanceComponentDetection@0
     condition: eq(variables.IS_PR, false)
     inputs:
-      DockerImagesToScan: '$(GOLANG_BASE_IMAGE), $(CI_BASE_IMAGE), ${{ variables.repoImageName }}:$(linuxImagetag)'
+      DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
 
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
- Component governance and sbom generation does not work for docker images if there are spaces in the list of images
eg _Processing of image " containerinsightsprod.azurecr.io/public/azuremonitor/containerinsights/cidev:3.1.13-6-g45fa343da-20230929012045" failed_ in the [build run](https://github-private.visualstudio.com/microsoft/_build/results?buildId=68957&view=logs&j=c275f7fe-e659-5231-3649-94d1ac43e3f4&t=e7abeffa-84f6-5501-3706-c2d57b1ee59d)


this extra space at the beginning of containerinsightsprod is coming from the list of images provided.