### PR TITLE
Enable disable addon test pipeline

### DIFF
--- a/.pipelines/daily_addons_enablement_test.yaml
+++ b/.pipelines/daily_addons_enablement_test.yaml
@@ -1,0 +1,64 @@
+schedules:
+- cron: '0 0 * * *'
+  displayName: Daily midnight test
+  branches:
+    include:
+    - ci_prod
+jobs:
+    - job: test
+      variables:
+        armServiceConnectionName: 'ci-1es-acr-connection'
+        subscription: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
+      pool:
+        name: Azure-Pipelines-CI-Test-EO
+      steps:
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: '${{ variables.armServiceConnectionName }}'
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                az --version
+                az account show
+                az account set -s ${{ variables.subscription }}
+                
+                # Check if the omsagent addon is enabled
+                addonEnabled=$(az aks show --resource-group $(RESOURCEGROUP) --name $(AKSCLUSTERNAME) --query addonProfiles.omsagent.enabled -o tsv)
+                
+                if [ "$addonEnabled" == "true" ]; then
+                    echo "OMSAgent addon is enabled on the AKS cluster."
+                    disable=$(az aks disable-addons --addons monitoring --name $(AKSCLUSTERNAME) --resource-group $(RESOURCEGROUP))
+                    omsagentEnabled=$(echo $disable | jq '.addonProfiles.omsagent.enabled')
+                    if [ $omsagentEnabled == "true" ]; then
+                      echo "Omsagent is not disabled."
+                      exit -1
+                    fi
+                    
+                    echo "Re-enabling the OMSAgent addon..."
+                    enable=$(az aks enable-addons --addons monitoring --name $(AKSCLUSTERNAME) --resource-group $(RESOURCEGROUP) --workspace-resource-id $(LOGANALYTICSWORKSPACE))
+                    omsagentEnabled=$(echo $enable | jq '.addonProfiles.omsagent.enabled')
+                    if [ $omsagentEnabled == "false" ]; then
+                      echo "Omsagent is not enabled"
+                      exit -1
+                    fi
+                    omsagentWorkspace=$(az aks show --resource-group $(RESOURCEGROUP) --name $(AKSCLUSTERNAME) --query addonProfiles.omsagent.config.logAnalyticsWorkspaceResourceID -o tsv)
+                    if [ "$omsagentWorkspace" != "$(LOGANALYTICSWORKSPACE)" ]; then
+                      echo "Omsagent is not enabled with the correct log analytics workspace - $omsagentWorkspace"
+                      exit -1
+                    fi
+                    
+                    echo "Sleeping for everything to get set up and logs start flowing"
+                    sleep $(SLEEPDURATION)
+                    # Check if there is data in the Log Analytics workspace
+                    dataCount=$(az monitor log-analytics query --workspace $(WORKSPACEID) --analytics-query "ContainerInventory | where TimeGenerated > ago(5m) and _ResourceId contains 'daily_enable_disable_test' | count")
+                    countValue=$(echo "$dataCount" | jq -r '.[0].Count')
+                    if [ $countValue -gt 0 ]; then
+                      echo "Data is present in the Log Analytics workspace."
+                    else
+                      echo "No data is present in the Log Analytics workspace."
+                      exit -1
+                    fi
+                else
+                    echo "OMSAgent addon is not enabled on the AKS cluster."
+                    exit -1
+                fi


### PR DESCRIPTION
This pull request includes changes to the `.pipelines/daily_addons_enablement_test.yaml` file. The changes primarily involve setting up a new scheduled job that checks the status of the OMSAgent addon on an AKS cluster and performs various operations based on its status.

Here are the most important changes:

* Added a new scheduled job that runs daily at midnight on the `ci_prod` branch. The job uses the Azure CLI to interact with an AKS cluster.
* Defined several variables, including the Azure subscription ID, the resource group name, the AKS cluster name, and the Log Analytics workspace ID.
* Added a script that checks if the OMSAgent addon is enabled on the AKS cluster. If it is, the script disables and then re-enables the addon, waits for logs to start flowing, and then checks if there is data in the Log Analytics workspace. If the addon is not enabled or if there is no data in the workspace, the script exits with an error.