### PR TITLE
collect logs from pods from excluded system ns

### DIFF
--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -90,15 +90,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @collectStdoutLogs && !stdoutSystemPods.nil? && stdoutSystemPods.kind_of?(Array)
           # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
           if stdoutSystemPods.length > 0 && stdoutSystemPods[0].kind_of?(String)
-            #Empty the array to use the values from configmap
-            stdoutSystemPods.each do |systemPod|
-              if @stdoutIncludeSystemPods.empty?
-                # To not append , for the first element
-                @stdoutIncludeSystemPods.concat(systemPod)
-              else
-                @stdoutIncludeSystemPods.concat("," + systemPod)
-              end
-            end
+            @stdoutIncludeSystemPods = stdoutsytemPods.join(",")
             puts "config::Using config map setting for stdout log collection to include system pods"
           end
         end
@@ -150,15 +142,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @collectStderrLogs && !stderrSystemPods.nil? && stderrSystemPods.kind_of?(Array)
           # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
           if stderrSystemPods.length > 0 && stderrSystemPods[0].kind_of?(String)
-            #Empty the array to use the values from configmap
-            stderrSystemPods.each do |systemPod|
-              if @stderrIncludeSystemPods.empty?
-                # To not append , for the first element
-                @stderrIncludeSystemPods.concat(systemPod)
-              else
-                @stderrIncludeSystemPods.concat("," + systemPod)
-              end
-            end
+            @stderrIncludeSystemPods = stderrSystemPods.join(",")
             puts "config::Using config map setting for stderr log collection to include system pods"
           end
         end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -87,21 +87,19 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           end
         end
 
-        if @collectStdoutLogs && !stdoutSystemPods.nil?
-          if stdoutSystemPods.kind_of?(Array)
-            # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
-            if stdoutSystemPods.length > 0 && stdoutSystemPods[0].kind_of?(String)
-              #Empty the array to use the values from configmap
-              stdoutSystemPods.each do |systemPod|
-                if @stdoutIncludeSystemPods.empty?
-                  # To not append , for the first element
-                  @stdoutIncludeSystemPods.concat(systemPod)
-                else
-                  @stdoutIncludeSystemPods.concat("," + systemPod)
-                end
+        if @collectStdoutLogs && !stdoutSystemPods.nil? && stdoutSystemPods.kind_of?(Array)
+          # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
+          if stdoutSystemPods.length > 0 && stdoutSystemPods[0].kind_of?(String)
+            #Empty the array to use the values from configmap
+            stdoutSystemPods.each do |systemPod|
+              if @stdoutIncludeSystemPods.empty?
+                # To not append , for the first element
+                @stdoutIncludeSystemPods.concat(systemPod)
+              else
+                @stdoutIncludeSystemPods.concat("," + systemPod)
               end
-              puts "config::Using config map setting for stdout log collection to include system pods"
             end
+            puts "config::Using config map setting for stdout log collection to include system pods"
           end
         end
 
@@ -149,21 +147,19 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           end
         end
 
-        if @collectStderrLogs && !stderrSystemPods.nil?
-          if stderrSystemPods.kind_of?(Array)
-            # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
-            if stderrSystemPods.length > 0 && stderrSystemPods[0].kind_of?(String)
-              #Empty the array to use the values from configmap
-              stderrSystemPods.each do |systemPod|
-                if @stderrIncludeSystemPods.empty?
-                  # To not append , for the first element
-                  @stderrIncludeSystemPods.concat(systemPod)
-                else
-                  @stderrIncludeSystemPods.concat("," + systemPod)
-                end
+        if @collectStderrLogs && !stderrSystemPods.nil? && stderrSystemPods.kind_of?(Array)
+          # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
+          if stderrSystemPods.length > 0 && stderrSystemPods[0].kind_of?(String)
+            #Empty the array to use the values from configmap
+            stderrSystemPods.each do |systemPod|
+              if @stderrIncludeSystemPods.empty?
+                # To not append , for the first element
+                @stderrIncludeSystemPods.concat(systemPod)
+              else
+                @stderrIncludeSystemPods.concat("," + systemPod)
               end
-              puts "config::Using config map setting for stderr log collection to include system pods"
             end
+            puts "config::Using config map setting for stderr log collection to include system pods"
           end
         end
 

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -168,7 +168,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         end
 
         # If we have to collect logs from system pods belonging to exlcuded namespaces from either of the streams we need to reset exclude path to noop
