### PR TITLE
Gangams/expose disable telemetry config option

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -6,6 +6,7 @@ GHSA-jq35-85cj-fj4p
 GHSA-7ww5-4wqc-m92c
 GHSA-mhpq-9638-x6pw
 CVE-2023-48795
+CVE-2023-50658
 
 #telegraf HIGH
 GHSA-m425-mq94-257g

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -94,7 +94,6 @@ require_relative "ConfigParseErrorLogger"
 @promFbitMemBufLimitDefault = "10m" #mb
 
 @ignoreProxySettings = false
-@disableTelemetry = false
 
 @multiline_enabled = "false"
 
@@ -371,11 +370,6 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           @waittime_port_25229 = waittime.to_i
           puts "Using config map value: WAITTIME_PORT_25229 = #{@waittime_port_25229}"
         end
-        telemetry_config = parseConfigMap[:agent_settings][:telemetry_config]
-        if !telemetry_config.nil? && !telemetry_config[:disable_telemetry].nil?
-          @disableTelemetry = telemetry_config[:disable_telemetry]
-          puts "Using config map value: disable_telemetry = #{@disableTelemetry}"
-        end
       end
     end
   rescue => errorStr
@@ -485,10 +479,6 @@ if !file.nil?
     file.write("export AZMON_MULTILINE_ENABLED=#{@multiline_enabled}\n")
   end
 
-  if @disableTelemetry
-    file.write("export DISABLE_TELEMETRY=#{@disableTelemetry}\n")
-  end
-
   file.write("export WAITTIME_PORT_25226=#{@waittime_port_25226}\n")
   file.write("export WAITTIME_PORT_25228=#{@waittime_port_25228}\n")
   file.write("export WAITTIME_PORT_25229=#{@waittime_port_25229}\n")
@@ -575,10 +565,6 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
     end
     if @multiline_enabled.strip.casecmp("true") == 0
       commands = get_command_windows("AZMON_MULTILINE_ENABLED", @multiline_enabled)
-      file.write(commands)
-    end
-    if @disableTelemetry
-      commands = get_command_windows("DISABLE_TELEMETRY", @disableTelemetry)
       file.write(commands)
     end
     # Close file after writing all environment variables

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -94,6 +94,7 @@ require_relative "ConfigParseErrorLogger"
 @promFbitMemBufLimitDefault = "10m" #mb
 
 @ignoreProxySettings = false
+@disableTelemetry = false
 
 @multiline_enabled = "false"
 
@@ -370,6 +371,11 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           @waittime_port_25229 = waittime.to_i
           puts "Using config map value: WAITTIME_PORT_25229 = #{@waittime_port_25229}"
         end
+        telemetry_config = parseConfigMap[:agent_settings][:telemetry_config]
+        if !telemetry_config.nil? && !telemetry_config[:disable_telemetry].nil?
+          @disableTelemetry = telemetry_config[:disable_telemetry]
+          puts "Using config map value: disable_telemetry = #{@disableTelemetry}"
+        end
       end
     end
   rescue => errorStr
@@ -479,6 +485,10 @@ if !file.nil?
     file.write("export AZMON_MULTILINE_ENABLED=#{@multiline_enabled}\n")
   end
 
+  if @disableTelemetry
+    file.write("export DISABLE_TELEMETRY=#{@disableTelemetry}\n")
+  end
+
   file.write("export WAITTIME_PORT_25226=#{@waittime_port_25226}\n")
   file.write("export WAITTIME_PORT_25228=#{@waittime_port_25228}\n")
   file.write("export WAITTIME_PORT_25229=#{@waittime_port_25229}\n")
@@ -565,6 +575,10 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
     end
     if @multiline_enabled.strip.casecmp("true") == 0
       commands = get_command_windows("AZMON_MULTILINE_ENABLED", @multiline_enabled)
+      file.write(commands)
+    end
+    if @disableTelemetry
+      commands = get_command_windows("DISABLE_TELEMETRY", @disableTelemetry)
       file.write(commands)
     end
     # Close file after writing all environment variables

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -336,7 +336,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           puts "Using config map value: AZMON_FBIT_MEM_BUF_LIMIT = #{@promFbitMemBufLimit.to_s + "m"}"
         end
       end
