### PR TITLE
make multiline languages configurable

### DIFF
--- a/build/common/installer/conf/azm-containers-parser-multiline.conf
+++ b/build/common/installer/conf/azm-containers-parser-multiline.conf
@@ -1,7 +1,7 @@
 [MULTILINE_PARSER]
     name          dotnet
     type          regex
-    flush_timeout 1000 # milliseconds
+    flush_timeout 4000 # milliseconds, set to fluent-bit default https://github.com/fluent/fluent-bit/blob/master/include/fluent-bit/multiline/flb_ml.h#L50
     
     # Regex rules for multiline parsing
     # ---------------------------------

--- a/build/common/installer/conf/azm-containers-parser-multiline.conf
+++ b/build/common/installer/conf/azm-containers-parser-multiline.conf
@@ -1,5 +1,5 @@
 [MULTILINE_PARSER]
-    name          dotnet-multiline
+    name          dotnet
     type          regex
     flush_timeout 1000 # milliseconds
     

--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -17,9 +17,10 @@ def is_number?(value)
   true if Integer(value) rescue false
 end
 
-def substituteMultiline(multilineLogging, new_contents)
-    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true"
+def substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
+    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true" && !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
       new_contents = new_contents.gsub("#${MultilineEnabled}", "")
+      new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
       new_contents = new_contents.gsub("azm-containers-parser.conf", "azm-containers-parser-multiline.conf")
       # replace parser with multiline version. ensure running script multiple times does not have negative impact
       if (/[^\.]Parser\s{1,}docker/).match(new_contents)
@@ -43,6 +44,7 @@ def substituteFluentBitPlaceHolders
     memBufLimit = ENV["FBIT_TAIL_MEM_BUF_LIMIT"]
     ignoreOlder = ENV["FBIT_TAIL_IGNORE_OLDER"]
     multilineLogging = ENV["AZMON_MULTILINE_ENABLED"]
+    stacktraceLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
 
     serviceInterval = (!interval.nil? && is_number?(interval) && interval.to_i > 0) ? interval : @default_service_interval
     serviceIntervalSetting = "Flush         " + serviceInterval
@@ -79,13 +81,13 @@ def substituteFluentBitPlaceHolders
       new_contents = new_contents.gsub("\n    ${TAIL_IGNORE_OLDER}\n", "\n")
     end
 
-    new_contents = substituteMultiline(multilineLogging, new_contents)
+    new_contents = substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
     File.open(@fluent_bit_conf_path, "w") { |file| file.puts new_contents }
     puts "config::Successfully substituted the placeholders in fluent-bit.conf file"
 
     puts "config::Starting to substitute the placeholders in fluent-bit-common.conf file for log collection"
     text = File.read(@fluent_bit_common_conf_path)
-    new_contents = substituteMultiline(multilineLogging, text)
+    new_contents = substituteMultiline(multilineLogging, stacktraceLanguages, text)
     File.open(@fluent_bit_common_conf_path, "w") { |file| file.puts new_contents }
     puts "config::Successfully substituted the placeholders in fluent-bit-common.conf file"
 

--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -18,9 +18,11 @@ def is_number?(value)
 end
 
 def substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
-    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true" && !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
-      new_contents = new_contents.gsub("#${MultilineEnabled}", "")
-      new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
+    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true"
+      if !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
+        new_contents = new_contents.gsub("#${MultilineEnabled}", "")
+        new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
+      end
       new_contents = new_contents.gsub("azm-containers-parser.conf", "azm-containers-parser-multiline.conf")
       # replace parser with multiline version. ensure running script multiple times does not have negative impact
       if (/[^\.]Parser\s{1,}docker/).match(new_contents)

--- a/build/common/installer/scripts/fluent-bit-geneva-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-geneva-conf-customizer.rb
@@ -38,6 +38,7 @@ def substituteFluentBitPlaceHolders(configFilePath)
     memBufLimit = ENV["FBIT_TAIL_MEM_BUF_LIMIT"]
     ignoreOlder = ENV["FBIT_TAIL_IGNORE_OLDER"]
     multilineLogging = ENV["AZMON_MULTILINE_ENABLED"]
+    stacktraceLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
     enableFluentBitThreading = ENV["ENABLE_FBIT_THREADING"]
 
     serviceInterval = is_valid_number?(interval) ? interval : @default_service_interval
