### PR TITLE
win custom metrics

### DIFF
--- a/build/linux/installer/conf/kube.conf
+++ b/build/linux/installer/conf/kube.conf
@@ -59,13 +59,6 @@
      keepalive true
    </match>
 
-   #custom_metrics_mdm filter plugin for perf data from windows nodes
-    <filter mdm.cadvisorperf**>
-     @type cadvisor2mdm
-     metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
-     @log_level info
-    </filter>
-
 
   <worker "#{ENV['FLUENTD_POD_INVENTORY_WORKER_ID']}">
     #Kubernetes pod inventory

--- a/build/linux/installer/conf/windows_rs_containerinventory.conf
+++ b/build/linux/installer/conf/windows_rs_containerinventory.conf
@@ -23,3 +23,10 @@
     </buffer>
     keepalive true
   </match>
+
+    #custom_metrics_mdm filter plugin for perf data from windows nodes
+  <filter mdm.cadvisorperf**>
+    @type cadvisor2mdm
+    metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
+    @log_level info
+  </filter>

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -763,7 +763,13 @@ function Start-Fluent-Telegraf {
         Start-Telegraf
     }
 
-    fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
+    $windowsFluentBitDisabled = [System.Environment]::GetEnvironmentVariable("AZMON_WINDOWS_FLUENT_BIT_DISABLED", "process")
+    $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
+
+    # Start fluentd as a windows service only if windowsFluentBitDisabled is false or isAADMSIAuth is false or genevaLogsIntegration is true
+    if ($windowsFluentBitDisabled.ToLower() -ne 'false' -or $genevaLogsIntegration.ToLower() -eq "true" -or $isAADMSIAuth.ToLower() -ne "true") {
+        fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
+    }
 
     Notepad.exe | Out-Null
 }


### PR DESCRIPTION
This pull request involves changes to the configuration and behavior of Fluentd and Fluent Bit in a Kubernetes environment. The most critical changes include the relocation of the `custom_metrics_mdm` filter plugin for performance data from Windows nodes, and the conditional start of Fluentd as a Windows service based on certain environment variables.

Here are the key changes:

Configuration Changes:
* [`build/linux/installer/conf/kube.conf`](diffhunk://#diff-ecda4597169f4e3a53863d5aaddcfef190cc4f914a6de42dfd67539e617e2396L62-L68): Removed the `custom_metrics_mdm` filter plugin for performance data from Windows nodes. This plugin was responsible for collecting certain metrics like `cpuUsageNanoCores`, `memoryWorkingSetBytes`, and `pvUsedBytes`.
* [`build/linux/installer/conf/windows_rs_containerinventory.conf`](diffhunk://#diff-7acecafd990f723c582d7957778048f2ae29c034b4448b6ac2a5bfc222692244R26-R32): Added the `custom_metrics_mdm` filter plugin for performance data from Windows nodes. This is the same plugin that was removed from the `kube.conf` file.

Behavior Changes:
* [`kubernetes/windows/main.ps1`](diffhunk://#diff-2da2290d6fae65f77898d02932989c6f205d597ff0641c902610425a4d8845bdR766-R772): Modified the `Start-Fluent-Telegraf` function to conditionally start Fluentd as a Windows service. The service will start if the `AZMON_WINDOWS_FLUENT_BIT_DISABLED` environment variable is not set to 'false', or if the `USING_AAD_MSI_AUTH` environment variable is not set to 'true', or if the `genevaLogsIntegration` variable is set to 'true'.

These changes suggest a shift in the strategy for collecting performance data from Windows nodes in the Kubernetes environment.