### PR TITLE
fix telegraf config related fixes

### DIFF
--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -51,6 +51,10 @@ def get_command_windows(env_variable_name, env_variable_value)
   return "#{env_variable_name}=#{env_variable_value}\n"
 end
 
+def is_windows?
+  return !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
+end
+
 # Use parser to parse the configmap toml file to a ruby structure
 def parseConfigMap
   begin
@@ -109,6 +113,12 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
     new_contents = new_contents.gsub("$AZMON_TELEGRAF_CUSTOM_PROM_KUBERNETES_FIELD_SELECTOR", "# Commenting this out since new plugins will be created per namespace\n  # $AZMON_TELEGRAF_CUSTOM_PROM_KUBERNETES_FIELD_SELECTOR")
     new_contents = new_contents.gsub("$AZMON_TELEGRAF_CUSTOM_PROM_SCRAPE_SCOPE", "# Commenting this out since new plugins will be created per namespace\n  # $AZMON_TELEGRAF_CUSTOM_PROM_SCRAPE_SCOPE")
 
+    timeout_config_key = "timeout"
+    if is_windows?
+      # For windows, the timeout config key is different because of old version of telegraf
+      timeout_config_key = "response_timeout"
+    end
+
     pluginConfigsWithNamespaces = ""
     monitorKubernetesPodsNamespaces.each do |namespace|
       if !namespace.nil?
@@ -128,7 +138,7 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
   metric_version = #{@metricVersion}
   url_tag = \"#{@urlTag}\"
   bearer_token = \"#{@bearerToken}\"
-  response_timeout = \"#{@responseTimeout}\"
+  #{timeout_config_key} = \"#{@responseTimeout}\"
   tls_ca = \"#{@tlsCa}\"
   insecure_skip_verify = #{@insecureSkipVerify}\n"
         end
@@ -262,7 +272,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         end
       elsif @controller.casecmp(@daemonset) == 0 &&
             ((!@containerType.nil? && @containerType.casecmp(@promSideCar) == 0) ||
-             (!@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0) && @sidecarScrapingEnabled.strip.casecmp("true") == 0) &&
+             (is_windows?) && @sidecarScrapingEnabled.strip.casecmp("true") == 0) &&
             !parsedConfig[:prometheus_data_collection_settings][:cluster].nil?
         #Get prometheus custom config settings for monitor kubernetes pods
         begin
@@ -290,7 +300,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             kubernetesLabelSelectors = (kubernetesLabelSelectors.nil?) ? @defaultCustomPrometheusLabelSelectors : kubernetesLabelSelectors
             kubernetesFieldSelectors = (kubernetesFieldSelectors.nil?) ? @defaultCustomPrometheusFieldSelectors : kubernetesFieldSelectors
 
-            if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
+            if is_windows?
               file_name = "/etc/telegraf/telegraf.conf"
             else
               file_name = "/opt/telegraf-test-prom-side-car.conf"
@@ -346,8 +356,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
                 file.close
                 puts "config::Successfully created telemetry file for prometheus sidecar"
               end
-            elsif !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
-              # Setting the environment variable for starting telegraf only when monitorKubernetesPods is true 
+            elsif is_windows?
+              # Setting the environment variable for starting telegraf only when monitorKubernetesPods is true
               file = File.open("setpromenv.txt", "w")
               if !file.nil?
                 commands = get_command_windows("TELEMETRY_CUSTOM_PROM_MONITOR_PODS", monitorKubernetesPods)

--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -137,7 +137,6 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
   fielddrop = #{fieldDropSetting}
   metric_version = #{@metricVersion}
   url_tag = \"#{@urlTag}\"
-  bearer_token = \"#{@bearerToken}\"
   #{timeout_config_key} = \"#{@responseTimeout}\"
   tls_ca = \"#{@tlsCa}\"
   insecure_skip_verify = #{@insecureSkipVerify}\n"

--- a/build/linux/installer/scripts/tomlparser-osm-config.rb
+++ b/build/linux/installer/scripts/tomlparser-osm-config.rb
@@ -112,7 +112,7 @@ def replaceOsmTelegrafConfigPlaceHolders
   metric_version = #{@metricVersion}
   url_tag = \"#{@urlTag}\"
   bearer_token = \"#{@bearerToken}\"
-  response_timeout = \"#{@responseTimeout}\"
+  timeout = \"#{@responseTimeout}\"
   tls_ca = \"#{@tlsCa}\"
   insecure_skip_verify = #{@insecureSkipVerify}\n"
           end

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -1059,10 +1059,6 @@ spec:
           # Uncomment below lines for MSI Auth Mode  testing
           # - name: USING_AAD_MSI_AUTH
           #   value: "true"
-          - name: HOSTNAME
-            valueFrom:
-               fieldRef:
-                 fieldPath: spec.nodeName
          volumeMounts:
           #  Uncomment below lines when telegraf upgraded to 1.28.5 or higher
           # - name: kube-api-access

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -38,6 +38,7 @@ Write-Host ('Finished Installing Fluentbit')
 
 Write-Host ('Installing Telegraf');
 try {
+    # For next telegraf update, make sure to update config changes in telegraf.conf, tomlparser-prom-customconfig.rb and tomlparser-osm-config.rb
     $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.24.2_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf


### PR DESCRIPTION
This pull request primarily focuses on refactoring and improving the codebase of the `tomlparser-prom-customconfig.rb` and `tomlparser-osm-config.rb` scripts in the `build` directory. The changes include the introduction of a new helper function `is_windows?`, the replacement of direct checks for the Windows OS with this new function, and the adjustment of timeout configuration keys based on the OS. Additionally, there are changes to the `ama-logs.yaml` file in the `kubernetes` directory.

Here are the key changes:

Refactoring and code improvements:

* [`build/common/installer/scripts/tomlparser-prom-customconfig.rb`](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fR54-R57): Introduced a new helper function `is_windows?` to check if the operating system is Windows, which improves code readability and maintainability.
* [`build/common/installer/scripts/tomlparser-prom-customconfig.rb`](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fL265-R275): Replaced direct checks for the Windows OS with the new `is_windows?` function in multiple places. This makes the code cleaner and easier to understand. [[1]](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fL265-R275) [[2]](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fL293-R303) [[3]](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fL349-R359)

Configuration adjustments:

* [`build/common/installer/scripts/tomlparser-prom-customconfig.rb`](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fR116-R121): Adjusted the timeout configuration key based on the OS in the `createPrometheusPluginsWithNamespaceSetting` function. For Windows, the key is "response_timeout", while for other OS, it's "timeout". This change ensures proper configuration for different OS. [[1]](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fR116-R121) [[2]](diffhunk://#diff-4d7c36f6b1ebf2aec29222b55e62468b4ba91ee25f373077d5766307f8fb185fL131-R141)
* [`build/linux/installer/scripts/tomlparser-osm-config.rb`](diffhunk://#diff-e514ade633a2df6d7c90d676b596791d3f31be69b06b30c5f38d568d6ed95fdaL115-R115): Changed the timeout configuration key from "response_timeout" to "timeout" in the `replaceOsmTelegrafConfigPlaceHolders` function.

Configuration file changes:

* [`kubernetes/ama-logs.yaml`](diffhunk://#diff-36d02cbde2b90a572c51c987289a1cfdf4726779cefbd512e2d1663ecf2c8dd4L1062-L1065): Removed the `HOSTNAME` environment variable from the specification. The reason for this change since this duplicate.