### PR TITLE
Update ai instrumentation key for USNAT/USSEC

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -24,7 +24,6 @@ setCloudSpecificApplicationInsightsConfig() {
             ;;
          "usnat")
             APPLICATIONINSIGHTS_AUTH="YTk5NTlkNDYtYzE3Zi0xZDYxLWJhODgtZWU3NDFjMGI3MTliCg=="
-            # IngestionEndpoint: usnateast-0.in.applicationinsights.azure.eaglex.ic.gov
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.eaglex.ic.gov/v2/track"
             echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
@@ -33,7 +32,6 @@ setCloudSpecificApplicationInsightsConfig() {
             ;;
          "ussec")
             APPLICATIONINSIGHTS_AUTH="NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
-            # IngestionEndpoint: usseceast-0.in.applicationinsights.azure.microsoft.scloud
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
             echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -29,7 +29,6 @@ setCloudSpecificApplicationInsightsConfig() {
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
             source ~/.bashrc
             ;;
-            ;;
          "ussec")
             APPLICATIONINSIGHTS_AUTH="NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.microsoft.scloud/v2/track"

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -28,9 +28,6 @@ setCloudSpecificApplicationInsightsConfig() {
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.eaglex.ic.gov/v2/track"
             echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
-            aikey=$(echo "$APPLICATIONINSIGHTS_AUTH" | base64 -d)
-            export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey
-            echo "export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey" >>~/.bashrc
             source ~/.bashrc
             ;;
             ;;
@@ -40,9 +37,6 @@ setCloudSpecificApplicationInsightsConfig() {
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
             echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
-            aikey=$(echo "$APPLICATIONINSIGHTS_AUTH" | base64 -d)
-            export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey
-            echo "export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey" >>~/.bashrc
             source ~/.bashrc
             ;;
           *)

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -22,39 +22,30 @@ setCloudSpecificApplicationInsightsConfig() {
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
             source ~/.bashrc
             ;;
-         "usnat" | "ussec")
-           # Check if the instrumentation key needs to be fetched from a storage account (as in airgapped clouds)
-            if [ ${#APPLICATIONINSIGHTS_AUTH_URL} -ge 1 ]; then # (check if APPLICATIONINSIGHTS_AUTH_URL has length >=1)
-                  for BACKOFF in {1..4}; do
-                        KEY=$(curl -sS $APPLICATIONINSIGHTS_AUTH_URL)
-                        # there's no easy way to get the HTTP status code from curl, so just check if the result is well formatted
-                        if [[ $KEY =~ ^[A-Za-z0-9=]+$ ]]; then
-                              break
-                        else
-                              sleep $((2 ** $BACKOFF / 4)) # (exponential backoff)
-                        fi
-                  done
-
-                  # validate that the retrieved data is an instrumentation key
-                  if [[ $KEY =~ ^[A-Za-z0-9=]+$ ]]; then
-                        export APPLICATIONINSIGHTS_AUTH=$(echo $KEY)
-                        echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
-                        echo "Using cloud-specific instrumentation key"
-                  else
-                        # no ikey can be retrieved. Disable telemetry and continue
-                        export DISABLE_TELEMETRY=true
-                        echo "export DISABLE_TELEMETRY=true" >>~/.bashrc
-                        echo "Could not get cloud-specific instrumentation key (network error?). Disabling telemetry"
-                  fi
-            fi
-
+         "usnat")
+            APPLICATIONINSIGHTS_AUTH="YTk5NTlkNDYtYzE3Zi0xZDYxLWJhODgtZWU3NDFjMGI3MTliCg=="
+            # IngestionEndpoint: usnateast-0.in.applicationinsights.azure.eaglex.ic.gov
+            APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.eaglex.ic.gov/v2/track"
+            echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
+            echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
             aikey=$(echo "$APPLICATIONINSIGHTS_AUTH" | base64 -d)
             export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey
             echo "export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey" >>~/.bashrc
             source ~/.bashrc
             ;;
-
-        *)
+            ;;
+         "ussec")
+            APPLICATIONINSIGHTS_AUTH="NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
+            # IngestionEndpoint: usseceast-0.in.applicationinsights.azure.microsoft.scloud
+            APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
+            echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc
+            echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
+            aikey=$(echo "$APPLICATIONINSIGHTS_AUTH" | base64 -d)
+            export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey
+            echo "export TELEMETRY_APPLICATIONINSIGHTS_KEY=$aikey" >>~/.bashrc
+            source ~/.bashrc
+            ;;
+          *)
             echo "default is Public cloud"
             ;;
     esac

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -76,26 +76,6 @@ function Set-ProcessAndMachineEnvVariables($name, $value) {
     [System.Environment]::SetEnvironmentVariable($name, $value, "Machine")
 }
 
