### PR TITLE
Add AI onboarding ARM templates

### DIFF
--- a/AIOnboardingARMTemplates/existingClusterOnboarding.json
+++ b/AIOnboardingARMTemplates/existingClusterOnboarding.json
@@ -11,7 +11,7 @@
         "aksResourceLocation": {
             "type": "string",
             "metadata": {
-              "description": "Location of the AKS resource e.g. \"East US\""
+              "description": "Location of the AKS resource e.g. \"eastus\""
             }
         },
         "openTelemetryLogsPort": {

--- a/AIOnboardingARMTemplates/existingClusterOnboarding.json
+++ b/AIOnboardingARMTemplates/existingClusterOnboarding.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "aksResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "AKS Cluster Resource ID"
+            }
+        },
+        "aksResourceLocation": {
+            "type": "string",
+            "metadata": {
+              "description": "Location of the AKS resource e.g. \"East US\""
+            }
+        },
+        "openTelemetryLogsPort": {
+            "type": "int",
+            "metadata": {
+              "description": "Port to use for OpenTelemetry Logs"
+            },
+            "defaultValue": "28331"
+        },
+        "openTelemetryMetricsPort": {
+            "type": "int",
+            "metadata": {
+              "description": "Port to use for OpenTelemetry Metrics"
+            },
+            "defaultValue": "28333"
+        },
+        "resourceTagValues": {
+            "type": "object",
+            "metadata": {
+              "description": "Existing or new tags to use on AKS, ContainerInsights and DataCollectionRule Resources"
+            }
+        }
+    },
+    "variables": {
+        "clusterSubscriptionId": "[split(parameters('aksResourceId'),'/')[2]]",
+        "clusterResourceGroup": "[split(parameters('aksResourceId'),'/')[4]]",
+        "clusterName": "[split(parameters('aksResourceId'),'/')[8]]",
+        "clusterLocation": "[replace(parameters('aksResourceLocation'),' ', '')]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "[Concat('aks-appmonitoring-msi-addon', '-',  uniqueString(parameters('aksResourceId')))]",
+            "apiVersion": "2017-05-10",
+            "subscriptionId": "[variables('clusterSubscriptionId')]",
+            "resourceGroup": "[variables('clusterResourceGroup')]",
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {},
+                "variables": {},
+                "resources": [
+                    {
+                        "name": "[variables('clusterName')]",
+                        "type": "Microsoft.ContainerService/managedClusters",
+                        "location": "[parameters('aksResourceLocation')]",
+                        "tags": "[parameters('resourceTagValues')]",
+                        "apiVersion": "2024-02-02-preview",
+                        "properties": {
+                            "azureMonitorProfile": {
+                                "appMonitoring": {
+                                    "autoInstrumentation": {
+                                        "enabled": true
+                                    },
+                                    "openTelemetryMetrics": {
+                                        "enabled": true,
+                                        "port": "[parameters('openTelemetryMetricsPort')]"
+                                    },
+                                    "openTelemetryLogs": {
+                                        "enabled": true,
+                                        "port": "[parameters('openTelemetryLogsPort')]"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+              },
+              "parameters": {}
+            }
+        }
+    ]
+}

--- a/AIOnboardingARMTemplates/existingClusterParam.json
+++ b/AIOnboardingARMTemplates/existingClusterParam.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "value": "/subscriptions/<SubscriptionId>/resourcegroups/<ResourceGroup>/providers/Microsoft.ContainerService/managedClusters/<ResourceName>"
+    },
+    "aksResourceLocation": {
+      "value": "<aksClusterLocation>"
+    },
+    "openTelemetryLogsPort": {
+      "value": <openTelemetryLogsPort_int>
+    },
+    "openTelemetryMetricsPort": {
+      "value": <openTelemetryMetricsPort_int>
+    },
+    "resourceTagValues": {
+      "value": {
+        "<existingOrnew-tag-name1>": "<existingOrnew-tag-value1>",
+        "<existingOrnew-tag-name2>": "<existingOrnew-tag-value2>",
+        "<existingOrnew-tag-nameN>": "<existingOrnew-tag-valueN>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces two new JSON files for Azure Resource Manager (ARM) templates, which are used to automate deployments in Microsoft Azure. The first file, `existingClusterOnboarding.json`, defines the deployment template for an existing Azure Kubernetes Service (AKS) cluster. The second file, `existingClusterParam.json`, provides parameter values for the deployment template.

Here are the key changes:

* [`AIOnboardingARMTemplates/existingClusterOnboarding.json`](diffhunk://#diff-5ae6a92df76f06138ee7303ac1749a16992396c6be31d302dcce240faf06f63cR1-R89): This new file is an ARM template for onboarding an existing AKS cluster. It includes parameters for the AKS resource ID and location, ports for OpenTelemetry logs and metrics, and tags for AKS, ContainerInsights, and DataCollectionRule resources. The template also includes a deployment for an AKS monitoring add-on, which enables auto-instrumentation and OpenTelemetry logs and metrics.

* [`AIOnboardingARMTemplates/existingClusterParam.json`](diffhunk://#diff-8abce7b09c25189ac9ac6bee36c93c6f2c05ff2f35cf08f4b96357a5502cea1fR1-R25): This new file provides parameter values for the `existingClusterOnboarding.json` template. It includes placeholders for the AKS resource ID and location, OpenTelemetry logs and metrics ports, and resource tags.