### PR TITLE
fix configmap parse error

### DIFF
--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -336,7 +336,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           puts "Using config map value: AZMON_FBIT_MEM_BUF_LIMIT = #{@promFbitMemBufLimit.to_s + "m"}"
         end
       end
-      proxy_config = parsedConfigMap[:agent_settings][:proxy_config]
+      proxy_config = parsedConfig[:agent_settings][:proxy_config]
       if !proxy_config.nil?
         ignoreProxySettings = proxy_config[:ignore_proxy_settings]
         if !ignoreProxySettings.nil? && ignoreProxySettings.downcase == "true"


### PR DESCRIPTION
This pull request includes a small but crucial change to the `populateSettingValuesFromConfigMap` method in the `tomlparser-agent-config.rb` file. The change modifies the source from which `proxy_config` is derived, switching from `parsedConfigMap` to `parsedConfig`. This ensures that the correct configuration is used when setting up the proxy configuration.