@@ -81,8 +82,9 @@ def substituteFluentBitPlaceHolders(configFilePath)
       new_contents = new_contents.gsub("\n    ${TAIL_THREADED}\n", "\n")
     end
 
-    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true"
+    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true" && !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
       new_contents = new_contents.gsub("#${MultilineEnabled}", "")
+      new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
       new_contents = new_contents.gsub("azm-containers-parser.conf", "azm-containers-parser-multiline.conf")
       # replace parser with multiline version. ensure running script multiple times does not have negative impact
       if (/[^\.]Parser\s{1,}docker/).match(text)

--- a/build/common/installer/scripts/fluent-bit-geneva-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-geneva-conf-customizer.rb
@@ -82,9 +82,11 @@ def substituteFluentBitPlaceHolders(configFilePath)
       new_contents = new_contents.gsub("\n    ${TAIL_THREADED}\n", "\n")
     end
 
-    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true" && !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
-      new_contents = new_contents.gsub("#${MultilineEnabled}", "")
-      new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
+    if !multilineLogging.nil? && multilineLogging.to_s.downcase == "true"
+      if !stacktraceLanguages.nil? && !stacktraceLanguages.empty?
+        new_contents = new_contents.gsub("#${MultilineEnabled}", "")
+        new_contents = new_contents.gsub("#${MultilineLanguages}", stacktraceLanguages)
+      end
       new_contents = new_contents.gsub("azm-containers-parser.conf", "azm-containers-parser-multiline.conf")
       # replace parser with multiline version. ensure running script multiple times does not have negative impact
       if (/[^\.]Parser\s{1,}docker/).match(text)

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -168,11 +168,18 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           if multilineLanguages.kind_of?(Array)
             # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
             # update stacktraceLanguages only if customer explicity overrode via configmap
+            #Empty the array to use the values from configmap
+            @stacktraceLanguages.clear
             if multilineLanguages.length > 0 && multilineLanguages[0].kind_of?(String)
-              #Empty the array to use the values from configmap
-              @stacktraceLanguages.clear
-              @stacktraceLanguages = multilineLanguages.join(",")
-              puts "config::Using config map setting for multiline languages"
+              invalid_lang = multilineLanguages.any? { |lang| !["java", "python", "go", "dotnet"].include?(lang.downcase) }
+              if invalid_lang
+                puts "config::WARN: stacktrace languages contains invalid languages. Disabling multiline stacktrace logging"
+              else
+                @stacktraceLanguages = multilineLanguages.join(",").downcase
+                puts "config::Using config map setting for multiline languages"
+              end
+            else
+              puts "config::WARN: stacktrace languages is not an array of strings. Disabling multiline stacktrace logging"
             end
           end
         end

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -24,7 +24,7 @@ require_relative "ConfigParseErrorLogger"
 @containerLogsRoute = "v2" # default for linux
 @adxDatabaseName = "containerinsights" # default for all configurations
 @logEnableMultiline = "false"
-@stacktraceLanguages = "go,java,python"
+@stacktraceLanguages = "go,java,python,dotnet"
 if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
   @containerLogsRoute = "v1" # default is v1 for windows until windows agent integrates windows ama
   # This path format is necessary for fluent-bit in windows
@@ -167,17 +167,11 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         if !multilineLanguages.nil?
           if multilineLanguages.kind_of?(Array)
             # Checking only for the first element to be string because toml enforces the arrays to contain elements of same type
+            # update stacktraceLanguages only if customer explicity overrode via configmap
             if multilineLanguages.length > 0 && multilineLanguages[0].kind_of?(String)
               #Empty the array to use the values from configmap
               @stacktraceLanguages.clear
-              multilineLanguages.each do |language|
-                if @stacktraceLanguages.empty?
-                  # To not append , for the first element
-                  @stacktraceLanguages.concat(language)
-                else
-                  @stacktraceLanguages.concat("," + language)
-                end
-              end
+              @stacktraceLanguages = multilineLanguages.join(",")
               puts "config::Using config map setting for multiline languages"
             end
           end

--- a/build/linux/installer/conf/fluent-bit-geneva.conf
+++ b/build/linux/installer/conf/fluent-bit-geneva.conf
@@ -33,4 +33,4 @@
 #${MultilineEnabled}    Name multiline
 #${MultilineEnabled}    Match geneva.container.log.*
 #${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}

