### PR TITLE
make dotnet conform better to stacktrace format

### DIFF
--- a/build/common/installer/conf/azm-containers-parser-multiline.conf
+++ b/build/common/installer/conf/azm-containers-parser-multiline.conf
@@ -13,6 +13,7 @@
     
     # rules |   state name  | regex pattern                  | next state
     # ------|---------------|--------------------------------------------
-    rule      "start_state"     "/^( *)(?!at).*Exception.*/"                                                                                                                  "at"
-    rule      "at"              "/^( *)at ([._\w\d]*(\.[._\w\d<>]+)?)\.([_\w\d\[\]<>]*)\((([_\w\d]+(\[\]|&|\*)? [_\w\d]+)(, )?)*\)( in .*)?(:line *\d*)?/"                    "at2"
-    rule      "at2"             "/^( *)(at .*|--- End of inner exception stack trace ---)/"                                                                                   "at2"
+
+    rule      "start_state"     "/^[\s]*[\w\.]*Exception: /"                                                           "stack_trace"
+    rule      "stack_trace"     "/^[\s]*at [\w\.\+<>]+[\[\]\w\.\+<>]*\(.*?\)( in )?.*/"                                "stack_trace"
+    rule      "stack_trace"     "/^[\s]*--- End of (inner exception stack trace|stack trace) ---/"                     "stack_trace"

--- a/build/common/installer/conf/azm-containers-parser-multiline.conf
+++ b/build/common/installer/conf/azm-containers-parser-multiline.conf
@@ -14,6 +14,6 @@
     # rules |   state name  | regex pattern                  | next state
     # ------|---------------|--------------------------------------------
 
-    rule      "start_state"     "/^[\s]*[\w\.]*Exception: /"                                                           "stack_trace"
+    rule      "start_state"     "/^[\s]*(?![a-z]+\.[\w\.]+Exception:)[\w]+(\.[\w]+)+Exception:/"                       "stack_trace"
     rule      "stack_trace"     "/^[\s]*at [\w\.\+<>]+[\[\]\w\.\+<>]*\(.*?\)( in )?.*/"                                "stack_trace"
     rule      "stack_trace"     "/^[\s]*--- End of (inner exception stack trace|stack trace) ---/"                     "stack_trace"


### PR DESCRIPTION
the start_state was unnecessarily broad in scope. Reduced its scope to match .NET stacktraces better. 

Eg. it shouldn't match java exceptions which are similar pattern eg: redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Broken pipe (Write failed)

New start_state regex rubular link https://rubular.com/r/JJmfqcpw6eTacN  

Tested on CI/CD multiline cluster