### PR TITLE
Telemetry gap: Adding missing heartbeat telemetry

### DIFF
--- a/source/plugins/ruby/in_kube_events.rb
+++ b/source/plugins/ruby/in_kube_events.rb
@@ -144,7 +144,7 @@ module Fluent::Plugin
           ApplicationInsightsUtility.sendMetricTelemetry("EventCount", @eventsCount, {})
         end
 
-        # Adding telemetry to send kubevents telemetry every 5 minutes
+        # Adding telemetry to send kube events telemetry every 5 minutes
         timeDifference = (DateTime.now.to_time.to_i - @kubeEventsTelemetryTimeTracker).abs
         timeDifferenceInMinutes = timeDifference / 60
         if (timeDifferenceInMinutes >= 5)

--- a/source/plugins/ruby/in_kube_events.rb
+++ b/source/plugins/ruby/in_kube_events.rb
@@ -151,7 +151,7 @@ module Fluent::Plugin
         end
 
         if telemetryFlush
-          ApplicationInsightsUtility.sendCustomEvent("KubeStateEventsHeartBeatEvent", {})
+          ApplicationInsightsUtility.sendCustomEvent("KubeEventsHeartBeatEvent", {})
           @@kubeEventsTelemetryTimeTracker = DateTime.now.to_time.to_i
         end
       rescue => errorStr

--- a/source/plugins/ruby/in_kube_events.rb
+++ b/source/plugins/ruby/in_kube_events.rb
@@ -66,7 +66,7 @@ module Fluent::Plugin
             $log.warn("Normal kube events collection enabled for cluster")
           end
         end
-        @@kubeEventsTelemetryTimeTracker = DateTime.now.to_time.to_i
+        @kubeEventsTelemetryTimeTracker = DateTime.now.to_time.to_i
       end
     end
 
@@ -89,6 +89,7 @@ module Fluent::Plugin
         eventQueryState = getEventQueryState
         newEventQueryState = []
         @eventsCount = 0
+        telemetryFlush = false
 
         if ExtensionUtils.isAADMSIAuthMode()
           $log.info("in_kube_events::enumerate: AAD AUTH MSI MODE")
@@ -144,7 +145,7 @@ module Fluent::Plugin
         end
 
         # Adding telemetry to send kubevents telemetry every 5 minutes
-        timeDifference = (DateTime.now.to_time.to_i - @@kubeEventsTelemetryTimeTracker).abs
+        timeDifference = (DateTime.now.to_time.to_i - @kubeEventsTelemetryTimeTracker).abs
         timeDifferenceInMinutes = timeDifference / 60
         if (timeDifferenceInMinutes >= 5)
           telemetryFlush = true
@@ -152,7 +153,7 @@ module Fluent::Plugin
 
         if telemetryFlush
           ApplicationInsightsUtility.sendCustomEvent("KubeEventsHeartBeatEvent", {})
-          @@kubeEventsTelemetryTimeTracker = DateTime.now.to_time.to_i
+          @kubeEventsTelemetryTimeTracker = DateTime.now.to_time.to_i
         end
       rescue => errorStr
         $log.warn "in_kube_events::enumerate:Failed in enumerate: #{errorStr}"

--- a/source/plugins/ruby/in_kube_nodes.rb
+++ b/source/plugins/ruby/in_kube_nodes.rb
@@ -181,6 +181,7 @@ module Fluent::Plugin
         timeDifference = (DateTime.now.to_time.to_i - @@nodeInventoryLatencyTelemetryTimeTracker).abs
         timeDifferenceInMinutes = timeDifference / 60
         if (timeDifferenceInMinutes >= @TELEMETRY_FLUSH_INTERVAL_IN_MINUTES)
+          ApplicationInsightsUtility.sendCustomEvent("KubeNodeInventoryHeartBeatEvent", {})
           @applicationInsightsUtility.sendMetricTelemetry("NodeInventoryE2EProcessingLatencyMs", @nodeInventoryE2EProcessingLatencyMs, {})
           @applicationInsightsUtility.sendMetricTelemetry("NodesAPIE2ELatencyMs", @nodesAPIE2ELatencyMs, {})
           telemetryProperties = {}