--- a/build/linux/installer/conf/fluent-bit.conf
+++ b/build/linux/installer/conf/fluent-bit.conf
@@ -43,4 +43,4 @@
 #${MultilineEnabled}    Name multiline
 #${MultilineEnabled}    Match oms.container.log.la.*
 #${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}

--- a/build/windows/installer/conf/fluent-bit-geneva.conf
+++ b/build/windows/installer/conf/fluent-bit-geneva.conf
@@ -31,4 +31,4 @@
 #${MultilineEnabled}    Name multiline
 #${MultilineEnabled}    Match geneva.container.log.*
 #${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}

--- a/build/windows/installer/conf/fluent-bit.conf
+++ b/build/windows/installer/conf/fluent-bit.conf
@@ -42,4 +42,4 @@
 #${MultilineEnabled}    Name multiline
 #${MultilineEnabled}    Match oms.container.log.la.*
 #${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser go, java, python, dotnet-multiline
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -48,9 +48,11 @@ data:
           # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
           # containerlog_schema_version = "v2"
        #[log_collection_settings.enable_multiline_logs]
-          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces.
+          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces. Update stacktrace_languages to specificy which languages to collect stacktraces for. Default Go, Java, and Python.
+          # NOTE: for better performance consider enabling only for languages that are needed
           # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
           # enabled = "false"
+          # stacktrace_languages = ["go", "java", "python"] 
 
 
   prometheus-data-collection-settings: |-

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -48,9 +48,9 @@ data:
           # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
           # containerlog_schema_version = "v2"
        #[log_collection_settings.enable_multiline_logs]
-          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces. Update stacktrace_languages to specificy which languages to collect stacktraces for. Default Go, Java, Python, Dotnet.
+          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces. Update stacktrace_languages to specificy which languages to collect stacktraces for(valid inputs: go, java, python, dotnet). Default enables all.
           # NOTE: for better performance consider enabling only for languages that are needed. Dotnet is experimental and may not work in all cases.
-          # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
+          # If enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
           # enabled = "false"
           # stacktrace_languages = ["go", "java", "python", "dotnet"] 
 

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -48,11 +48,11 @@ data:
           # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
           # containerlog_schema_version = "v2"
        #[log_collection_settings.enable_multiline_logs]
-          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces. Update stacktrace_languages to specificy which languages to collect stacktraces for. Default Go, Java, and Python.
-          # NOTE: for better performance consider enabling only for languages that are needed
+          # fluent-bit based multiline log collection for .NET, Go, Java, and Python stacktraces. Update stacktrace_languages to specificy which languages to collect stacktraces for. Default Go, Java, Python, Dotnet.
+          # NOTE: for better performance consider enabling only for languages that are needed. Dotnet is experimental and may not work in all cases.
           # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
           # enabled = "false"
-          # stacktrace_languages = ["go", "java", "python"] 
+          # stacktrace_languages = ["go", "java", "python", "dotnet"] 
 
 
   prometheus-data-collection-settings: |-

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -27,6 +27,7 @@ class CAdvisorMetricsAPIClient
   @clusterContainerLogEnrich = ENV["AZMON_CLUSTER_CONTAINER_LOG_ENRICH"]
   @clusterContainerLogSchemaVersion = ENV["AZMON_CONTAINER_LOG_SCHEMA_VERSION"]
   @clusterMultilineEnabled = ENV["AZMON_MULTILINE_ENABLED"]
+  @clusterMultilineLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
 
   @dsPromInterval = ENV["TELEMETRY_DS_PROM_INTERVAL"]
   @dsPromFieldPassCount = ENV["TELEMETRY_DS_PROM_FIELDPASS_LENGTH"]
@@ -299,6 +300,9 @@ class CAdvisorMetricsAPIClient
                     end
                     if (!@clusterMultilineEnabled.nil? && !@clusterMultilineEnabled.empty?)
                       telemetryProps["multilineEnabled"] = @clusterMultilineEnabled
+                      if (!@clusterMultilineLanguages.nil? && !@clusterMultilineLanguages.empty?)
+                        telemetryProps["multilineLanguages"] = @clusterMultilineLanguages
+                      end
                     end
                     ApplicationInsightsUtility.sendMetricTelemetry(metricNametoReturn, metricValue, telemetryProps)
                   end


### PR DESCRIPTION
- makes .NET optional. Default now is Go, Python and Java
- Customers can override defaults by using stacktrace_languages option in configmap to select the languages they want to use