### PR TITLE
Gangams/onboarding Extend ARM templates for AMPLS scenario

### DIFF
--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
@@ -238,7 +238,7 @@
     },
     "resources": [
         {
-            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
             "type": "Microsoft.Insights/dataCollectionEndpoints",
             "apiVersion": "2022-06-01",
             "name": "[variables('dceName')]",
@@ -294,7 +294,7 @@
             }
         },
         {
-            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
             "type": "Microsoft.Resources/deployments",
             "name": "[Concat('aks-monitoring-msi-dcea', '-',  uniqueString(parameters('aksResourceId')))]",
             "apiVersion": "2017-05-10",
@@ -327,7 +327,7 @@
             }
         },
         {
-            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
             "type": "Microsoft.Resources/deployments",
             "name": "[Concat('aks-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('aksResourceId')))]",
             "apiVersion": "2017-05-10",

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
@@ -85,6 +85,18 @@
             "metadata": {
                 "description": "An array of Kubernetes namespaces for the data collection of inventory, events and metrics"
             }
+        },
+        "useAzureMonitorPrivateLinkScope": {
+            "type": "bool",
+            "metadata": {
+                "description": "Flag to indicate if Azure Monitor Private Link Scope should be used or not"
+            }
+        },
+        "azureMonitorPrivateLinkScopeResourceId": {
+            "type": "string",
+            "metadata": {
+              "description": "Specify the Resource Id of the Azure Monitor Private Link Scope."
+            }
         }
     },
     "variables": {
@@ -97,6 +109,12 @@
         "dcrName":"[if(greater(length(variables('dcrNameFull')), 64), substring(variables('dcrNameFull'), 0, 64), variables('dcrNameFull'))]",
         "associationName":  "ContainerInsightsExtension",
         "dataCollectionRuleId": "[resourceId(variables('clusterSubscriptionId'), variables('clusterResourceGroup'), 'Microsoft.Insights/dataCollectionRules', variables('dcrName'))]",
+        "dceName": "[variables('dcrName')]",
+        "dceAssociationName": "configurationAccessEndpoint",
+        "dataCollectionEndpointId": "[resourceId(variables('clusterSubscriptionId'), variables('clusterResourceGroup'), 'Microsoft.Insights/dataCollectionEndpoints', variables('dceName'))]",
+        "privateLinkScopeName": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[8]]",
+        "privateLinkScopeResourceGroup": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[4]]",
+        "privateLinkScopeSubscriptionId": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[2]]",
         "ciOnlyTemplate": {
                 "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
@@ -220,11 +238,23 @@
     },
     "resources": [
         {
+            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "type": "Microsoft.Insights/dataCollectionEndpoints",
+            "apiVersion": "2022-06-01",
+            "name": "[variables('dceName')]",
+            "location": "[variables('workspaceLocation')]",
+            "kind": "Linux",
+            "properties": {}
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "name": "[Concat('aks-monitoring-msi-dcr', '-',  uniqueString(variables('dcrName')))]",
             "apiVersion": "2017-05-10",
             "subscriptionId": "[variables('clusterSubscriptionId')]",
             "resourceGroup": "[variables('clusterResourceGroup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
+             ],
             "properties": {
               "mode": "Incremental",
               "template": "[if(parameters('enableSyslog'), variables('syslogAndCITemplate'), variables('ciOnlyTemplate'))]",
@@ -264,13 +294,79 @@
             }
         },
         {
+            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "type": "Microsoft.Resources/deployments",
+            "name": "[Concat('aks-monitoring-msi-dcea', '-',  uniqueString(parameters('aksResourceId')))]",
+            "apiVersion": "2017-05-10",
+            "subscriptionId": "[variables('clusterSubscriptionId')]",
+            "resourceGroup": "[variables('clusterResourceGroup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
+             ],
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {},
+                "variables": {},
+                "resources": [
+                    {
+                        "type": "Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations",
+                        "name": "[concat(variables('clusterName'),'/microsoft.insights/', variables('dceAssociationName'))]",
+                        "apiVersion": "2022-06-01",
+                        "properties": {
+                            "description": "Association of data collection rule endpoint. Deleting this association will break the data collection endpoint for this AKS Cluster.",
+                            "dataCollectionEndpointId": "[variables('dataCollectionEndpointId')]"
+                        }
+                    }
+
+                ]
+              },
+              "parameters": {}
+            }
+        },
+        {
+            "condition": "[equals(parameters('useAzureMonitorPrivateLinkScope'), true)]",
+            "type": "Microsoft.Resources/deployments",
+            "name": "[Concat('aks-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('aksResourceId')))]",
+            "apiVersion": "2017-05-10",
+            "subscriptionId": "[variables('privateLinkScopeSubscriptionId')]",
+            "resourceGroup": "[variables('privateLinkScopeResourceGroup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
+             ],
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {},
+                "variables": {},
+                "resources": [
+                    {
+                        "type": "microsoft.insights/privatelinkscopes/scopedresources",
+                        "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('dceName'), '-connection'))]",
+                        "apiVersion": "2021-07-01-preview",
+                        "properties": {
+                            "linkedResourceId": "[variables('dataCollectionEndpointId')]"
+                        }
+                    }
+
+                ]
+              },
+              "parameters": {}
+            }
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "name": "[Concat('aks-monitoring-msi-addon', '-',  uniqueString(parameters('aksResourceId')))]",
             "apiVersion": "2017-05-10",
             "subscriptionId": "[variables('clusterSubscriptionId')]",
             "resourceGroup": "[variables('clusterResourceGroup')]",
             "dependsOn": [
-                "[Concat('aks-monitoring-msi-dcra', '-',  uniqueString(parameters('aksResourceId')))]"
+                "[Concat('aks-monitoring-msi-dcra', '-',  uniqueString(parameters('aksResourceId')))]",
+                "[Concat('aks-monitoring-msi-dcea', '-',  uniqueString(parameters('aksResourceId')))]"
             ],
             "properties": {
               "mode": "Incremental",
@@ -307,3 +403,4 @@
         }
     ]
 }