-        if !@stdoutIncludeSystemPods.empty || !@stderrIncludeSystemPods.empty
+        if !@stdoutIncludeSystemPods.empty? || !@stderrIncludeSystemPods.empty?
           @excludePath = "*.csv2"
         end
 

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -20,6 +20,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
+          # include_system_pods = ["coredns"]
 
        [log_collection_settings.stderr]
           # Default value for enabled is true
@@ -29,6 +31,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
+          # include_system_pods = ["coredns"]
 
        [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -206,8 +206,12 @@ var (
 	NameIDMap map[string]string
 	// StdoutIgnoreNamespaceSet set of  excluded K8S namespaces for stdout logs
 	StdoutIgnoreNsSet map[string]bool
+	// StdoutIncludeSystemPodsSet set of included system pods for stdout logs
+	StdoutIncludeSystemPodsSet map[string]bool
 	// StderrIgnoreNamespaceSet set of  excluded K8S namespaces for stderr logs
 	StderrIgnoreNsSet map[string]bool
+	// StderrIncludeSystemPodsSet set of included system pods for stderr logs
+	StderrIncludeSystemPodsSet map[string]bool
 	// DataUpdateMutex read and write mutex access to the container id set
 	DataUpdateMutex = &sync.Mutex{}
 	// ContainerLogTelemetryMutex read and write mutex access to the Container Log Telemetry
@@ -498,6 +502,32 @@ func populateExcludedStderrNamespaces() {
 		for _, ns := range stderrNSExcludeList {
 			Log("Excluding namespace %s for stderr log collection", ns)
 			StderrIgnoreNsSet[strings.TrimSpace(ns)] = true
+		}
+	}
+}
+
+func populateIncludedStdoutSystemPods() {
+	collectStdoutLogs := os.Getenv("AZMON_COLLECT_STDOUT_LOGS")
+	var stdoutIncludedSystemPodsList []string
+	includeList := os.Getenv("AZMON_STDOUT_INCLUDED_SYSTEM_PODS")
+	if (strings.Compare(collectStdoutLogs, "true") == 0) && (len(includeList) > 0) {
+		stdoutIncludedSystemPodsList = strings.Split(includeList, ",")
+		for _, pod := range stdoutIncludedSystemPodsList {
+			Log("Including system pod %s for stdout log collection", pod)
+			StdoutIncludeSystemPodsSet[strings.TrimSpace(pod)] = true
+		}
+	}
+}
+
+func populateIncludedStderrSystemPods() {
+	collectStderrLogs := os.Getenv("AZMON_COLLECT_STDERR_LOGS")
+	var stderrIncludedSystemPodsList []string
+	includeList := os.Getenv("AZMON_STDERR_INCLUDED_SYSTEM_PODS")
+	if (strings.Compare(collectStderrLogs, "true") == 0) && (len(includeList) > 0) {
+		stderrIncludedSystemPodsList = strings.Split(includeList, ",")
+		for _, pod := range stderrIncludedSystemPodsList {
+			Log("Including system pod %s for stdout log collection", pod)
+			StderrIncludeSystemPodsSet[strings.TrimSpace(pod)] = true
 		}
 	}
 }
@@ -1147,13 +1177,28 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 		containerID, k8sNamespace, k8sPodName, containerName := GetContainerIDK8sNamespacePodNameFromFileName(ToString(record["filepath"]))
 		logEntrySource := ToString(record["stream"])
 
+		dsName, deploymentName := "", ""
+		if len(StdoutIncludeSystemPodsSet) > 0 || len(StderrIncludeSystemPodsSet) > 0 {
+			dsName, deploymentName = GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
+		}
+
 		if strings.EqualFold(logEntrySource, "stdout") {
-			if containerID == "" || containsKey(StdoutIgnoreNsSet, k8sNamespace) {
-				continue
+			if containerID == "" { continue }
+			if containsKey(StdoutIgnoreNsSet, k8sNamespace) {
+				if (containsKey(StdoutIncludeSystemPodsSet, dsName) || containsKey(StdoutIncludeSystemPodsSet, deploymentName)) {
+					// do nothing
+				} else {
+					continue
+				}
 			}
 		} else if strings.EqualFold(logEntrySource, "stderr") {
-			if containerID == "" || containsKey(StderrIgnoreNsSet, k8sNamespace) {
-				continue
+			if containerID == "" { continue }
+			if containsKey(StderrIgnoreNsSet, k8sNamespace) {
+				if (containsKey(StderrIncludeSystemPodsSet, dsName) || containsKey(StderrIncludeSystemPodsSet, deploymentName)) {
+					// do nothing
+				} else {
+					continue
+				}
 			}
 		}
 
@@ -1622,6 +1667,21 @@ func GetContainerIDK8sNamespacePodNameFromFileName(filename string) (string, str
 	return id, ns, podName, containerName
 }
 
+// GetDSNameAndDeploymentNameFromK8sPodName tries to extract potential deployment name and daemonset name from the pod name. If its not possible to extract then sends empty string
+func GetDSNameAndDeploymentNameFromK8sPodName(podName string) (string, string) {
+	dsName := ""
+	deploymentName := ""
+	last := strings.LastIndex(podName, "-")
+	if last != -1 {
+		dsName = podName[:last]
+		last = strings.LastIndex(dsName, "-")
+		if last != -1 {
+			deploymentName = dsName[:last]
+		}
+	}
+	return dsName, deploymentName
+}
+
 // InitializePlugin reads and populates plugin configuration
 func InitializePlugin(pluginConfPath string, agentVersion string) {
 	go func() {
@@ -1927,6 +1987,8 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 	if strings.Compare(strings.ToLower(os.Getenv("CONTROLLER_TYPE")), "daemonset") == 0 {
 		populateExcludedStdoutNamespaces()
 		populateExcludedStderrNamespaces()
+		populateIncludedStdoutSystemPods()
+		populateIncludedStderrSystemPods()
 		//enrichment not applicable for ADX and v2 schema
 		if enrichContainerLogs == true && ContainerLogsRouteADX != true && ContainerLogSchemaV2 != true {
 			Log("ContainerLogEnrichment=true; starting goroutine to update containerimagenamemaps \n")

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -512,7 +512,7 @@ func populateIncludedStdoutSystemPods() {
 	collectStdoutLogs := os.Getenv("AZMON_COLLECT_STDOUT_LOGS")
 	var stdoutIncludedSystemPodsList []string
 	includeList := os.Getenv("AZMON_STDOUT_INCLUDED_SYSTEM_PODS")
-	if (strings.Compare(collectStdoutLogs, "true") == 0) && (len(includeList) > 0) {
+	if (collectStdoutLogs == "true") && (len(includeList) > 0) {
 		stdoutIncludedSystemPodsList = strings.Split(includeList, ",")
 		for _, pod := range stdoutIncludedSystemPodsList {
 			Log("Including system pod %s for stdout log collection", pod)
@@ -1182,28 +1182,16 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 		if strings.EqualFold(logEntrySource, "stdout") {
 			if containerID == "" { continue }
 			if containsKey(StdoutIgnoreNsSet, k8sNamespace) {
-				dsName, deploymentName := "", ""
-				if len(StdoutIncludeSystemPodsSet) > 0 {
-					dsName, deploymentName = GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
-				}
-				if (containsKey(StdoutIncludeSystemPodsSet, dsName) || containsKey(StdoutIncludeSystemPodsSet, deploymentName)) {
-					// do nothing
-				} else {
-					continue
-				}
+				if len(StdoutIncludeSystemPodsSet) == 0 { continue }
+				dsName, deploymentName := GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
+				if (!containsKey(StdoutIncludeSystemPodsSet, dsName) && !containsKey(StdoutIncludeSystemPodsSet, deploymentName)) { continue }
 			}
 		} else if strings.EqualFold(logEntrySource, "stderr") {
 			if containerID == "" { continue }
 			if containsKey(StderrIgnoreNsSet, k8sNamespace) {
-				dsName, deploymentName := "", ""
-				if len(StderrIncludeSystemPodsSet) > 0 {
-					dsName, deploymentName = GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
-				}
-				if (containsKey(StderrIncludeSystemPodsSet, dsName) || containsKey(StderrIncludeSystemPodsSet, deploymentName)) {
-					// do nothing
-				} else {
-					continue
-				}
+				if len(StderrIncludeSystemPodsSet) == 0 { continue }
+				dsName, deploymentName := GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
+				if (!containsKey(StderrIncludeSystemPodsSet, dsName) && !containsKey(StderrIncludeSystemPodsSet, deploymentName)) { continue }
 			}
 		}
 


### PR DESCRIPTION
- enabled log collection of specific pods from excluded system namespaces
- use daemonset and deployment names to identify pods whose logs need to be collected.
- extracts potential ds and deployment names from podName and matches against user provided input in configmap option include_system_pods

eg. user sets include_system_pods = ["coredns"] where coredns can be deployment name or daemonset name which will result in pod name coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. 