### PR TITLE
Solving pipeline bugs for windows ama url variable

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -69,6 +69,16 @@ jobs:
     
       cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
       tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
+
+      windowsAMAUrl=""
+      if [ -z "$WINDOWS_AMA_URL" ]
+        then
+          echo "\$WINDOWS_AMA_URL variable is not set"
+        else
+          windowsAMAUrl=$WINDOWS_AMA_URL
+          echo "\$WINDOWS_AMA_URL is $WINDOWS_AMA_URL"
+      fi
+      echo "##vso[task.setvariable variable=windowsAMAUrl;isOutput=true]$windowsAMAUrl"
     name: setup
 
   - task: CopyFiles@2
@@ -280,6 +290,7 @@ jobs:
     windows2019BaseImageVersion: ltsc2019
     Codeql.Enabled: true
     Codeql.BuildIdentifier: 'windowsbuild'
+    windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
   steps:
   - task: PowerShell@2
     inputs:
@@ -311,7 +322,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(WINDOWS_AMA_URL) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
 
   - task: PowerShell@2
     displayName: Extract files to sign
@@ -488,6 +499,7 @@ jobs:
     windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
     windows2022BaseImageVersion: ltsc2022
     Codeql.SkipTaskAutoInjection: true
+    windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
   steps:
   - task: PowerShell@2
     inputs:
@@ -520,7 +532,7 @@ jobs:
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
 
-        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(WINDOWS_AMA_URL) .
+        docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
 
   - task: PowerShell@2
     displayName: Extract files to sign

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -1,6 +1,5 @@
 # Supported values of windows version are ltsc2019 or ltsc2022 which are being passed by the build script or build pipeline
 ARG WINDOWS_VERSION=
-ARG WINDOWS_AMA_URL=
 FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 LABEL maintainer="OMSContainers@microsoft.com"
 LABEL vendor=Microsoft\ Corp \
@@ -40,7 +39,8 @@ RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\
 SHELL ["powershell"]
 
 ENV tmpdir /opt/amalogswindows/scripts/powershell
-ENV WINDOWS_AMA_URL ${WINDOWS_AMA_URL}
+ARG WINDOWS_AMA_URL=
+ENV WINDOWS_AMA_URL_NEW ${WINDOWS_AMA_URL}
 ENV COMPlus_ThreadPool_UnfairSemaphoreSpinLimit 0
 
 WORKDIR /opt/amalogswindows/scripts/powershell

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -71,7 +71,7 @@ Write-Host ('Extracting Certificate Generator Package')
     Expand-Archive -Path /opt/amalogswindows/certificategenerator.zip -Destination /opt/amalogswindows/certgenerator/ -Force
 Write-Host ('Finished Extracting Certificate Generator Package')
 
-$windowsazuremonitoragent = [System.Environment]::GetEnvironmentVariable('WINDOWS_AMA_URL')
+$windowsazuremonitoragent = [System.Environment]::GetEnvironmentVariable("WINDOWS_AMA_URL_NEW", "process")
 if ([string]::IsNullOrEmpty($windowsazuremonitoragent)) {
     Write-Host ('Environment variable WINDOWS_AMA_URL is not set. Using default value')
     $windowsazuremonitoragent = "https://github.com/microsoft/Docker-Provider/releases/download/windows-ama-bits/GenevaMonitoringAgent.46.9.43.zip"


### PR DESCRIPTION
This pull request primarily modifies the handling of the `WINDOWS_AMA_URL` environment variable in the Azure pipeline configuration file `.pipelines/azure_pipeline_mergedbranches.yaml` and in the Dockerfile `kubernetes/windows/Dockerfile`. The changes ensure that the `WINDOWS_AMA_URL` variable is properly checked and assigned, and that it is correctly used in the Docker build commands. 

Environment variable handling:

* [`.pipelines/azure_pipeline_mergedbranches.yaml`](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dR72-R81): Added a check and assignment for the `WINDOWS_AMA_URL` variable, and used the assigned variable in the Docker build commands. [[1]](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dR72-R81) [[2]](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dR293) [[3]](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dL314-R325) [[4]](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dR502) [[5]](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dL523-R535)
* [`kubernetes/windows/Dockerfile`](diffhunk://#diff-5c511ea7097598edb1ac655fb776c2c5db7f9875c4a853f608bcc44c6145ec64L3): Removed the `WINDOWS_AMA_URL` argument from the Dockerfile and added it as an environment variable. [[1]](diffhunk://#diff-5c511ea7097598edb1ac655fb776c2c5db7f9875c4a853f608bcc44c6145ec64L3) [[2]](diffhunk://#diff-5c511ea7097598edb1ac655fb776c2c5db7f9875c4a853f608bcc44c6145ec64L43-R43)
* [`kubernetes/windows/setup.ps1`](diffhunk://#diff-5ec4ab2461b56d161a16acc7831e62fa863591ac9e6986aaf6833a9af73f881eL74-R74): Changed the environment variable used in the script from `WINDOWS_AMA_URL` to `WINDOWS_AMA_URL_NEW`.