### PR TITLE
fix version in Geneva config xml

### DIFF
--- a/Documentation/Internal/ContainerLogV2-Linux.xml
+++ b/Documentation/Internal/ContainerLogV2-Linux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MonitoringManagement version="1.1" namespace="<NamespaceForLinuxContainers>" eventVersion="1" timestamp="2016-01-20T00:00:00.000">
+<MonitoringManagement version="1.0" namespace="<NamespaceForLinuxContainers>" eventVersion="1" timestamp="2016-01-20T00:00:00.000">
   <Accounts>
     <Account moniker="<GenevaLogsAccountMoniker>" isDefault="true" />
   </Accounts>


### PR DESCRIPTION
`MonitoringManagement` version attribute has been downgraded from `1.1` to `1.0` and this MUST be 1.0 and its only supported version by Monitoring Agent.