### PR TITLE
Upgrade fluentd to 1.16.3 for linux

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -75,7 +75,7 @@ echo "$(fluent-bit --version)" >> packages_version.txt
 
 # install fluentd using the mariner package
 # sudo tdnf install rubygem-fluentd-1.14.6 -y
-fluentd_version="1.14.6"
+fluentd_version="1.16.3"
 gem install fluentd -v $fluentd_version --no-document
 
 # remove the test directory from fluentd


### PR DESCRIPTION
Upgrade fluentd to 1.16.3 for linux
Only debug message: 
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/fb279b30-1fe0-40ed-93ed-236044e1361d)
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/6e3b93ac-0c79-4aa8-b012-debc7ac581ee)

Replicaset: 
root [ /var/opt/microsoft/docker-cimprov/log ]# grep  -r "error" /var/opt/microsoft/docker-cimprov/log/fluentd.log                    
  2024-03-01 19:28:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:28:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:29:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:29:21 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:30:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:30:21 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:31:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:31:21 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:32:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:32:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:33:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:33:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:34:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:34:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:35:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:35:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:36:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
  2024-03-01 19:36:20 +0000 [debug]: #0 /usr/lib/ruby/3.1.0/net/http/response.rb:142:in `error!'
root [ /var/opt/microsoft/docker-cimprov/log ]# grep  -r "warn" /var/opt/microsoft/docker-cimprov/log/fluentd.log                     
2024-03-01 19:27:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:27:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:27:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:28:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:28:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:28:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:29:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:29:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:29:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:30:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:30:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:30:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:31:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:31:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:31:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:32:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList
2024-03-01 19:32:59 +0000 [warn]: #0 in_kubestate_hpa::enumerate:Received empty hpaList
2024-03-01 19:32:59 +0000 [warn]: #0 in_kube_pvinventory::enumerate:Received empty pvInventory
2024-03-01 19:33:59 +0000 [warn]: #0 in_kube_events::enumerate:Received empty eventList

ds memory usage: 
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/0afc6001-7e15-4993-80b5-025a47424efe)
ds cpu:
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/64d9ebb1-7a5d-4592-a2bd-17effd26e36f)
rs memory rss:
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/136a8094-ee5a-480e-bae0-46319dae339c)
rs working set:
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/8f293d13-3c5e-4284-8a28-93a6470e27ce)
rs cpu:
![image](https://github.com/microsoft/Docker-Provider/assets/25573844/3529916c-274e-4c89-91fe-7cfa67c6d131)

