### PR TITLE
update dcr optimization error messages

### DIFF
--- a/build/linux/installer/scripts/dcr-config-parser.rb
+++ b/build/linux/installer/scripts/dcr-config-parser.rb
@@ -33,12 +33,12 @@ if !@controllerType.nil? && !@controllerType.empty? && @controllerType.strip.cas
     end
 
     # Raise an error if no JSON file is found
-    raise 'No JSON file found in the specified directory' unless file_path
+    raise 'No JSON file found in the specified directory. Check if mdsd is running in MSI mode' unless file_path
 
     file_contents = File.read(file_path)
     data = JSON.parse(file_contents)
 
-    raise 'Invalid JSON structure: Missing required keys' unless data.is_a?(Hash) && data.key?('dataSources')
+    raise 'Invalid JSON structure: Missing required key: dataSources. Check if DCR is valid' unless data.is_a?(Hash) && data.key?('dataSources')
 
     # Extract the stream values
     streams = data['dataSources'].select { |ds| ds['id'] == 'ContainerInsightsExtension' }

--- a/build/linux/installer/scripts/dcr-config-parser.rb
+++ b/build/linux/installer/scripts/dcr-config-parser.rb
@@ -16,6 +16,7 @@ require_relative 'ConfigParseErrorLogger'
 @logs_and_events_only = false
 
 return if ENV['GENEVA_LOGS_INTEGRATION']&.strip&.casecmp?('true')
+return if ENV['GENEVA_LOGS_INTEGRATION_SERVICE_MODE']&.strip&.casecmp?('true')
 return if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp('windows').zero?
 return unless ENV['USING_AAD_MSI_AUTH']&.strip&.casecmp?('true')
 

--- a/build/linux/installer/scripts/livenessprobe.sh
+++ b/build/linux/installer/scripts/livenessprobe.sh
@@ -16,7 +16,7 @@ if [[ "${CONTROLLER_TYPE}" == "DaemonSet" && "${CONTAINER_TYPE}" != "PrometheusS
   fi
 
   CURRENT_LOGS_AND_EVENTS_ONLY=${LOGS_AND_EVENTS_ONLY}
-  ruby /opt/dcr-config-parser.rb
+  ruby /opt/dcr-config-parser.rb > /dev/write-to-traces 2>&1
   source /opt/dcr_env_var
   if [ "${LOGS_AND_EVENTS_ONLY}" != "${CURRENT_LOGS_AND_EVENTS_ONLY}" ]; then
     echo "dcr_env_var has been updated - dcr config changed" > /dev/termination-log


### PR DESCRIPTION
This pull request includes updates to the error messages in the `dcr-config-parser.rb` script. The changes make the error messages more informative, providing additional context for troubleshooting. Specifically, the error message for when no JSON file is found now suggests checking if mdsd is running in MSI mode. Similarly, the error message for when the required key 'dataSources' is missing from the JSON structure now suggests checking if DCR is valid.