-      proxy_config = parseConfigMap[:agent_settings][:proxy_config]
+      proxy_config = parsedConfigMap[:agent_settings][:proxy_config]
       if !proxy_config.nil?
         ignoreProxySettings = proxy_config[:ignore_proxy_settings]
         if !ignoreProxySettings.nil? && ignoreProxySettings.downcase == "true"

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -48,7 +48,7 @@ end
 def populateSettingValuesFromConfigMap(parsedConfig)
   begin
     if !parsedConfig.nil? && !parsedConfig[:agent_settings].nil?
-      telemetry_config = parseConfigMap[:agent_settings][:telemetry_config]
+      telemetry_config = parsedConfig[:agent_settings][:telemetry_config]
       if !telemetry_config.nil? && !telemetry_config[:disable_telemetry].nil?
         @disableTelemetry = telemetry_config[:disable_telemetry]
         puts "Using config map value: disable_telemetry = #{@disableTelemetry}"
@@ -72,21 +72,6 @@ else
   end
 end
 
-# Write the settings to file, so that they can be set as environment variables
-file = File.open("common_agent_config_env_var", "w")
-
-if !file.nil?
-  if @disableTelemetry
-    file.write("export DISABLE_TELEMETRY=#{@disableTelemetry}\n")
-  end
-
-  # Close file after writing all environment variables
-  file.close
-else
-  puts "Exception while opening file for writing config environment variables"
-  puts "****************End Config Processing********************"
-end
-
 def get_command_windows(env_variable_name, env_variable_value)
   return "#{env_variable_name}=#{env_variable_value}\n"
 end
@@ -104,6 +89,20 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
     puts "****************End Config Processing********************"
   else
     puts "Exception while opening file for writing config environment variables for WINDOWS LOG"
+    puts "****************End Config Processing********************"
+  end
+else
+  # Write the settings to file, so that they can be set as environment variables
+  file = File.open("common_agent_config_env_var", "w")
+  if !file.nil?
+    if @disableTelemetry
+      file.write("export DISABLE_TELEMETRY=#{@disableTelemetry}\n")
+    end
+
+    # Close file after writing all environment variables
+    file.close
+  else
+    puts "Exception while opening file for writing config environment variables"
     puts "****************End Config Processing********************"
   end
 end

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -1,6 +1,5 @@
 #!/usr/local/bin/ruby
 
-
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 
@@ -10,6 +9,10 @@ require_relative "ConfigParseErrorLogger"
 @configSchemaVersion = ""
 
 @disableTelemetry = false
+
+def is_windows?
+  return !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
+end
 
 def is_number?(value)
   true if Integer(value) rescue false
@@ -76,7 +79,7 @@ def get_command_windows(env_variable_name, env_variable_value)
   return "#{env_variable_name}=#{env_variable_value}\n"
 end
 
