### PR TITLE
fix script errors

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -3,6 +3,8 @@
 # Get the start time of the setup in seconds
 startTime=$(date +%s)
 
+echo "startup script start @ $(date +'%Y-%m-%dT%H:%M:%S')"
+
 gracefulShutdown() {
       echo "gracefulShutdown start @ $(date +'%Y-%m-%dT%H:%M:%S')"
       echo "gracefulShutdown fluent-bit process start @ $(date +'%Y-%m-%dT%H:%M:%S')"
@@ -1035,7 +1037,7 @@ if [ ! -e "/etc/config/kube.conf" ]; then
                   AZMON_CONTAINER_LOG_SCHEMA_VERSION="v2"
                   echo "export AZMON_CONTAINER_LOG_SCHEMA_VERSION=$AZMON_CONTAINER_LOG_SCHEMA_VERSION" >>~/.bashrc
 
-                  if [ -z $FBIT_SERVICE_GRACE_INTERVAL_SECONDS ]; then
+                  if [ -z "$FBIT_SERVICE_GRACE_INTERVAL_SECONDS" ]; then
                        export FBIT_SERVICE_GRACE_INTERVAL_SECONDS="10"
                   fi
                   echo "Using FluentBit Grace Interval seconds:${FBIT_SERVICE_GRACE_INTERVAL_SECONDS}"
@@ -1043,7 +1045,7 @@ if [ ! -e "/etc/config/kube.conf" ]; then
 
                   source ~/.bashrc
                   # Delay FBIT service start to ensure MDSD is ready in 1P mode to avoid data loss
-                  sleep ${FBIT_SERVICE_GRACE_INTERVAL_SECONDS}
+                  sleep "${FBIT_SERVICE_GRACE_INTERVAL_SECONDS}"
             fi
             echo "using fluentbitconf file: ${fluentBitConfFile} for fluent-bit"
             if [ "$CONTAINER_RUNTIME" == "docker" ]; then
@@ -1155,6 +1157,8 @@ fi
 endTime=$(date +%s)
 elapsed=$((endTime-startTime))
 echo "startup script took: $elapsed seconds"
+
+echo "startup script start @ $(date +'%Y-%m-%dT%H:%M:%S')"
 
 shutdown() {
      if [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1158,7 +1158,7 @@ endTime=$(date +%s)
 elapsed=$((endTime-startTime))
 echo "startup script took: $elapsed seconds"
 
-echo "startup script start @ $(date +'%Y-%m-%dT%H:%M:%S')"
+echo "startup script end @ $(date +'%Y-%m-%dT%H:%M:%S')"
 
 shutdown() {
      if [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" == "true" ]; then

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -4,15 +4,15 @@
 startTime=$(date +%s)
 
 gracefulShutdown() {
-      echo "gracefulShutdown start @ `date --rfc-3339=seconds`"
-      echo "gracefulShutdown fluent-bit process start @ `date --rfc-3339=seconds`"
+      echo "gracefulShutdown start @ $(date +'%Y-%m-%dT%H:%M:%S')"
+      echo "gracefulShutdown fluent-bit process start @ $(date +'%Y-%m-%dT%H:%M:%S')"
       pkill -f fluent-bit
-      sleep ${FBIT_SERVICE_GRACE_INTERVAL_SECONDS} # wait for the fluent-bit graceful shutdown before terminating mdsd to complete pending tasks if any
-      echo "gracefulShutdown fluent-bit process complete @ `date --rfc-3339=seconds`"
-      echo "gracefulShutdown mdsd process start @ `date --rfc-3339=seconds`"
+      sleep "${FBIT_SERVICE_GRACE_INTERVAL_SECONDS}" # wait for the fluent-bit graceful shutdown before terminating mdsd to complete pending tasks if any
+      echo "gracefulShutdown fluent-bit process complete @ $(date +'%Y-%m-%dT%H:%M:%S')"
+      echo "gracefulShutdown mdsd process start @ $(date +'%Y-%m-%dT%H:%M:%S')"
       pkill -f mdsd
-      echo "gracefulShutdown mdsd process compelete @ `date --rfc-3339=seconds`"
-      echo "gracefulShutdown complete @ `date --rfc-3339=seconds`"
+      echo "gracefulShutdown mdsd process compelete @ $(date +'%Y-%m-%dT%H:%M:%S')"
+      echo "gracefulShutdown complete @ $(date +'%Y-%m-%dT%H:%M:%S')"
 }
 
 # please use this instead of adding env vars to bashrc directly


### PR DESCRIPTION
This pull request includes changes to the `kubernetes/linux/main.sh` script. The changes primarily involve the replacement of the old date format in the `gracefulShutdown` function with a new one and the addition of quotes around a variable in a `sleep` command.

* [`kubernetes/linux/main.sh`](diffhunk://#diff-16c72639c92748bb0587fea9d4bee32127bd5b252e2138fea83433a43c0a5f65L7-R15): The `date --rfc-3339=seconds` command has been replaced with `date +'%Y-%m-%dT%H:%M:%S'` to change the format of the date. Additionally, the `FBIT_SERVICE_GRACE_INTERVAL_SECONDS` variable in the `sleep` command has been enclosed in quotes to prevent word splitting and pathname expansion.