### PR TITLE
add fluent-bit kubernetes filter

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -43,6 +43,7 @@ def substituteFluentBitPlaceHolders
     memBufLimit = ENV["FBIT_TAIL_MEM_BUF_LIMIT"]
     ignoreOlder = ENV["FBIT_TAIL_IGNORE_OLDER"]
     multilineLogging = ENV["AZMON_MULTILINE_ENABLED"]
+    kubernetesMetadataCollection = env["AZMON_KUBERNETES_METADATA_ENABLED"]
 
     serviceInterval = (!interval.nil? && is_number?(interval) && interval.to_i > 0) ? interval : @default_service_interval
     serviceIntervalSetting = "Flush         " + serviceInterval
@@ -77,6 +78,10 @@ def substituteFluentBitPlaceHolders
       new_contents = new_contents.gsub("${TAIL_IGNORE_OLDER}", "Ignore_Older " + ignoreOlder)
     else
       new_contents = new_contents.gsub("\n    ${TAIL_IGNORE_OLDER}\n", "\n")
+    end
+
+    if !kubernetesMetadataCollection.nil? && kubernetesMetadataCollection.to_s.downcase == "true"
+      new_contents = new_contents.gsub("#${KubernetesMetadataCollection}", "")
     end
 
     new_contents = substituteMultiline(multilineLogging, new_contents)

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -212,6 +212,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       if !parsedConfig[:log_collection_settings][:metadata_collection].nil? && !parsedConfig[:log_collection_settings][:metadata_collection][:enabled].nil?
         @logEnableKubernetesMetadata = parsedConfig[:log_collection_settings][:metadata_collection][:enabled]
         puts "config::Using config map setting for kubernetes metadata"
+      end
+    end
   end
 end
 

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -212,11 +212,6 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       if !parsedConfig[:log_collection_settings][:metadata_collection].nil? && !parsedConfig[:log_collection_settings][:metadata_collection][:enabled].nil?
         @logEnableKubernetesMetadata = parsedConfig[:log_collection_settings][:metadata_collection][:enabled]
         puts "config::Using config map setting for kubernetes metadata"
-
-        if @containerLogSchemaVersion.strip.casecmp("v2") != 0
-          puts "config:: WARN: container logs V2 is disabled and is required for kubernetes metadata. Disabling kubernetes metadata collection"
-          @logEnableKubernetesMetadata = false
-        end
   end
 end
 

--- a/build/linux/installer/conf/fluent-bit.conf
+++ b/build/linux/installer/conf/fluent-bit.conf
@@ -44,3 +44,13 @@
 #${MultilineEnabled}    Match oms.container.log.la.*
 #${MultilineEnabled}    multiline.key_content log
 #${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+
+#${KubernetesFilterEnabled}[FILTER]
+#${KubernetesFilterEnabled}    Name                kubernetes
+#${KubernetesFilterEnabled}    Match               oms.container.log.la.*
+#${KubernetesFilterEnabled}    Merge_Log           Off
+#${KubernetesFilterEnabled}    Buffer_Size         0
+#${KubernetesFilterEnabled}    Use_Kubelet         true
+#${KubernetesFilterEnabled}    Kubelet_Port        10250
+#${KubernetesFilterEnabled}    Kubelet_Host        ${NODE_IP}
+#${KubernetesFilterEnabled}    tls.verify          Off

--- a/build/windows/installer/conf/fluent-bit.conf
+++ b/build/windows/installer/conf/fluent-bit.conf
@@ -43,3 +43,13 @@
 #${MultilineEnabled}    Match oms.container.log.la.*
 #${MultilineEnabled}    multiline.key_content log
 #${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+
+#${KubernetesFilterEnabled}[FILTER]
+#${KubernetesFilterEnabled}    Name                kubernetes
+#${KubernetesFilterEnabled}    Match               oms.container.log.la.*
+#${KubernetesFilterEnabled}    Merge_Log           Off
+#${KubernetesFilterEnabled}    Buffer_Size         0
+#${KubernetesFilterEnabled}    Use_Kubelet         true
+#${KubernetesFilterEnabled}    Kubelet_Port        10250
+#${KubernetesFilterEnabled}    Kubelet_Host        ${NODE_IP}
+#${KubernetesFilterEnabled}    tls.verify          Off

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -51,6 +51,9 @@ data:
           # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces.
           # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
           # enabled = "false"
+       #[log_collection_settings.metadata_collection]
+          # if enabled will collect kubernetes metadata for ContainerLogv2 schema. Default false
+          # enabled = false
 
 
   prometheus-data-collection-settings: |-

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -27,6 +27,7 @@ class CAdvisorMetricsAPIClient
   @clusterContainerLogEnrich = ENV["AZMON_CLUSTER_CONTAINER_LOG_ENRICH"]
   @clusterContainerLogSchemaVersion = ENV["AZMON_CONTAINER_LOG_SCHEMA_VERSION"]
   @clusterMultilineEnabled = ENV["AZMON_MULTILINE_ENABLED"]
+  @clusterKubernetesMetadataEnabled = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
 
   @dsPromInterval = ENV["TELEMETRY_DS_PROM_INTERVAL"]
   @dsPromFieldPassCount = ENV["TELEMETRY_DS_PROM_FIELDPASS_LENGTH"]
@@ -295,6 +296,9 @@ class CAdvisorMetricsAPIClient
                     end
                     if (!@clusterMultilineEnabled.nil? && !@clusterMultilineEnabled.empty?)
                       telemetryProps["multilineEnabled"] = @clusterMultilineEnabled
+                    end
+                    if (!@clusterKubernetesMetadataEnabled.nil? && !@clusterKubernetesMetadataEnabled.empty?)
+                      telemetryProps["metadataEnabled"] = @clusterKubernetesMetadataEnabled
                     end
                     ApplicationInsightsUtility.sendMetricTelemetry(metricNametoReturn, metricValue, telemetryProps)
                   end


### PR DESCRIPTION
- Uses fluent-bit Kubernetes filter to capture kubernetes metadata for container log
- Enabled via configmap. Default disabled