-function Set-AirgapCloudSpecificApplicationInsightsConfig {
-     # Need to do this before the SA fetch for AI key for airgapped clouds so that it is not overwritten with defaults.
-     $appInsightsAuth = [System.Environment]::GetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH", "process")
-     if (![string]::IsNullOrEmpty($appInsightsAuth)) {
-         [System.Environment]::SetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH", $appInsightsAuth, "machine")
-         Write-Host "Successfully set environment variable APPLICATIONINSIGHTS_AUTH - $($appInsightsAuth) for target 'machine'..."
-     }
-     else {
-         Write-Host "Failed to set environment variable APPLICATIONINSIGHTS_AUTH for target 'machine' since it is either null or empty"
-     }
-
-     $appInsightsEndpoint = [System.Environment]::GetEnvironmentVariable("APPLICATIONINSIGHTS_ENDPOINT", "process")
-     if (![string]::IsNullOrEmpty($appInsightsEndpoint)) {
-         [System.Environment]::SetEnvironmentVariable("APPLICATIONINSIGHTS_ENDPOINT", $appInsightsEndpoint, "machine")
-         Write-Host "Successfully set environment variable APPLICATIONINSIGHTS_ENDPOINT - $($appInsightsEndpoint) for target 'machine'..."
-     }
-
-     $aiKeyDecoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:APPLICATIONINSIGHTS_AUTH))
-     Set-ProcessAndMachineEnvVariables "TELEMETRY_APPLICATIONINSIGHTS_KEY" $aiKeyDecoded
-}
 function Set-CloudSpecificApplicationInsightsConfig {
     param (
         [string]$CloudEnvironment
@@ -118,14 +98,12 @@ function Set-CloudSpecificApplicationInsightsConfig {
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "YTk5NTlkNDYtYzE3Zi0xZDYxLWJhODgtZWU3NDFjMGI3MTliCg=="
             # IngestionEndpoint: usnateast-0.in.applicationinsights.azure.eaglex.ic.gov
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.eaglex.ic.gov/v2/track"
-            Set-AirgapCloudSpecificApplicationInsightsConfig
         }
         "ussec" {
             Write-Host "Set-CloudSpecificApplicationInsightsConfig: Setting Application Insights configuration for USSec Cloud"
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
               # IngestionEndpoint: usseceast-0.in.applicationinsights.azure.microsoft.scloud
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
-            Set-AirgapCloudSpecificApplicationInsightsConfig
         }
         default {
             Write-Host "Set-CloudSpecificApplicationInsightsConfig: defaulting to Public Cloud Application Insights configuration"

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -96,13 +96,11 @@ function Set-CloudSpecificApplicationInsightsConfig {
         "usnat" {
             Write-Host "Set-CloudSpecificApplicationInsightsConfig: Setting Application Insights configuration for USNat Cloud"
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "YTk5NTlkNDYtYzE3Zi0xZDYxLWJhODgtZWU3NDFjMGI3MTliCg=="
-            # IngestionEndpoint: usnateast-0.in.applicationinsights.azure.eaglex.ic.gov
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.eaglex.ic.gov/v2/track"
         }
         "ussec" {
             Write-Host "Set-CloudSpecificApplicationInsightsConfig: Setting Application Insights configuration for USSec Cloud"
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
-              # IngestionEndpoint: usseceast-0.in.applicationinsights.azure.microsoft.scloud
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
         }
         default {


### PR DESCRIPTION
This pull request includes changes to the `kubernetes/linux/main.sh` and `kubernetes/windows/main.ps1` scripts. The changes are primarily focused on the handling of Application Insights configuration for the `usnat` and `ussec` cloud environments. The most significant changes include removing the logic for fetching the instrumentation key from a storage account and replacing it with hardcoded values for the `APPLICATIONINSIGHTS_AUTH` and `APPLICATIONINSIGHTS_ENDPOINT` environment variables.

Changes to Application Insights configuration:

* [`kubernetes/linux/main.sh`](diffhunk://#diff-16c72639c92748bb0587fea9d4bee32127bd5b252e2138fea83433a43c0a5f65L25-L56): Removed the logic for fetching the instrumentation key from a storage account for the `usnat` and `ussec` cloud environments. Instead, hardcoded values for the `APPLICATIONINSIGHTS_AUTH` and `APPLICATIONINSIGHTS_ENDPOINT` environment variables are now set directly.

* [`kubernetes/windows/main.ps1`](diffhunk://#diff-2da2290d6fae65f77898d02932989c6f205d597ff0641c902610425a4d8845bdL96-L131): Similar changes were made in the PowerShell script. The logic for fetching the instrumentation key from a storage account was removed in the `Set-AirgapCloudSpecificApplicationInsightsConfig` function. In the `Set-CloudSpecificApplicationInsightsConfig` function, hardcoded values for the `APPLICATIONINSIGHTS_AUTH` and `APPLICATIONINSIGHTS_ENDPOINT` environment variables are now set directly for the `usnat` and `ussec` cloud environments. [[1]](diffhunk://#diff-2da2290d6fae65f77898d02932989c6f205d597ff0641c902610425a4d8845bdL96-L131) [[2]](diffhunk://#diff-2da2290d6fae65f77898d02932989c6f205d597ff0641c902610425a4d8845bdR118-R127)