### PR TITLE
Gangams/fips updates

### DIFF
--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -103,7 +103,7 @@ COPY --from=builder /opt/microsoft/azure-mdsd/lib/libsymcrypt.so.103 /opt/micros
 # logrotate dependencies
 COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/
 # curl dependencies
-COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /usr/lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssl.so.1.1 /lib/libssh2.so.1 /lib/libcrypto.so.1.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
+COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssl.so.1.1 /lib/libssh2.so.1 /lib/libcrypto.so.1.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
 COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
 # jq dependencies
 COPY --from=builder /lib/libjq.so.1 /lib/libc.so.6 /lib/libm.so.6 /lib/libonig.so.5 /lib/

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -21,6 +21,7 @@ ENV tmpdir /opt
 
 RUN tdnf clean all
 RUN tdnf repolist --refresh
+RUN tdnf -y update
 RUN tdnf install -y build-essential wget curl sudo net-tools cronie rsyslog dmidecode gnupg make logrotate busybox gawk tar && rm -rf /var/lib/apt/lists/*
 RUN mkdir /busybin && busybox --install /busybin
 
@@ -102,7 +103,8 @@ COPY --from=builder /opt/microsoft/azure-mdsd/lib/libsymcrypt.so.103 /opt/micros
 # logrotate dependencies
 COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/
 # curl dependencies
-COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssl.so.1.1 /lib/libssh2.so.1 /lib/libcrypto.so.1.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl from base image and copying them over causes FIPS HMAC verification failure
+COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
 COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
 # jq dependencies
 COPY --from=builder /lib/libjq.so.1 /lib/libc.so.6 /lib/libm.so.6 /lib/libonig.so.5 /lib/

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -21,7 +21,6 @@ ENV tmpdir /opt
 
 RUN tdnf clean all
 RUN tdnf repolist --refresh
-RUN tdnf -y update
 RUN tdnf install -y build-essential wget curl sudo net-tools cronie rsyslog dmidecode gnupg make logrotate busybox gawk tar && rm -rf /var/lib/apt/lists/*
 RUN mkdir /busybin && busybox --install /busybin
 

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -93,7 +93,8 @@ COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/li
 # ruby dependencies
 COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/libc.so.6 /usr/lib/
 # fluent-bit dependencies
-COPY --from=builder /lib/libssl.so.1.1 /lib/libcrypto.so.1.1 /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /usr/lib/libc.so.6 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl from base image and copying them over causes FIPS HMAC verification failure
+COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
 # telegraf dependencies
 COPY --from=builder /lib/libc.so.6 /lib/
 # mdsd dependencies

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -22,7 +22,7 @@ ENV tmpdir /opt
 RUN tdnf clean all
 RUN tdnf repolist --refresh
 RUN tdnf -y update
-RUN tdnf install -y build-essential wget openssl curl sudo net-tools cronie rsyslog dmidecode gnupg make logrotate busybox gawk tar && rm -rf /var/lib/apt/lists/*
+RUN tdnf install -y build-essential wget curl sudo net-tools cronie rsyslog dmidecode gnupg make logrotate busybox gawk tar && rm -rf /var/lib/apt/lists/*
 RUN mkdir /busybin && busybox --install /busybin
 
 COPY --from=golang-builder /src/kubernetes/linux/Linux_ULINUX_1.0_*_64_Release/docker-cimprov-*.*.*-*.*.sh $tmpdir/

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -93,7 +93,7 @@ COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/li
 # ruby dependencies
 COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/libc.so.6 /usr/lib/
 # fluent-bit dependencies
-# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl from base image and copying them over causes FIPS HMAC verification failure
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
 COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
 # telegraf dependencies
 COPY --from=builder /lib/libc.so.6 /lib/
@@ -104,7 +104,7 @@ COPY --from=builder /opt/microsoft/azure-mdsd/lib/libsymcrypt.so.103 /opt/micros
 # logrotate dependencies
 COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/
 # curl dependencies
-# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl from base image and copying them over causes FIPS HMAC verification failure
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
 COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
 COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
 # jq dependencies

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -246,6 +246,8 @@ generateGenevaInfraNamespaceConfig() {
       rm /etc/opt/microsoft/docker-cimprov/fluent-bit-geneva-logs_infra.conf
 }
 
+echo "MARINER $(grep 'VERSION=' /etc/os-release)" >> packages_version.txt
+
 #using /var/opt/microsoft/docker-cimprov/state instead of /var/opt/microsoft/ama-logs/state since the latter gets deleted during onboarding
 mkdir -p /var/opt/microsoft/docker-cimprov/state
 echo "disabled" > /var/opt/microsoft/docker-cimprov/state/syslog.status

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -12,8 +12,6 @@ fi
 sudo tdnf install ca-certificates-microsoft -y
 sudo update-ca-trust
 
-echo "MARINER $(grep 'VERSION=' /etc/os-release)" >> packages_version.txt
-
 # sudo tdnf install ruby-3.1.3 -y
 tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
 wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20230330.tar.gz -O ruby-build.tar.gz

--- a/source/plugins/ruby/in_kube_nodes.rb
+++ b/source/plugins/ruby/in_kube_nodes.rb
@@ -603,6 +603,10 @@ module Fluent::Plugin
         end
         properties["NODES_CHUNK_SIZE"] = @NODES_CHUNK_SIZE
         properties["NODES_EMIT_STREAM_BATCH_SIZE"] = @NODES_EMIT_STREAM_BATCH_SIZE
+        nodeLabels = item["metadata"]["labels"]
+        if !nodeLabels.nil? && !nodeLabels.empty? && nodeLabels.key?("kubernetes.azure.com/fips_enabled") && nodeLabels["kubernetes.azure.com/fips_enabled"] == "true"
+          properties["FipsEnabled"] = "true"
+        end
       rescue => errorStr
         $log.warn "in_kube_nodes::getContainerNodeIngetNodeTelemetryPropsventoryRecord:Failed: #{errorStr}"
       end


### PR DESCRIPTION
Changes for the FIPs updates. Verified on FIPS enabled nodes - Azure Linux and Ubuntu and also Windows nodes (2019 & 2022).   Update to use the openssl shipped with distroless image instead of copying the binaries from base to distroless image.  For FIPs validation, Mariner team introduced HMAC verification on the binaries and openssl binaries will have associated .hmac files.  Copying just binaries will cause the Openssl FIP test failures and recommendation for Mariner team to use the Openssl shipped in distroless image.