### PR TITLE
add syslog option to linux daemonset for Arc

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -75,6 +75,10 @@ spec:
        {{- end }}
        - name: CONTROLLER_TYPE
          value: "DaemonSet"
+       {{- if .Values.amalogs.syslog.enabled }}
+       - name: SYSLOG_HOST_PORT
+         value: {{ .Values.amalogs.syslog.syslogPort | quote }}
+       {{- end }}
        - name: NODE_IP
          valueFrom:
             fieldRef:
@@ -132,6 +136,12 @@ spec:
          protocol: TCP
        - containerPort: 25224
          protocol: UDP
+       {{- if .Values.amalogs.syslog.enabled }}
+       - name: syslog
+         containerPort: {{ .Values.amalogs.syslog.syslogPort }}
+         hostPort: {{ .Values.amalogs.syslog.syslogPort }}
+         protocol: TCP
+       {{- end }}
        volumeMounts:
         - name: kube-api-access
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -78,6 +78,7 @@ amalogs:
     clusterRegion: <your_cluster_region>
   rbac: true
   sidecarscraping: true
+  # Syslog collection on Arc K8s clusters requires additional config dependencies on the node and is currently not supported. Please open a service ticket if there is a syslog collection requirement.
   syslog:
     enabled: false
     syslogPort: 28330

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -78,6 +78,9 @@ amalogs:
     clusterRegion: <your_cluster_region>
   rbac: true
   sidecarscraping: true
+  syslog:
+    enabled: false
+    syslogPort: 28330
   logsettings:
     logflushintervalsecs: "15"
     tailbufchunksizemegabytes: "1"


### PR DESCRIPTION
This pull request primarily focuses on adding support for syslog in the Azure Monitor Containers chart. The changes allow the user to enable syslog and specify a port for it in the `values.yaml` file. These values are then used in the `ama-logs-daemonset.yaml` file to set up the environment and expose the specified port.

Syslog support addition:

* [`charts/azuremonitor-containers/values.yaml`](diffhunk://#diff-c143ea0bc79e879c685e11a8b334d9cf66ed4c7cdaab210e63c27b6a550942a9R81-R83): Added `syslog` configuration under `amalogs` with `enabled` and `syslogPort` options. By default, syslog is disabled.
* [`charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml`](diffhunk://#diff-7f1ec92e3cc74e738754b6375ca8facca6b09bebc12fb3e539c3f8f9e70cdf72R78-R81): Added conditional blocks that check if syslog is enabled. If it is, a new environment variable `SYSLOG_HOST_PORT` is set and a new port is exposed with the name `syslog`. The port number for both is taken from the `syslogPort` value in `values.yaml`. [[1]](diffhunk://#diff-7f1ec92e3cc74e738754b6375ca8facca6b09bebc12fb3e539c3f8f9e70cdf72R78-R81) [[2]](diffhunk://#diff-7f1ec92e3cc74e738754b6375ca8facca6b09bebc12fb3e539c3f8f9e70cdf72R139-R144)