### PR TITLE
update multiline parser config logic

### DIFF
--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -24,7 +24,7 @@ require_relative "ConfigParseErrorLogger"
 @containerLogsRoute = "v2" # default for linux
 @adxDatabaseName = "containerinsights" # default for all configurations
 @logEnableMultiline = "false"
-@stacktraceLanguages = "go,java,python"
+@stacktraceLanguages = "go,java,python" #supported languages for multiline logs. java is also used for dotnet stacktraces
 if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
   @containerLogsRoute = "v1" # default is v1 for windows until windows agent integrates windows ama
   # This path format is necessary for fluent-bit in windows

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -24,7 +24,7 @@ require_relative "ConfigParseErrorLogger"
 @containerLogsRoute = "v2" # default for linux
 @adxDatabaseName = "containerinsights" # default for all configurations
 @logEnableMultiline = "false"
-@stacktraceLanguages = "go,java,python,dotnet"
+@stacktraceLanguages = "go,java,python"
 if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
   @containerLogsRoute = "v1" # default is v1 for windows until windows agent integrates windows ama
   # This path format is necessary for fluent-bit in windows
@@ -175,7 +175,13 @@ def populateSettingValuesFromConfigMap(parsedConfig)
               if invalid_lang
                 puts "config::WARN: stacktrace languages contains invalid languages. Disabling multiline stacktrace logging"
               else
-                @stacktraceLanguages = multilineLanguages.join(",").downcase
+                multilineLanguages = multilineLanguages.map(&:downcase)
+                # the java multiline parser also captures dotnet
+                if multilineLanguages.include?("dotnet")
+                  multilineLanguages.delete("dotnet")
+                  multilineLanguages << "java" unless multilineLanguages.include?("java")
+                end
+                @stacktraceLanguages = multilineLanguages.join(",")
                 puts "config::Using config map setting for multiline languages"
               end
             else


### PR DESCRIPTION
This pull request includes changes to the `tomlparser.rb` file within the `build/common/installer/scripts/` directory. The changes focus on modifying the handling of languages supported for multiline logs and stacktraces. The most significant changes involve removing `dotnet` from the `@stacktraceLanguages` variable and adjusting the `populateSettingValuesFromConfigMap` method to handle `dotnet` as a special case.

Here are the most important changes in detail:

* [`build/common/installer/scripts/tomlparser.rb`](diffhunk://#diff-be1193a49b27f3fec5e115daf986f4479bcfd5a010fc3518e090a1a6180e3177L27-R27): The `@stacktraceLanguages` variable has been updated to remove `dotnet` and include a comment indicating the supported languages for multiline logs. It's noted that `java` is also used for `dotnet` stacktraces.
* `build/common/installer/scripts/tomlparser.rb` (within `def populateSettingValuesFromConfigMap(parsedConfig)`): The handling of `dotnet` has been adjusted in the method. If `dotnet` is included in the `multilineLanguages`, it's removed and `java` is added to the list, unless `java` is already included. This change ensures that `dotnet` stacktraces are handled correctly.