### PR TITLE
Update windows_fluent_bit default to disable

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -115,7 +115,7 @@ def substituteFluentBitPlaceHolders
 
     new_contents = substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
 
-    if !@isWindows || (@isWindows && (windowsFluentBitDisabled.nil? || windowsFluentBitDisabled.to_s.downcase == "false"))
+    if !@isWindows || (@isWindows && (!windowsFluentBitDisabled.nil? && windowsFluentBitDisabled.to_s.downcase == "false"))
       new_contents = substituteResourceOptimization(resourceOptimizationEnabled, new_contents)
     end
     File.open(@fluent_bit_conf_path, "w") { |file| file.puts new_contents }

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -97,7 +97,7 @@ require_relative "ConfigParseErrorLogger"
 
 @multiline_enabled = "false"
 @resource_optimization_enabled = false
-@windows_fluent_bit_disabled = false
+@windows_fluent_bit_disabled = true
 
 @waittime_port_25226 = 45
 @waittime_port_25228 = 120
@@ -367,8 +367,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       windows_fluent_bit_config = parsedConfig[:agent_settings][:windows_fluent_bit]
       if !windows_fluent_bit_config.nil?
         windows_fluent_bit_disabled = windows_fluent_bit_config[:disabled]
-        if !windows_fluent_bit_disabled.nil? && windows_fluent_bit_disabled.downcase == "true"
-          @windows_fluent_bit_disabled = true
+        if !windows_fluent_bit_disabled.nil? && windows_fluent_bit_disabled.downcase == "false"
+          @windows_fluent_bit_disabled = false
         end
         puts "Using config map value: AZMON_WINDOWS_FLUENT_BIT_DISABLED = #{@windows_fluent_bit_disabled}"
       end
@@ -503,7 +503,7 @@ if !file.nil?
 
   file.write("export AZMON_RESOURCE_OPTIMIZATION_ENABLED=#{@resource_optimization_enabled}\n")
 
-  if @windows_fluent_bit_disabled
+  if !@windows_fluent_bit_disabled
     file.write("export AZMON_WINDOWS_FLUENT_BIT_DISABLED=#{@windows_fluent_bit_disabled}\n")
   end
 
@@ -600,7 +600,7 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
       file.write(commands)
     end
 
-    if @windows_fluent_bit_disabled
+    if !@windows_fluent_bit_disabled
       commands = get_command_windows("AZMON_WINDOWS_FLUENT_BIT_DISABLED", @windows_fluent_bit_disabled)
       file.write(commands)
     end

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -194,7 +194,7 @@ data:
 
     # Disables fluent-bit for perf and container inventory for Windows
     #[agent_settings.windows_fluent_bit]
-    #    disabled = "false"
+    #    disabled = "true"
 
     # The following settings are "undocumented", we don't recommend uncommenting them unless directed by Microsoft.
     # Configuration settings for the waittime for the network listeners to be available

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -948,7 +948,7 @@ if [ ! -f /etc/cron.d/ci-agent ]; then
 fi
 
 setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}"
-if [ "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" == "true" ] || [ "${USING_AAD_MSI_AUTH}" != "true" ] || [ "${GENEVA_LOGS_INTEGRATION}" == "true" ]; then
+if [ "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" == "true" ] || [ -z "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" ] || [ "${USING_AAD_MSI_AUTH}" != "true" ] || [ "${GENEVA_LOGS_INTEGRATION}" == "true" ]; then
       if [ -e "/etc/config/kube.conf" ]; then
            # Replace a string in the configmap file
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube.conf


### PR DESCRIPTION
This pull request primarily modifies the handling of the `windows_fluent_bit_disabled` variable in various scripts. The changes primarily involve reversing the logic for this variable, which changes the default behavior of the system. 

Here are the key changes:

Changes to default values and conditions:

* [`build/common/installer/scripts/tomlparser-agent-config.rb`](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43L100-R100): The default value of `windows_fluent_bit_disabled` is changed from `false` to `true`. This means that by default, Fluent Bit is disabled on Windows.

* [`build/common/installer/scripts/fluent-bit-conf-customizer.rb`](diffhunk://#diff-9ddf023aaa9b5992b30250db0faebd74e2ee801c09a1d1cc46f6ec7781bf9a16L118-R118): The condition for `windows_fluent_bit_disabled` in the `substituteFluentBitPlaceHolders` method is adjusted. Now, resource optimization substitution only occurs if Fluent Bit is explicitly enabled on Windows.

Changes to value assignment:

* [`build/common/installer/scripts/tomlparser-agent-config.rb`](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43L370-R371): In the `populateSettingValuesFromConfigMap` method, the assignment of `windows_fluent_bit_disabled` is reversed. Now, `windows_fluent_bit_disabled` is set to `false` only if the parsed configuration explicitly sets it to `false`.

Changes to output:

* [`build/common/installer/scripts/tomlparser-agent-config.rb`](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43L506-R506): The conditions for writing the `AZMON_WINDOWS_FLUENT_BIT_DISABLED` environment variable in the `populateSettingValuesFromConfigMap` and `get_command_windows` methods are reversed. Now, the environment variable is written only if Fluent Bit is not disabled. [[1]](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43L506-R506) [[2]](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43L603-R603)

Changes to configuration:

* [`kubernetes/container-azm-ms-agentconfig.yaml`](diffhunk://#diff-201ccecad7a2f8b262394e44d37daaed39ab2ee6ce403a57738c92e283e73756L197-R197): The commented-out configuration for `disabled` under `agent_settings.windows_fluent_bit` is changed from `"false"` to `"true"`. This suggests a recommended change in configuration for users who wish to modify this setting.

Changes to script logic:

* [`kubernetes/linux/main.sh`](diffhunk://#diff-16c72639c92748bb0587fea9d4bee32127bd5b252e2138fea83433a43c0a5f65L951-R951): The condition for a block of code is modified to also execute if `AZMON_WINDOWS_FLUENT_BIT_DISABLED` is not set. This ensures that the block of code will execute by default, unless the user explicitly disables Fluent Bit.