### PR TITLE
Gangams/fix arc k8s windows custom metrics bug

### DIFF
--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -417,6 +417,15 @@ function Set-EnvironmentVariables {
     else {
         Write-Host "Failed to set environment variable KUBERNETES_PORT_443_TCP_PORT for target 'machine' since it is either null or empty"
     }
+
+    $kubernetesServiceHost = [System.Environment]::GetEnvironmentVariable("KUBERNETES_SERVICE_HOST", "process")
+    if (![string]::IsNullOrEmpty($kubernetesServiceHost)) {
+        [System.Environment]::SetEnvironmentVariable("KUBERNETES_SERVICE_HOST", $kubernetesServiceHost, "machine")
+        Write-Host "Successfully set environment variable KUBERNETES_SERVICE_HOST - $($kubernetesServiceHost) for target 'machine'..."
+    }
+    else {
+        Write-Host "Failed to set environment variable KUBERNETES_SERVICE_HOST for target 'machine' since it is either null or empty"
+    }
 }
 
 function Read-Configs {
@@ -426,7 +435,7 @@ function Read-Configs {
     #Parse the configmap to set the right environment variables for agent config.
     ruby /opt/amalogswindows/scripts/ruby/tomlparser-agent-config.rb
     Set-EnvironmentVariablesFromFile "/opt/amalogswindows/scripts/powershell/setagentenv.txt"
-    
+
     #Replace placeholders in fluent-bit.conf
     ruby /opt/amalogswindows/scripts/ruby/fluent-bit-conf-customizer.rb
 
@@ -854,11 +863,11 @@ if ($isGenevaModeVar) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
-} 
+}
 if (!$isGenevaModeVar -and ![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
     Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
-    #start Windows AMA 
+    #start Windows AMA
     Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
     $version = Get-Content -Path "C:\opt\windowsazuremonitoragent\version.txt"
     Write-Host $version

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -227,7 +227,7 @@ class KubernetesApiClient
     def getUserAgent()
       return @@userAgent if !@@userAgent.nil?
       begin
-          @@userAgent = "ama-logs/#{ENV['AGENT_VERSION'].nil? ? '0.0.0' : ENV['AGENT_VERSION']} (#{ENV['OS_TYPE'].nil? ? 'linux' : ENV['OS_TYPE']}; Ruby #{RUBY_PLATFORM})"
+        @@userAgent = "ama-logs/#{ENV["AGENT_VERSION"].nil? ? "0.0.0" : ENV["AGENT_VERSION"]} (#{ENV["OS_TYPE"].nil? ? "linux" : ENV["OS_TYPE"]}; Ruby #{RUBY_PLATFORM})"
       rescue => error
         @Log.warn("KubernetesAPIClient::getUserAgent : getUserAgent failed: #{error}")
       end
@@ -893,20 +893,6 @@ class KubernetesApiClient
       end
       return continuationToken, resourceInventory
     end #getResourcesAndContinuationToken
-
-    def getKubeAPIServerUrl(env = ENV)
-      apiServerUrl = nil
-      begin
-        if env["KUBERNETES_SERVICE_HOST"] && env["KUBERNETES_PORT_443_TCP_PORT"]
-          apiServerUrl = "https://#{env["KUBERNETES_SERVICE_HOST"]}:#{env["KUBERNETES_PORT_443_TCP_PORT"]}"
-        else
-          @Log.warn "Kubernetes environment variable not set KUBERNETES_SERVICE_HOST: #{env["KUBERNETES_SERVICE_HOST"]} KUBERNETES_PORT_443_TCP_PORT: #{env["KUBERNETES_PORT_443_TCP_PORT"]}. Unable to form resourceUri"
-        end
-      rescue => errorStr
-        @Log.warn "KubernetesApiClient::getKubeAPIServerUrl:Failed  #{errorStr}"
-      end
-      return apiServerUrl
-    end
 
     def getKubeServicesInventoryRecords(serviceList, batchTime = Time.utc.iso8601)
       kubeServiceRecords = []

--- a/source/plugins/ruby/arc_k8s_cluster_identity.rb
+++ b/source/plugins/ruby/arc_k8s_cluster_identity.rb
@@ -6,7 +6,6 @@ require "uri"
 require "json"
 require "base64"
 require "time"
-require_relative "KubernetesApiClient"
 require_relative "ApplicationInsightsUtility"
 
 class ArcK8sClusterIdentity
@@ -34,7 +33,8 @@ class ArcK8sClusterIdentity
     @isLastTokenRenewalUpdatePending = false
     @token_file_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     @cert_file_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-    @kube_api_server_url = KubernetesApiClient.getKubeAPIServerUrl
+    @kube_api_server_url = "https://#{ENV["KUBERNETES_SERVICE_HOST"]}:#{ENV["KUBERNETES_PORT_443_TCP_PORT"]}"
+    @log.info "Kubernetes API Server URL:#{@kube_api_server_url} @ #{Time.now.utc.iso8601}"
     if @kube_api_server_url.nil?
       @log.warn "got api server url nil from KubernetesApiClient.getKubeAPIServerUrl @ #{Time.now.utc.iso8601}"
     end

--- a/source/plugins/ruby/arc_k8s_cluster_identity.rb
+++ b/source/plugins/ruby/arc_k8s_cluster_identity.rb
@@ -39,7 +39,7 @@ class ArcK8sClusterIdentity
     if !kubernetesServiceHost.empty? && !kubernetesServicePort.empty?
       @kube_api_server_url = "https://#{kubernetesServiceHost}:#{kubernetesServicePort}"
     else
-       @log.warn "got api server url empty since either KUBERNETES_SERVICE_HOST or KUBERNETES_PORT_443_TCP_PORT env var is empty  @ #{Time.now.utc.iso8601}"
+      @log.warn "Kubernetes API Server URL is empty since either KUBERNETES_SERVICE_HOST or KUBERNETES_PORT_443_TCP_PORT env var is empty @ #{Time.now.utc.iso8601}"
     end
     @log.info "Kubernetes API Server URL:#{@kube_api_server_url} @ #{Time.now.utc.iso8601}"
     @http_client = get_http_client

--- a/source/plugins/ruby/arc_k8s_cluster_identity.rb
+++ b/source/plugins/ruby/arc_k8s_cluster_identity.rb
@@ -33,11 +33,15 @@ class ArcK8sClusterIdentity
     @isLastTokenRenewalUpdatePending = false
     @token_file_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     @cert_file_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-    @kube_api_server_url = "https://#{ENV["KUBERNETES_SERVICE_HOST"]}:#{ENV["KUBERNETES_PORT_443_TCP_PORT"]}"
-    @log.info "Kubernetes API Server URL:#{@kube_api_server_url} @ #{Time.now.utc.iso8601}"
-    if @kube_api_server_url.nil?
-      @log.warn "got api server url nil from KubernetesApiClient.getKubeAPIServerUrl @ #{Time.now.utc.iso8601}"
+    kubernetesServiceHost = ENV["KUBERNETES_SERVICE_HOST"]
+    kubernetesServicePort = ENV["KUBERNETES_PORT_443_TCP_PORT"]
+    @kube_api_server_url = ""
+    if !kubernetesServiceHost.empty? && !kubernetesServicePort.empty?
+      @kube_api_server_url = "https://#{kubernetesServiceHost}:#{kubernetesServicePort}"
+    else
+       @log.warn "got api server url empty since either KUBERNETES_SERVICE_HOST or KUBERNETES_PORT_443_TCP_PORT env var is empty  @ #{Time.now.utc.iso8601}"
     end
+    @log.info "Kubernetes API Server URL:#{@kube_api_server_url} @ #{Time.now.utc.iso8601}"
     @http_client = get_http_client
     @service_account_token = get_service_account_token
     @extensionName = ENV["ARC_K8S_EXTENSION_NAME"]


### PR DESCRIPTION
For Arc k8s, in case of legacy auth mode, windows custom metrics  not ingested because of the KUBERNETES_SERVICE_HOST environment variable not available in ruby code. Fix is to set the environment variable in main.ps1 and also removed KubernetesApiClient dependency  in arc_k8s_cluster_identity.rb.