### PR TITLE
Update the code to take toggle for env vars in windows

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -115,7 +115,7 @@ def substituteFluentBitPlaceHolders
 
     new_contents = substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
 
-    if !@isWindows || (@isWindows && !windowsFluentBitDisabled.nil? && windowsFluentBitDisabled.to_s.downcase == "false")
+    if !@isWindows || (@isWindows && (windowsFluentBitDisabled.nil? || windowsFluentBitDisabled.to_s.downcase == "false"))
       new_contents = substituteResourceOptimization(resourceOptimizationEnabled, new_contents)
     end
     File.open(@fluent_bit_conf_path, "w") { |file| file.puts new_contents }

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -502,7 +502,10 @@ if !file.nil?
   end
 
   file.write("export AZMON_RESOURCE_OPTIMIZATION_ENABLED=#{@resource_optimization_enabled}\n")
-  file.write("export AZMON_WINDOWS_FLUENT_BIT_DISABLED=#{@windows_fluent_bit_disabled}\n")
+
+  if @windows_fluent_bit_disabled
+    file.write("export AZMON_WINDOWS_FLUENT_BIT_DISABLED=#{@windows_fluent_bit_disabled}\n")
+  end
 
   file.write("export WAITTIME_PORT_25226=#{@waittime_port_25226}\n")
   file.write("export WAITTIME_PORT_25228=#{@waittime_port_25228}\n")
@@ -597,8 +600,10 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
       file.write(commands)
     end
 
-    commands = get_command_windows("AZMON_WINDOWS_FLUENT_BIT_DISABLED", @windows_fluent_bit_disabled)
-    file.write(commands)
+    if @windows_fluent_bit_disabled
+      commands = get_command_windows("AZMON_WINDOWS_FLUENT_BIT_DISABLED", @windows_fluent_bit_disabled)
+      file.write(commands)
+    end
     # Close file after writing all environment variables
     file.close
     puts "****************End Config Processing********************"


### PR DESCRIPTION
This pull request primarily focuses on refining the conditions and settings related to the `windowsFluentBitDisabled` flag in the `fluent-bit-conf-customizer.rb` and `tomlparser-agent-config.rb` files. The changes ensure that the `windowsFluentBitDisabled` flag is properly considered in various conditions and that it is written to the configuration only when it is set.

Key changes include:

* [`build/common/installer/scripts/fluent-bit-conf-customizer.rb`](diffhunk://#diff-9ddf023aaa9b5992b30250db0faebd74e2ee801c09a1d1cc46f6ec7781bf9a16L118-R118): The condition in the `substituteFluentBitPlaceHolders` method has been adjusted to account for the case where `windowsFluentBitDisabled` is `nil`. Previously, it only considered cases where `windowsFluentBitDisabled` was explicitly set to `false`. With this change, the `windowsFluentBitDisabled` flag is considered `false` by default unless explicitly set otherwise.
* [`build/common/installer/scripts/tomlparser-agent-config.rb`](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43R505-R508): In the `populateSettingValuesFromConfigMap` method, the `windows_fluent_bit_disabled` value is now written to the configuration only when it is set. Similarly, in the `get_command_windows` method, the command for `AZMON_WINDOWS_FLUENT_BIT_DISABLED` is only written when `windows_fluent_bit_disabled` is set. These changes ensure that the `windows_fluent_bit_disabled` flag is only included in the configuration when it is explicitly set, preventing potential confusion or errors from an unset flag. [[1]](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43R505-R508) [[2]](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43R603-R606)