### PR TITLE
collect logs from pods from excluded system ns (#1138)

### DIFF
--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -98,10 +98,16 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stdoutSystemPods.each_with_object([]) do |pod, entries|
             namespace, _controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && @stdoutExcludeNamespaces.include?(namespace)
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stdoutExcludeNamespaces.include?(namespace)
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
+              unless @allowed_system_namespaces.include?(namespace)
+                puts "config:: collect_system_pod_logs only works for system namespaces #{@allowed_system_namespaces}"
+              end
+              if @stdoutExcludeNamespaces.include?(namespace)
+                puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
+              end
             end
           end
 
@@ -159,10 +165,16 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stderrSystemPods.each_with_object([]) do |pod, entries|
             namespace, _controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && @stderrExcludeNamespaces.include?(namespace)
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stderrExcludeNamespaces.include?(namespace)
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
+              unless @allowed_system_namespaces.include?(namespace)
+                puts "config:: collect_system_pod_logs only works for system namespaces #{@allowed_system_namespaces}"
+              end
+              if @stdoutExcludeNamespaces.include?(namespace)
+                puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
+              end
             end
           end
 

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -98,7 +98,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stdoutSystemPods.each_with_object([]) do |pod, entries|
             namespace, controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && !@stdoutExcludeNamespaces.include?(namespace) && !controller&.empty?
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stdoutExcludeNamespaces.include?(namespace) && controller && !controller.empty?
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
@@ -108,7 +108,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
               end
-              if controller&.empty?
+              if !controller || controler.empty?
                 puts "config:: Please provide valid controller name. controller name is empty"
               end
             end
@@ -168,7 +168,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stderrSystemPods.each_with_object([]) do |pod, entries|
             namespace, controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && !@stderrExcludeNamespaces.include?(namespace) && !controller&.empty?
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stderrExcludeNamespaces.include?(namespace) && controller && !controller.empty?
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
@@ -178,7 +178,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
               end
-              if controller&.empty?
+              if !controller || controler.empty?
                 puts "config:: Please provide valid controller name. controller name is empty"
               end
             end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -97,8 +97,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @collectStdoutLogs && stdoutSystemPods.is_a?(Array) && !stdoutSystemPods.empty?
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stdoutSystemPods.each_with_object([]) do |pod, entries|
-            namespace, _controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && !@stdoutExcludeNamespaces.include?(namespace)
+            namespace, controller = pod.split(':') # Split once and use the result
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stdoutExcludeNamespaces.include?(namespace) && !controller&.empty?
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
@@ -107,6 +107,9 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               end
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
+              end
+              if controller&.empty?
+                puts "config:: Please provide valid controller name. controller name is empty"
               end
             end
           end
@@ -164,8 +167,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @collectStderrLogs && stderrSystemPods.is_a?(Array) && !stderrSystemPods.empty?
           # Using is_a? for type checking and directly checking if the array is not empty
           filtered_entries = stderrSystemPods.each_with_object([]) do |pod, entries|
-            namespace, _controller = pod.split(':') # Split once and use the result
-            if namespace && @allowed_system_namespaces.include?(namespace) && !@stderrExcludeNamespaces.include?(namespace)
+            namespace, controller = pod.split(':') # Split once and use the result
+            if namespace && @allowed_system_namespaces.include?(namespace) && !@stderrExcludeNamespaces.include?(namespace) && !controller&.empty?
               entries << pod
             else
               puts "config:: invalid entry for collect_system_pod_logs: #{pod}"
@@ -174,6 +177,9 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               end
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
+              end
+              if controller&.empty?
+                puts "config:: Please provide valid controller name. controller name is empty"
               end
             end
           end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -94,7 +94,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if @collectStdoutLogs && !stdoutSystemPods.nil? && stdoutSystemPods.kind_of?(Array)
           # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
           if stdoutSystemPods.length > 0 && stdoutSystemPods[0].kind_of?(String)
-            @stdoutIncludeSystemPods = stdoutsytemPods.join(",")
+            @stdoutIncludeSystemPods = stdoutSystemPods.join(",")
             puts "config::Using config map setting for stdout log collection to include system pods"
           end
         end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -67,8 +67,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         stdoutNamespaces = parsedConfig[:log_collection_settings][:stdout][:exclude_namespaces]
         
         stdoutSystemPods = Array.new
-        if !parsedConfig[:log_collection_settings][:stdout][:include_system_pods].nil?
-          stdoutSystemPods = parsedConfig[:log_collection_settings][:stdout][:include_system_pods]
+        if !parsedConfig[:log_collection_settings][:stdout][:collect_system_pod_logs].nil?
+          stdoutSystemPods = parsedConfig[:log_collection_settings][:stdout][:collect_system_pod_logs]
         end
 
         #Clearing it, so that it can be overridden with the config map settings
@@ -112,8 +112,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         stderrNamespaces = parsedConfig[:log_collection_settings][:stderr][:exclude_namespaces]
 
         stderrSystemPods = Array.new
-        if !parsedConfig[:log_collection_settings][:stderr][:include_system_pods].nil?
-          stderrSystemPods = parsedConfig[:log_collection_settings][:stderr][:include_system_pods]
+        if !parsedConfig[:log_collection_settings][:stderr][:collect_system_pod_logs].nil?
+          stderrSystemPods = parsedConfig[:log_collection_settings][:stderr][:collect_system_pod_logs]
         end
 
         stdoutNamespaces = Array.new
@@ -149,11 +149,6 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             @stderrIncludeSystemPods = stderrSystemPods.join(",")
             puts "config::Using config map setting for stderr log collection to include system pods"
           end
-        end
-
-        # If we have to collect logs from system pods belonging to exlcuded namespaces from either of the streams we need to reset exclude path to noop
-        if !@stdoutIncludeSystemPods.empty? || !@stderrIncludeSystemPods.empty?
-          @excludePath = "*.csv2"
         end
 
       end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -108,7 +108,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
               end
-              if !controller || controler.empty?
+              if !controller || controller.empty?
                 puts "config:: Please provide valid controller name. controller name is empty"
               end
             end
@@ -178,7 +178,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               if @stdoutExcludeNamespaces.include?(namespace)
                 puts "config:: please remove #{namespace} from exclude_namespaces to use collect_system_pod_logs"
               end
-              if !controller || controler.empty?
+              if !controller || controller.empty?
                 puts "config:: Please provide valid controller name. controller name is empty"
               end
             end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -12,8 +12,10 @@ require_relative "ConfigParseErrorLogger"
 # Setting default values which will be used in case they are not set in the configmap or if configmap doesnt exist
 @collectStdoutLogs = true
 @stdoutExcludeNamespaces = "kube-system,gatekeeper-system"
+@stdoutIncludeSystemPods = ""
 @collectStderrLogs = true
 @stderrExcludeNamespaces = "kube-system,gatekeeper-system"
+@stderrIncludeSystemPods = ""
 @collectClusterEnvVariables = true
 @logTailPath = "/var/log/containers/*.log"
 @logExclusionRegexPattern = "(^((?!stdout|stderr).)*$)"
@@ -63,6 +65,11 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         @collectStdoutLogs = parsedConfig[:log_collection_settings][:stdout][:enabled]
         puts "config::Using config map setting for stdout log collection"
         stdoutNamespaces = parsedConfig[:log_collection_settings][:stdout][:exclude_namespaces]
+        
+        stdoutSystemPods = Array.new
+        if !parsedConfig[:log_collection_settings][:stdout][:include_system_pods].nil?
+          stdoutSystemPods = parsedConfig[:log_collection_settings][:stdout][:include_system_pods]
+        end
 
         #Clearing it, so that it can be overridden with the config map settings
         @stdoutExcludeNamespaces.clear
@@ -83,6 +90,15 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             end
           end
         end
+
+        if @collectStdoutLogs && !stdoutSystemPods.nil? && stdoutSystemPods.kind_of?(Array)
+          # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
+          if stdoutSystemPods.length > 0 && stdoutSystemPods[0].kind_of?(String)
+            @stdoutIncludeSystemPods = stdoutsytemPods.join(",")
+            puts "config::Using config map setting for stdout log collection to include system pods"
+          end
+        end
+
       end
     rescue => errorStr
       ConfigParseErrorLogger.logError("Exception while reading config map settings for stdout log collection - #{errorStr}, using defaults, please check config map for errors")
@@ -94,6 +110,12 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         @collectStderrLogs = parsedConfig[:log_collection_settings][:stderr][:enabled]
         puts "config::Using config map setting for stderr log collection"
         stderrNamespaces = parsedConfig[:log_collection_settings][:stderr][:exclude_namespaces]
+
+        stderrSystemPods = Array.new
+        if !parsedConfig[:log_collection_settings][:stderr][:include_system_pods].nil?
+          stderrSystemPods = parsedConfig[:log_collection_settings][:stderr][:include_system_pods]
+        end
+
         stdoutNamespaces = Array.new
         #Clearing it, so that it can be overridden with the config map settings
         @stderrExcludeNamespaces.clear
@@ -120,6 +142,20 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             end
           end
         end
+
+        if @collectStderrLogs && !stderrSystemPods.nil? && stderrSystemPods.kind_of?(Array)
+          # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
+          if stderrSystemPods.length > 0 && stderrSystemPods[0].kind_of?(String)
+            @stderrIncludeSystemPods = stderrSystemPods.join(",")
+            puts "config::Using config map setting for stderr log collection to include system pods"
+          end
+        end
+
+        # If we have to collect logs from system pods belonging to exlcuded namespaces from either of the streams we need to reset exclude path to noop
+        if !@stdoutIncludeSystemPods.empty? || !@stderrIncludeSystemPods.empty?
+          @excludePath = "*.csv2"
+        end
+
       end
     rescue => errorStr
       ConfigParseErrorLogger.logError("Exception while reading config map settings for stderr log collection - #{errorStr}, using defaults, please check config map for errors")
@@ -306,8 +342,10 @@ if !file.nil?
   file.write("export AZMON_LOG_TAIL_PATH_DIR=#{logTailPathDir}\n")
   file.write("export AZMON_LOG_EXCLUSION_REGEX_PATTERN=\"#{@logExclusionRegexPattern}\"\n")
   file.write("export AZMON_STDOUT_EXCLUDED_NAMESPACES=#{@stdoutExcludeNamespaces}\n")
+  file.write("export AZMON_STDOUT_INCLUDED_SYSTEM_PODS=#{@stdoutIncludeSystemPods}\n")
   file.write("export AZMON_COLLECT_STDERR_LOGS=#{@collectStderrLogs}\n")
   file.write("export AZMON_STDERR_EXCLUDED_NAMESPACES=#{@stderrExcludeNamespaces}\n")
+  file.write("export AZMON_STDERR_INCLUDED_SYSTEM_PODS=#{@stderrIncludeSystemPods}\n")
   file.write("export AZMON_CLUSTER_COLLECT_ENV_VAR=#{@collectClusterEnvVariables}\n")
   file.write("export AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH=#{@excludePath}\n")
   file.write("export AZMON_CLUSTER_CONTAINER_LOG_ENRICH=#{@enrichContainerLogs}\n")
@@ -364,9 +402,13 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
     file.write(commands)
     commands = get_command_windows("AZMON_STDOUT_EXCLUDED_NAMESPACES", @stdoutExcludeNamespaces)
     file.write(commands)
+    commands = get_command_windows("AZMON_STDOUT_INCLUDED_SYSTEM_PODS", @stdoutIncludeSystemPods)
+    file.write(commands)
     commands = get_command_windows("AZMON_COLLECT_STDERR_LOGS", @collectStderrLogs)
     file.write(commands)
     commands = get_command_windows("AZMON_STDERR_EXCLUDED_NAMESPACES", @stderrExcludeNamespaces)
+    file.write(commands)
+    commands = get_command_windows("AZMON_STDERR_INCLUDED_SYSTEM_PODS", @stderrIncludeSystemPods)
     file.write(commands)
     commands = get_command_windows("AZMON_CLUSTER_COLLECT_ENV_VAR", @collectClusterEnvVariables)
     file.write(commands)

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -20,6 +20,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
+          # include_system_pods = ["coredns"]
 
        [log_collection_settings.stderr]
           # Default value for enabled is true
@@ -29,6 +31,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
+          # include_system_pods = ["coredns"]
 
        [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -20,7 +20,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
-          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for system pods
+          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.stderr]
@@ -31,7 +32,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
-          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for system pods
+          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.env_var]

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -21,7 +21,7 @@ data:
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
-          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.stderr]
@@ -33,7 +33,7 @@ data:
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
-          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.env_var]

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -20,8 +20,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
-          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
-          # include_system_pods = ["coredns"]
+          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for system pods
+          # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.stderr]
           # Default value for enabled is true