-if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
+if is_windows?
   # Write the settings to file, so that they can be set as environment variables
   file = File.open("setcommonagentenv.txt", "w")
   if !file.nil?

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -1,0 +1,109 @@
+#!/usr/local/bin/ruby
+
+#this should be require relative in Linux and require in windows, since it is a gem install on windows
+@os_type = ENV["OS_TYPE"]
+require "tomlrb"
+
+require_relative "ConfigParseErrorLogger"
+
+@configMapMountPath = "/etc/config/settings/agent-settings"
+@configSchemaVersion = ""
+
+@disableTelemetry = false
+
+def is_number?(value)
+  true if Integer(value) rescue false
+end
+
+# check if it is number and greater than 0
+def is_valid_number?(value)
+  return !value.nil? && is_number?(value) && value.to_i > 0
+end
+
+# check if it is a valid waittime
+def is_valid_waittime?(value, default)
+  return !value.nil? && is_number?(value) && value.to_i >= default / 2 && value.to_i <= 3 * default
+end
+
+# Use parser to parse the configmap toml file to a ruby structure
+def parseConfigMap
+  begin
+    # Check to see if config map is created
+    if (File.file?(@configMapMountPath))
+      puts "config::configmap container-azm-ms-agentconfig for common agent settings mounted, parsing values"
+      parsedConfig = Tomlrb.load_file(@configMapMountPath, symbolize_keys: true)
+      puts "config::Successfully parsed mounted config map"
+      return parsedConfig
+    else
+      puts "config::configmap container-azm-ms-agentconfig for common agent settings not mounted, using defaults"
+      return nil
+    end
+  rescue => errorStr
+    ConfigParseErrorLogger.logError("Exception while parsing config map for agent settings : #{errorStr}, using defaults, please check config map for errors")
+    return nil
+  end
+end
+
+# Use the ruby structure created after config parsing to set the right values to be used as environment variables
+def populateSettingValuesFromConfigMap(parsedConfig)
+  begin
+    if !parsedConfig.nil? && !parsedConfig[:agent_settings].nil?
+      telemetry_config = parseConfigMap[:agent_settings][:telemetry_config]
+      if !telemetry_config.nil? && !telemetry_config[:disable_telemetry].nil?
+        @disableTelemetry = telemetry_config[:disable_telemetry]
+        puts "Using config map value: disable_telemetry = #{@disableTelemetry}"
+      end
+    end
+  rescue => errorStr
+    puts "config::error:Exception while reading config settings for agent configuration setting - #{errorStr}, using defaults"
+  end
+end
+
+@configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
+puts "****************Start Config Processing********************"
+if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version , so hardcoding it
+  configMapSettings = parseConfigMap
+  if !configMapSettings.nil?
+    populateSettingValuesFromConfigMap(configMapSettings)
+  end
+else
+  if (File.file?(@configMapMountPath))
+    ConfigParseErrorLogger.logError("config::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
+  end
+end
+
+# Write the settings to file, so that they can be set as environment variables
+file = File.open("common_agent_config_env_var", "w")
+
+if !file.nil?
+  if @disableTelemetry
+    file.write("export DISABLE_TELEMETRY=#{@disableTelemetry}\n")
+  end
+
+  # Close file after writing all environment variables
+  file.close
+else
+  puts "Exception while opening file for writing config environment variables"
+  puts "****************End Config Processing********************"
+end
+
+def get_command_windows(env_variable_name, env_variable_value)
+  return "#{env_variable_name}=#{env_variable_value}\n"
+end
+
+if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
+  # Write the settings to file, so that they can be set as environment variables
+  file = File.open("setcommonagentenv.txt", "w")
+  if !file.nil?
+    if @disableTelemetry
+      commands = get_command_windows("DISABLE_TELEMETRY", @disableTelemetry)
+      file.write(commands)
+    end
+    # Close file after writing all environment variables
+    file.close
+    puts "****************End Config Processing********************"
+  else
+    puts "Exception while opening file for writing config environment variables for WINDOWS LOG"
+    puts "****************End Config Processing********************"
+  end
+end

--- a/build/common/installer/scripts/tomlparser-mdm-metrics-config.rb
+++ b/build/common/installer/scripts/tomlparser-mdm-metrics-config.rb
@@ -1,7 +1,7 @@
 #!/usr/local/bin/ruby
 # frozen_string_literal: true
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/common/installer/scripts/tomlparser-prom-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-prom-agent-config.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/build/linux/installer/datafiles/base_container.data
+++ b/build/linux/installer/datafiles/base_container.data
@@ -51,6 +51,7 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/docker-cimprov/fluent-bit-internal-metrics.conf;    build/linux/installer/conf/fluent-bit-internal-metrics.conf; 644; root; root
 
 /opt/tomlparser-agent-config.rb;                                build/common/installer/scripts/tomlparser-agent-config.rb;     755; root; root
+/opt/tomlparser-common-agent-config.rb;                         build/common/installer/scripts/tomlparser-common-agent-config.rb;     755; root; root
 /opt/tomlparser.rb;                                             build/common/installer/scripts/tomlparser.rb;     755; root; root
 /opt/fluent-bit-conf-customizer.rb;                           build/common/installer/scripts/fluent-bit-conf-customizer.rb;     755; root; root
 /opt/ConfigParseErrorLogger.rb;                                 build/common/installer/scripts/ConfigParseErrorLogger.rb;           755; root; root

--- a/build/linux/installer/scripts/tomlparser-npm-config.rb
+++ b/build/linux/installer/scripts/tomlparser-npm-config.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 
-#this should be require relative in Linux and require in windows, since it is a gem install on windows
+
 @os_type = ENV["OS_TYPE"]
 require "tomlrb"
 

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -206,6 +206,10 @@ data:
     #   upload_frequency_seconds = "1" # default 60 upload_frequency_seconds
     #   compression_level = "0"  # supported levels 0 to 9 and 0 means no compression
 
+    # The following settings are "undocumented", we don't recommend uncommenting them unless directed by Microsoft.
+    # [agent_settings.telemetry_config]
+    #   disable_telemetry = false  # if this is not applied, default value is false
+
 metadata:
   name: container-azm-ms-agentconfig
   namespace: kube-system

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -326,6 +326,13 @@ if [[ ((! -e "/etc/config/kube.conf") && ("${CONTAINER_TYPE}" == "PrometheusSide
       fi
 fi
 
+# common agent config settings applicable for all container types
+ruby tomlparser-common-agent-config.rb
+cat common_agent_config_env_var | while read line; do
+      echo $line >> ~/.bashrc
+done
+source common_agent_config_env_var
+
 #Parse the configmap to set the right environment variables for agent config.
 #Note > tomlparser-agent-config.rb has to be parsed first before fluent-bit-conf-customizer.rb for fbit agent settings
 if [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ] && [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" != "true" ]; then

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -431,6 +431,11 @@ function Read-Configs {
     # run config parser
     ruby /opt/amalogswindows/scripts/ruby/tomlparser.rb
     Set-EnvironmentVariablesFromFile "/opt/amalogswindows/scripts/powershell/setenv.txt"
+
+    #Parse the configmap to set the right environment variables for agent config.
+    ruby /opt/amalogswindows/scripts/ruby/tomlparser-common-agent-config.rb
+    Set-EnvironmentVariablesFromFile "/opt/amalogswindows/scripts/powershell/setcommonagentenv.txt"
+
     #Parse the configmap to set the right environment variables for agent config.
     ruby /opt/amalogswindows/scripts/ruby/tomlparser-agent-config.rb
     Set-EnvironmentVariablesFromFile "/opt/amalogswindows/scripts/powershell/setagentenv.txt"


### PR DESCRIPTION
This pull request introduces  a new config option to disable agent telemetry collection.

Major changes:

Script addition and integration:

* [`build/common/installer/scripts/tomlparser-common-agent-config.rb`](diffhunk://#diff-8febaeaf011c6173c3f18a49405a41e1a4bf6896d94872c35ff258d50b3d0141R1-R109): A new Ruby script was added that parses a config map to set environment variables related to agent settings. It includes functionality to validate numeric values and wait times, parse the config map, and write the settings to a file.
* [`build/linux/installer/datafiles/base_container.data`](diffhunk://#diff-052d74490d17fc2c3b2756c865475c249d0d516eb1a07c1097c013457e86a78dR54): The new Ruby script was added to the base container data file, ensuring it is included in the built container.
* [`kubernetes/linux/main.sh`](diffhunk://#diff-16c72639c92748bb0587fea9d4bee32127bd5b252e2138fea83433a43c0a5f65R329-R335): The main script for Linux was updated to call the new Ruby script and source the environment variables it sets.
* [`kubernetes/windows/main.ps1`](diffhunk://#diff-2da2290d6fae65f77898d02932989c6f205d597ff0641c902610425a4d8845bdR434-R438): The main script for Windows was also updated to call the new Ruby script and set the environment variables it defines.

Config map changes:

* [`kubernetes/container-azm-ms-agentconfig.yaml`](diffhunk://#diff-201ccecad7a2f8b262394e44d37daaed39ab2ee6ce403a57738c92e283e73756R210-R213): The Kubernetes config map file was updated to include a new, undocumented setting related to telemetry under `agent_settings.telemetry_config`.