--- a/source/plugins/ruby/in_kubestate_deployments.rb
+++ b/source/plugins/ruby/in_kubestate_deployments.rb
@@ -137,6 +137,7 @@ module Fluent::Plugin
           @@deploymentsCount = @deploymentsRunningTotal
         end
         if (((DateTime.now.to_time.to_i - @@telemetryLastSentTime).abs) / 60) >= Constants::KUBE_STATE_TELEMETRY_FLUSH_INTERVAL_IN_MINUTES
+          ApplicationInsightsUtility.sendCustomEvent("KubeStateDeploymentHeartBeatEvent", {})
           #send telemetry
           $log.info "sending deployemt telemetry..."
           ApplicationInsightsUtility.sendMetricTelemetry("MaxDeploymentCount", @@deploymentsCount, {})

--- a/source/plugins/ruby/in_kubestate_hpa.rb
+++ b/source/plugins/ruby/in_kubestate_hpa.rb
@@ -60,6 +60,7 @@ module Fluent::Plugin
         @condition = ConditionVariable.new
         @mutex = Mutex.new
         @thread = Thread.new(&method(:run_periodic))
+        @@kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
       end
     end
 
@@ -131,6 +132,18 @@ module Fluent::Plugin
           # this will not be a useful telemetry, as hpa counts will not be huge, just log for now
           $log.info("in_kubestate_hpa::hpaCount= #{hpaCount}")
           #ApplicationInsightsUtility.sendMetricTelemetry("HPACount", @hpaCount, {})
+        end
+
+        # Adding telemetry to send kubestateHPA telemetry every 5 minutes
+        timeDifference = (DateTime.now.to_time.to_i - @@kubeStateHPATelemetryTimeTracker).abs
+        timeDifferenceInMinutes = timeDifference / 60
+        if (timeDifferenceInMinutes >= 5)
+          telemetryFlush = true
+        end
+
+        if telemetryFlush
+          ApplicationInsightsUtility.sendCustomEvent("KubeStateHPAHeartBeatEvent", {})
+          @@kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
         end
       rescue => errorStr
         $log.warn "in_kubestate_hpa::enumerate:Failed in enumerate: #{errorStr}"

--- a/source/plugins/ruby/in_kubestate_hpa.rb
+++ b/source/plugins/ruby/in_kubestate_hpa.rb
@@ -60,7 +60,7 @@ module Fluent::Plugin
         @condition = ConditionVariable.new
         @mutex = Mutex.new
         @thread = Thread.new(&method(:run_periodic))
-        @@kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
+        @kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
       end
     end
 
@@ -80,6 +80,7 @@ module Fluent::Plugin
         hpaList = nil
         currentTime = Time.now
         batchTime = currentTime.utc.iso8601
+        telemetryFlush = false
 
         @hpaCount = 0
 
@@ -135,7 +136,7 @@ module Fluent::Plugin
         end
 
         # Adding telemetry to send kubestateHPA telemetry every 5 minutes
-        timeDifference = (DateTime.now.to_time.to_i - @@kubeStateHPATelemetryTimeTracker).abs
+        timeDifference = (DateTime.now.to_time.to_i - @kubeStateHPATelemetryTimeTracker).abs
         timeDifferenceInMinutes = timeDifference / 60
         if (timeDifferenceInMinutes >= 5)
           telemetryFlush = true
@@ -143,7 +144,7 @@ module Fluent::Plugin
 
         if telemetryFlush
           ApplicationInsightsUtility.sendCustomEvent("KubeStateHPAHeartBeatEvent", {})
-          @@kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
+          @kubeStateHPATelemetryTimeTracker = DateTime.now.to_time.to_i
         end
       rescue => errorStr
         $log.warn "in_kubestate_hpa::enumerate:Failed in enumerate: #{errorStr}"


### PR DESCRIPTION
Adding HeartBeatEvent telemetry for the following datatypes: 

KubeEventsHeartBeatEvent
KubeNodeInventoryHeartBeatEvent
KubePerfInventoryHeartBeatEvent
KubeStateDeploymentsHeartBeatEvent
KubeStateHPAHeartBeatEvent

![image](https://github.com/microsoft/Docker-Provider/assets/18661789/c93905b7-a375-4626-b2b3-66710312c708)
