### PR TITLE
use omfwd for syslog

### DIFF
--- a/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
+++ b/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
@@ -5,6 +5,6 @@ template(name="MDSD_RSYSLOG_TraditionalForwardFormat" type="string" string="<%PR
 template="MDSD_RSYSLOG_TraditionalForwardFormat"
 queue.type="LinkedList"
 action.resumeRetryCount="-1"
-queue.size="50000"
+queue.size="10000"
 queue.saveonshutdown="on"
 target="127.0.0.1" Port="28330" Protocol="tcp")

--- a/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
+++ b/build/linux/installer/conf/70-rsyslog-forward-mdsd-ci.conf
@@ -1,5 +1,10 @@
-$ModLoad omuxsock 
-$OMUxSockSocket /var/run/mdsd-ci/default_syslog.socket 
 template(name="MDSD_RSYSLOG_TraditionalForwardFormat" type="string" string="<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
-$OMUxSockDefaultTemplate MDSD_RSYSLOG_TraditionalForwardFormat
-*.* :omuxsock:
+
+# Forwarding all events through TCP port
+*.* action(type="omfwd"
+template="MDSD_RSYSLOG_TraditionalForwardFormat"
+queue.type="LinkedList"
+action.resumeRetryCount="-1"
+queue.size="50000"
+queue.saveonshutdown="on"
+target="127.0.0.1" Port="28330" Protocol="tcp")

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -428,6 +428,8 @@ spec:
             #  value: "my_acs_cluster_name"
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
+            - name: SYSLOG_HOST_PORT
+              value: "28330"
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -451,6 +451,10 @@ spec:
               protocol: TCP
             - containerPort: 25224
               protocol: UDP
+            - name: syslog
+              containerPort: 28330
+              hostPort: 28330
+              protocol: TCP
           volumeMounts:
             - name: kube-api-access
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -842,6 +842,8 @@ else
             echo "export MONITORING_USE_GENEVA_CONFIG_SERVICE=$MONITORING_USE_GENEVA_CONFIG_SERVICE" >> ~/.bashrc
             export MDSD_USE_LOCAL_PERSISTENCY="false"
             echo "export MDSD_USE_LOCAL_PERSISTENCY=$MDSD_USE_LOCAL_PERSISTENCY" >> ~/.bashrc
+            export MDSD_DEFAULT_TCP_SYSLOG_PORT=28330
+            echo "export MDSD_DEFAULT_TCP_SYSLOG_PORT=$MDSD_DEFAULT_TCP_SYSLOG_PORT" >> ~/.bashrc
       else
             echo "*** setting up oneagent in legacy auth mode ***"
             CIWORKSPACE_id="$(cat /etc/ama-logs-secret/WSID)"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -842,6 +842,16 @@ else
             echo "export MONITORING_USE_GENEVA_CONFIG_SERVICE=$MONITORING_USE_GENEVA_CONFIG_SERVICE" >> ~/.bashrc
             export MDSD_USE_LOCAL_PERSISTENCY="false"
             echo "export MDSD_USE_LOCAL_PERSISTENCY=$MDSD_USE_LOCAL_PERSISTENCY" >> ~/.bashrc
+            if [ -n "$SYSLOG_HOST_PORT" ] && [ "$SYSLOG_HOST_PORT" != "28330" ]; then
+                  echo "Updating rsyslog config file with non default SYSLOG_HOST_PORT value ${SYSLOG_HOST_PORT}"
+                  if sed -i "s/Port=\"[0-9]*\"/Port=\"$SYSLOG_HOST_PORT\"/g" /etc/opt/microsoft/docker-cimprov/70-rsyslog-forward-mdsd-ci.conf; then
+                        echo "Successfully updated the rsylog config file."
+                  else
+                        echo "Failed to update the rsyslog config file."
+                  fi
+            else
+                  echo "SYSLOG_HOST_PORT is ${SYSLOG_HOST_PORT}. No changes made."
+            fi
             export MDSD_DEFAULT_TCP_SYSLOG_PORT=28330
             echo "export MDSD_DEFAULT_TCP_SYSLOG_PORT=$MDSD_DEFAULT_TCP_SYSLOG_PORT" >> ~/.bashrc
       else

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -39,16 +39,10 @@ mv /usr/lib/ruby/gems/3.1.0/specifications/default/uri-0.11.0.gemspec /usr/lib/r
 gem uninstall time --version 0.2.0
 gem uninstall uri --version 0.11.0
 
-if [ "${ARCH}" != "arm64" ]; then
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.x86_64.rpm" -O azure-mdsd.rpm
-else
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.aarch64.rpm" -O azure-mdsd.rpm
-fi
-sudo tdnf install -y azure-mdsd.rpm
+sudo tdnf install -y azure-mdsd-1.27.4
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d
 cp -f $TMPDIR/envmdsd /etc/mdsd.d
 rm /usr/sbin/telegraf
-rm azure-mdsd.rpm
 
 mdsd_version=$(sudo tdnf list installed | grep mdsd | awk '{print $2}')
 echo "Azure mdsd: $mdsd_version" >> packages_version.txt

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -40,9 +40,9 @@ gem uninstall time --version 0.2.0
 gem uninstall uri --version 0.11.0
 
 if [ "${ARCH}" != "arm64" ]; then
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.26.1/azure-mdsd-1.26.1-build.master.97.x86_64.rpm" -O azure-mdsd.rpm
+    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.x86_64.rpm" -O azure-mdsd.rpm
 else
-    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.26.1/azure-mdsd-1.26.1-build.master.97.aarch64.rpm" -O azure-mdsd.rpm
+    wget "https://github.com/microsoft/Docker-Provider/releases/download/official%2Fmdsd%2F1.27.4/azure-mdsd-1.27.4-build.master.140.aarch64.rpm" -O azure-mdsd.rpm
 fi
 sudo tdnf install -y azure-mdsd.rpm
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d


### PR DESCRIPTION
- updates mdsd 1.27.4 from 1.26.1
- uses omfwd instead of omuxsock for syslog data transfer between host node and container
- uses default hostPort 28330 which can be overridden by providing SYSLOG_HOST_PORT (comes from toggle)