@@ -31,8 +31,8 @@ data:
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
-          # If you want to collect logs from system pods that have been excluded using exclude_namespaces setting, add them to the following setting. Provide daemonset or deployment name of the system pod. Eg adding coredns to list can capture logs from pods with name like coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. NOTE: this setting is only for system pods
-          # include_system_pods = ["coredns"]
+          # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for system pods
+          # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1503,7 +1503,7 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			if containerID == "" || containsKey(StdoutIgnoreNsSet, k8sNamespace) {
 				continue
 			}
-			if containsKey(StdoutIncludeSystemNamespaceSet, k8sNamespace) {
+			if len(StdoutIncludeSystemNamespaceSet) > 0 && containsKey(StdoutIncludeSystemNamespaceSet, k8sNamespace) {
 				if len(StdoutIncludeSystemResourceSet) != 0 {
 					dsName, deploymentName := GetControllerNameFromK8sPodName(k8sPodName)
 					if !containsKey(StdoutIncludeSystemResourceSet, k8sNamespace+":"+dsName) && !containsKey(StdoutIncludeSystemResourceSet, k8sNamespace+":"+deploymentName) {
@@ -1515,7 +1515,7 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			if containerID == "" || containsKey(StderrIgnoreNsSet, k8sNamespace) {
 				continue
 			}
-			if containsKey(StderrIncludeSystemNamespaceSet, k8sNamespace) {
+			if len(StderrIncludeSystemNamespaceSet) > 0 && containsKey(StderrIncludeSystemNamespaceSet, k8sNamespace) {
 				if len(StderrIncludeSystemResourceSet) != 0 {
 					dsName, deploymentName := GetControllerNameFromK8sPodName(k8sPodName)
 					if !containsKey(StderrIncludeSystemResourceSet, k8sNamespace+":"+dsName) && !containsKey(StderrIncludeSystemResourceSet, k8sNamespace+":"+deploymentName) {

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -2010,6 +2010,7 @@ func GetContainerIDK8sNamespacePodNameFromFileName(filename string) (string, str
 func GetControllerNameFromK8sPodName (podName string) (string, string) {
 	// clear cache if it exceeds the cache size
 	if len(PodNameToControllerNameMap) > PodNameToControllerNameMapCacheSize {
+		Log("Clearing PodNameToControllerNameMap cache")
 		PodNameToControllerNameMap = make(map[string][2]string)
 	}
 

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -127,11 +127,11 @@ const ContainerTypeEnv = "CONTAINER_TYPE"
 const DefaultAdxDatabaseName = "containerinsights"
 
 var SystemNamespaces = map[string]bool{
-	"kube-system":        true,
-	"azure-arc":          true,
-	"gatekeeper-system":  true,
-	"kube-public":        true,
-	"kube-node-lease":    true,
+	"kube-system":       true,
+	"azure-arc":         true,
+	"gatekeeper-system": true,
+	"kube-public":       true,
+	"kube-node-lease":   true,
 }
 
 var (
@@ -1524,7 +1524,9 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			if containsKey(SystemNamespaces, k8sNamespace) && containsKey(StdoutIncludeSystemNamespaceSet, k8sNamespace) {
 				if len(StdoutIncludeSystemResourceSet) != 0 {
 					dsName, deploymentName := GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
-					if (!containsKey(StdoutIncludeSystemResourceSet, k8sNamespace + ":" + dsName) && !containsKey(StdoutIncludeSystemResourceSet, k8sNamespace + ":" + deploymentName)) { continue }
+					if !containsKey(StdoutIncludeSystemResourceSet, k8sNamespace+":"+dsName) && !containsKey(StdoutIncludeSystemResourceSet, k8sNamespace+":"+deploymentName) {
+						continue
+					}
 				}
 			}
 		} else if strings.EqualFold(logEntrySource, "stderr") {
@@ -1534,7 +1536,9 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			if containsKey(SystemNamespaces, k8sNamespace) && containsKey(StderrIncludeSystemNamespaceSet, k8sNamespace) {
 				if len(StderrIncludeSystemResourceSet) != 0 {
 					dsName, deploymentName := GetDSNameAndDeploymentNameFromK8sPodName(k8sPodName)
-					if (!containsKey(StderrIncludeSystemResourceSet, k8sNamespace + ":" + dsName) && !containsKey(StderrIncludeSystemResourceSet, k8sNamespace + ":" + deploymentName)) { continue }
+					if !containsKey(StderrIncludeSystemResourceSet, k8sNamespace+":"+dsName) && !containsKey(StderrIncludeSystemResourceSet, k8sNamespace+":"+deploymentName) {
+						continue
+					}
 				}
 			}
 		}
@@ -1700,6 +1704,9 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 	}
 
 	numContainerLogRecords := 0
+
+	Log("StdoutIncludeSystemResourceSet : %v, StderrIncludeSystemResourceSet: %v, StdoutIncludeSystemNamespaceSet: %v, StderrIncludeSystemNamespaceSet: %v, PodNameToDSDeploymentNameMap: %v",
+		StdoutIncludeSystemResourceSet, StderrIncludeSystemResourceSet, StdoutIncludeSystemNamespaceSet, StderrIncludeSystemNamespaceSet, PodNameToDSDeploymentNameMap)
 
 	if ContainerLogSchemaV2 == true {
 		MdsdContainerLogTagName = MdsdContainerLogV2SourceName

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -32,6 +32,8 @@ class CAdvisorMetricsAPIClient
   @clusterKubernetesMetadataIncludeFields = ENV["AZMON_KUBERNETES_METADATA_INCLUDES_FIELDS"]
   @clusterAnnotationBasedFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]
   @clusterKubernetesMetadataCacheTTLSeconds = ENV["AZMON_KUBERNETES_METADATA_CACHE_TTL_SECONDS"]
+  @clusterStdOutIncludedSystemPods = ENV["AZMON_STDOUT_INCLUDED_SYSTEM_PODS"]
+  @clusterStdErrIncludedSystemPods = ENV["AZMON_STDERR_INCLUDED_SYSTEM_PODS"]
 
   @dsPromInterval = ENV["TELEMETRY_DS_PROM_INTERVAL"]
   @dsPromFieldPassCount = ENV["TELEMETRY_DS_PROM_FIELDPASS_LENGTH"]
@@ -319,6 +321,12 @@ class CAdvisorMetricsAPIClient
                     end
                     if (!@clusterKubernetesMetadataCacheTTLSeconds.nil? && !@clusterKubernetesMetadataCacheTTLSeconds.empty?)
                       telemetryProps["metadataCacheTTL"] = @clusterKubernetesMetadataCacheTTLSeconds
+                    end
+                    if (!@clusterStdOutIncludedSystemPods.nil? && !@clusterStdOutIncludedSystemPods.empty?)
+                      telemetryProps["stdoutSystemPods"] = @clusterStdOutIncludedSystemPods
+                    end
+                    if (!@clusterStdErrIncludedSystemPods.nil? && !@clusterStdErrIncludedSystemPods.empty?)
+                      telemetryProps["stderrSystemPods"] = @clusterStdErrIncludedSystemPods
                     end
                     ApplicationInsightsUtility.sendMetricTelemetry(metricNametoReturn, metricValue, telemetryProps)
                   end


### PR DESCRIPTION
- enabled log collection of specific pods from system namespaces.
- use daemonset and deployment names to identify pods whose logs need to be collected.
- extracts potential ds and deployment names from podName and matches against user provided input in configmap option include_system_pods

eg. user sets include_system_pods = ["coredns"] where coredns can be deployment name or daemonset name which will result in pod name coredns-77sd7 or coredns-65cbf4f7bc-jcn6z. 