### PR TITLE
Update the start fluentd condition

### DIFF
--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -766,8 +766,8 @@ function Start-Fluent-Telegraf {
     $windowsFluentBitDisabled = [System.Environment]::GetEnvironmentVariable("AZMON_WINDOWS_FLUENT_BIT_DISABLED", "process")
     $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
 
-    # Start fluentd as a windows service only if windowsFluentBitDisabled is false or isAADMSIAuth is false or genevaLogsIntegration is true
-    if ($windowsFluentBitDisabled.ToLower() -ne 'false' -or $genevaLogsIntegration.ToLower() -eq "true" -or $isAADMSIAuth.ToLower() -ne "true") {
+    # Start fluentd as a windows service only if windowsFluentBitDisabled is true or isAADMSIAuth is false or genevaLogsIntegration is true
+    if ([string]::IsNullOrEmpty($windowsFluentBitDisabled) -or $windowsFluentBitDisabled.ToLower() -eq 'true' -or ( ![string]::IsNullOrEmpty($genevaLogsIntegration) -and $genevaLogsIntegration.ToLower() -eq "true") -or [string]::IsNullOrEmpty($isAADMSIAuth) -or $isAADMSIAuth.ToLower() -eq "false") {
         fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
     }
 


### PR DESCRIPTION
This pull request includes a change in the `Start-Fluent-Telegraf` function in the `kubernetes/windows/main.ps1` file. The conditional statement that determines whether to start Fluentd as a Windows service has been modified. The new conditions include checks for whether the `windowsFluentBitDisabled` variable is null or empty or set to 'true', whether the `genevaLogsIntegration` variable is not null or empty and set to 'true', and whether the `isAADMSIAuth` variable is null or empty or set to 'false'.