+

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
@@ -104,6 +104,7 @@
         "clusterResourceGroup": "[split(parameters('aksResourceId'),'/')[4]]",
         "clusterName": "[split(parameters('aksResourceId'),'/')[8]]",
         "clusterLocation": "[replace(parameters('aksResourceLocation'),' ', '')]",
+        "workspaceName": "[split(parameters('workspaceResourceId'),'/')[8]]",
         "workspaceLocation":"[replace(parameters('workspaceRegion'),' ', '')]",
         "dcrNameFull": "[Concat('MSCI', '-', variables('workspaceLocation'), '-', variables('clusterName'))]",
         "dcrName":"[if(greater(length(variables('dcrNameFull')), 64), substring(variables('dcrNameFull'), 0, 64), variables('dcrNameFull'))]",
@@ -161,7 +162,8 @@
                                         "ciworkspace"
                                     ]
                                 }
-                            ]
+                            ],
+                            "dataCollectionEndpointId": "[if(parameters('useAzureMonitorPrivateLinkScope'), variables('dataCollectionEndpointId'), json('null'))]"
                         }
                     }
                 ]
@@ -230,7 +232,8 @@
                                         "ciworkspace"
                                     ]
                                 }
-                            ]
+                            ],
+                            "dataCollectionEndpointId": "[if(parameters('useAzureMonitorPrivateLinkScope'), variables('dataCollectionEndpointId'), json('null'))]"
                         }
                     }
                 ]
@@ -244,7 +247,11 @@
             "name": "[variables('dceName')]",
             "location": "[variables('workspaceLocation')]",
             "kind": "Linux",
-            "properties": {}
+            "properties": {
+                "networkAcls": {
+                    "publicNetworkAccess": "Disabled"
+                }
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -252,9 +259,6 @@
             "apiVersion": "2017-05-10",
             "subscriptionId": "[variables('clusterSubscriptionId')]",
             "resourceGroup": "[variables('clusterResourceGroup')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
-             ],
             "properties": {
               "mode": "Incremental",
               "template": "[if(parameters('enableSyslog'), variables('syslogAndCITemplate'), variables('ciOnlyTemplate'))]",
@@ -350,6 +354,35 @@
                         "apiVersion": "2021-07-01-preview",
                         "properties": {
                             "linkedResourceId": "[variables('dataCollectionEndpointId')]"
+                        }
+                    }
+
+                ]
+              },
+              "parameters": {}
+            }
+        },
+        {
+            "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
+            "type": "Microsoft.Resources/deployments",
+            "name": "[Concat('aks-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('workspaceResourceId')))]",
+            "apiVersion": "2017-05-10",
+            "subscriptionId": "[variables('privateLinkScopeSubscriptionId')]",
+            "resourceGroup": "[variables('privateLinkScopeResourceGroup')]",
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {},
+                "variables": {},
+                "resources": [
+                    {
+                        "type": "microsoft.insights/privatelinkscopes/scopedresources",
+                        "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('workspaceName'), '-connection'))]",
+                        "apiVersion": "2021-07-01-preview",
+                        "properties": {
+                            "linkedResourceId": "[parameters('workspaceResourceId')]"
                         }
                     }
 

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterParam.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterParam.json
@@ -91,6 +91,12 @@
         "Microsoft-ContainerNodeInventory",
         "Microsoft-Perf"
       ]
+    },
+    "useAzureMonitorPrivateLinkScope": {
+      "value": false
+    },
+    "azureMonitorPrivateLinkScopeResourceId": {
+      "value": "/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroup>/providers/microsoft.insights/privateLinkScopes/<azureMonitorPrivateLinkScopeName>"
     }
   }
 }


### PR DESCRIPTION
Extend ARM templates for e2e private link/AMPLS scenario. Same ARM templates supported for both private & non-private link scenario. If user specify the "useAzureMonitorPrivateLinkScope" : true then required resources related for AMPLS will be deployed and user doesnt need any manual steps else the behavior same as what exists already.

No changes to the non private link/AMPLS scenario.  For AMPLS scenario, and these are deployment steps
1.	Create DCE  in the Region of the specified Log Analytics Workspace with 
  "networkAcls": {
                    "publicNetworkAccess": "Disabled"
                }
2.	Create Container Insights Extension DCR  in the  Region of the specified Log Analytics Workspace
3.	Associate DCR with AKS cluster resource (i.e. DCR-A)
4.	Associate DCE with AKS cluster resource (i.e. DCE-A) and association name must be “configurationAccessEndpoint” .   
5.	Link the dataCollectionEndpointId & workspaceResourceId with provided AMPLS resource.  
6.	AKS RP PUT to enable the Container Insights Addon
