### PR TITLE
Gangams/dotnet core version update

### DIFF
--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -5,7 +5,7 @@
 #  3. copy the files under installer directory to ..\..\kubernetes\windows\amalogswindows
 #  4. Builds the livenessprobe cpp and copy the executable to the under directory ..\..\kubernetes\windows\amalogswindows
 
-$dotnetcoreframework = "net7.0"
+$dotnetcoreframework = "net6.0"
 
 Write-Host("Building Certificate generator code...")
 $currentdir =  $PSScriptRoot

--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -5,7 +5,7 @@
 #  3. copy the files under installer directory to ..\..\kubernetes\windows\amalogswindows
 #  4. Builds the livenessprobe cpp and copy the executable to the under directory ..\..\kubernetes\windows\amalogswindows
 
-$dotnetcoreframework = "netcoreapp3.1"
+$dotnetcoreframework = "net7.0"
 
 Write-Host("Building Certificate generator code...")
 $currentdir =  $PSScriptRoot

--- a/build/windows/installer/certificategenerator/CertificateGenerator.csproj
+++ b/build/windows/installer/certificategenerator/CertificateGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/build/windows/installer/certificategenerator/CertificateGenerator.csproj
+++ b/build/windows/installer/certificategenerator/CertificateGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/scripts/build/linux/install-build-pre-requisites.sh
+++ b/scripts/build/linux/install-build-pre-requisites.sh
@@ -97,12 +97,12 @@ register_microsoft_gpg_keys()
 
 install_dotnet_sdk()
 {
-  echo "installing dotnet sdk 3.1 ..."
+  echo "installing dotnet sdk 7.0 ..."
   sudo apt-get update -y
   sudo apt-get install -y apt-transport-https
   sudo apt-get update -y
-  sudo apt-get install -y dotnet-sdk-3.1
-  echo "installation of dotnet sdk 3.1 completed."
+  sudo apt-get install -y dotnet-sdk-7.0
+  echo "installation of dotnet sdk 7.0 completed."
 }
 
 install_gcc_for_windows_platform()

--- a/scripts/build/linux/install-build-pre-requisites.sh
+++ b/scripts/build/linux/install-build-pre-requisites.sh
@@ -97,12 +97,12 @@ register_microsoft_gpg_keys()
 
 install_dotnet_sdk()
 {
-  echo "installing dotnet sdk 7.0 ..."
+  echo "installing dotnet sdk 6.0 ..."
   sudo apt-get update -y
   sudo apt-get install -y apt-transport-https
   sudo apt-get update -y
-  sudo apt-get install -y dotnet-sdk-7.0
-  echo "installation of dotnet sdk 7.0 completed."
+  sudo apt-get install -y dotnet-sdk-6.0
+  echo "installation of dotnet sdk 6.0 completed."
 }
 
 install_gcc_for_windows_platform()
@@ -153,7 +153,7 @@ register_microsoft_gpg_keys
 # install cross platform gcc to build the go code for windows platform
 install_gcc_for_windows_platform
 
-# dotnet core sdk 7.0
+# dotnet core sdk 6.0
 install_dotnet_sdk
 
 # powershell core

--- a/scripts/build/linux/install-build-pre-requisites.sh
+++ b/scripts/build/linux/install-build-pre-requisites.sh
@@ -153,7 +153,7 @@ register_microsoft_gpg_keys
 # install cross platform gcc to build the go code for windows platform
 install_gcc_for_windows_platform
 
-# dotnet core sdk 3.1
+# dotnet core sdk 7.0
 install_dotnet_sdk
 
 # powershell core


### PR DESCRIPTION
update - upgrading dotnet version from dotnetcoreapp3.1 to dotnet 7.0 since dotnetcoreapp3.1 end of life. 
validated - on clusters with both windows server 2019 and windows server 2022 nodes.
