### PR TITLE
make multiline filter first in pipeline

### DIFF
--- a/build/linux/installer/conf/fluent-bit-geneva.conf
+++ b/build/linux/installer/conf/fluent-bit-geneva.conf
@@ -12,9 +12,13 @@
     Log_Level     info
     Parsers_File  /etc/opt/microsoft/docker-cimprov/azm-containers-parser.conf
     Log_File      /var/opt/microsoft/docker-cimprov/log/fluent-bit-geneva.log
-@INCLUDE fluent-bit-common.conf
-@INCLUDE fluent-bit-geneva-logs_*.conf
-@INCLUDE fluent-bit-internal-metrics.conf
+
+#NOTE: Multiline should be the first filter https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace
+#${MultilineEnabled}[FILTER]
+#${MultilineEnabled}    Name multiline
+#${MultilineEnabled}    Match geneva.container.log.*
+#${MultilineEnabled}    multiline.key_content log
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
 
 [FILTER]
     Name grep
@@ -29,8 +33,6 @@
     Record Computer ${HOSTNAME}
     Record AzureResourceId ${AKS_RESOURCE_ID}
 
-#${MultilineEnabled}[FILTER]
-#${MultilineEnabled}    Name multiline
-#${MultilineEnabled}    Match geneva.container.log.*
-#${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+@INCLUDE fluent-bit-common.conf
+@INCLUDE fluent-bit-geneva-logs_*.conf
+@INCLUDE fluent-bit-internal-metrics.conf

--- a/build/linux/installer/conf/fluent-bit.conf
+++ b/build/linux/installer/conf/fluent-bit.conf
@@ -11,9 +11,6 @@
     Parsers_File  /etc/opt/microsoft/docker-cimprov/azm-containers-parser.conf
     Log_File      /var/opt/microsoft/docker-cimprov/log/fluent-bit.log
 
-@INCLUDE fluent-bit-common.conf
-@INCLUDE fluent-bit-internal-metrics.conf
-
 [INPUT]
     Name tail
     Alias oms_tail
@@ -33,14 +30,18 @@
     ${TAIL_IGNORE_OLDER}
     Exclude_Path ${AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH}
 
+#NOTE: Multiline should be the first filter https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace
+#${MultilineEnabled}[FILTER]
+#${MultilineEnabled}    Name multiline
+#${MultilineEnabled}    Match oms.container.log.la.*
+#${MultilineEnabled}    multiline.key_content log
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+
 [FILTER]
     Name grep
     Alias oms_filter
     Match oms.container.log.la.*
     Exclude stream ${AZMON_LOG_EXCLUSION_REGEX_PATTERN}
 
-#${MultilineEnabled}[FILTER]
-#${MultilineEnabled}    Name multiline
-#${MultilineEnabled}    Match oms.container.log.la.*
-#${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+@INCLUDE fluent-bit-common.conf
+@INCLUDE fluent-bit-internal-metrics.conf

--- a/build/windows/installer/conf/fluent-bit-geneva.conf
+++ b/build/windows/installer/conf/fluent-bit-geneva.conf
@@ -10,9 +10,12 @@
     Parsers_File    /etc/fluent-bit/azm-containers-parser.conf
     Log_File        /etc/fluent-bit/fluent-bit-geneva.log
 
-@INCLUDE C:\\etc\fluent-bit\\fluent-bit-common.conf
-@INCLUDE C:\\etc\fluent-bit\\fluent-bit-geneva-logs_*.conf
-@INCLUDE C:\\etc\fluent-bit\\fluent-bit-internal-metrics.conf
+#NOTE: Multiline should be the first filter https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace
+#${MultilineEnabled}[FILTER]
+#${MultilineEnabled}    Name multiline
+#${MultilineEnabled}    Match geneva.container.log.*
+#${MultilineEnabled}    multiline.key_content log
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
 
 [FILTER]
     Name grep
@@ -27,8 +30,6 @@
     Record Computer ${HOSTNAME}
     Record AzureResourceId ${AKS_RESOURCE_ID}
 
-#${MultilineEnabled}[FILTER]
-#${MultilineEnabled}    Name multiline
-#${MultilineEnabled}    Match geneva.container.log.*
-#${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+@INCLUDE C:\\etc\fluent-bit\\fluent-bit-common.conf
+@INCLUDE C:\\etc\fluent-bit\\fluent-bit-geneva-logs_*.conf
+@INCLUDE C:\\etc\fluent-bit\\fluent-bit-internal-metrics.conf

--- a/build/windows/installer/conf/fluent-bit.conf
+++ b/build/windows/installer/conf/fluent-bit.conf
@@ -10,9 +10,6 @@
     Parsers_File    /etc/fluent-bit/azm-containers-parser.conf
     Log_File        /etc/fluent-bit/fluent-bit.log
 
-@INCLUDE fluent-bit-common.conf
-@INCLUDE fluent-bit-internal-metrics.conf
-
 [INPUT]
     Name                tail
     Alias               oms_tail
@@ -32,14 +29,17 @@
     ${TAIL_IGNORE_OLDER}
     Exclude_Path        ${AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH}
 
+#${MultilineEnabled}[FILTER]
+#${MultilineEnabled}    Name multiline
+#${MultilineEnabled}    Match oms.container.log.la.*
+#${MultilineEnabled}    multiline.key_content log
+#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+
 [FILTER]
     Name grep
     Alias oms_filter
     Match oms.container.log.la.*
     Exclude stream ${AZMON_LOG_EXCLUSION_REGEX_PATTERN}
 
-#${MultilineEnabled}[FILTER]
-#${MultilineEnabled}    Name multiline
-#${MultilineEnabled}    Match oms.container.log.la.*
-#${MultilineEnabled}    multiline.key_content log
-#${MultilineEnabled}    multiline.parser #${MultilineLanguages}
+@INCLUDE fluent-bit-common.conf
+@INCLUDE fluent-bit-internal-metrics.conf


### PR DESCRIPTION
Fluent-bit recommendation for multiline filter ordering

- Since concatenated records are re-emitted to the head of the Fluent Bit log pipeline, the multiline filter should be the first filter. Logs will be re-emitted by the multiline filter to the head of the pipeline- the filter will ignore its own re-emitted records, but other filters won't. If there are filters before the multiline filter, they will be applied twice. (Refer: https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace)
- Recommended for performance purposes. Has no functional impact 
