### PR TITLE
Send insights metrics data to AMA

### DIFF
--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1081,12 +1081,12 @@ func PostTelegrafMetricsToLA(telegrafRecords []map[interface{}]interface{}) int 
 				bts, er = MdsdInsightsMetricsMsgpUnixSocketClient.Write(msgpBytes)
 			} else {
 				if InsightsMetricsNamedPipe == nil {
-					EnsureGenevaOr3PNamedPipeExists(&InsightsMetricsNamedPipe, InsightsMetricsDataType, &ContainerLogsWindowsAMAClientCreateErrors, false, &MdsdContainerLogTagRefreshTracker)
+					EnsureGenevaOr3PNamedPipeExists(&InsightsMetricsNamedPipe, InsightsMetricsDataType, &InsightsMetricsWindowsAMAClientCreateErrors, false, &MdsdInsightsMetricsTagRefreshTracker)
 					if InsightsMetricsNamedPipe == nil {
 						Log("Error::mdsd::Unable to create mdsd client for insights metrics. Please check error log.")
 						ContainerLogTelemetryMutex.Lock()
 						defer ContainerLogTelemetryMutex.Unlock()
-						InsightsMetricsMDSDClientCreateErrors += 1
+						InsightsMetricsWindowsAMAClientCreateErrors += 1
 						return output.FLB_RETRY
 					}
 				}
@@ -2382,7 +2382,7 @@ func InitializePlugin(pluginConfPath string, agentVersion string) {
 		Log("Creating AMA client for KubeMonAgentEvents")
 		EnsureGenevaOr3PNamedPipeExists(&KubeMonAgentEventsNamedPipe, KubeMonAgentEventDataType, &KubeMonEventsWindowsAMAClientCreateErrors, false, &MdsdKubeMonAgentEventsTagRefreshTracker)
 		Log("Creating AMA client for InsightsMetrics")
-		EnsureGenevaOr3PNamedPipeExists(&InsightsMetricsNamedPipe, InsightsMetricsDataType, &ContainerLogsWindowsAMAClientCreateErrors, false, &MdsdContainerLogTagRefreshTracker)
+		EnsureGenevaOr3PNamedPipeExists(&InsightsMetricsNamedPipe, InsightsMetricsDataType, &InsightsMetricsWindowsAMAClientCreateErrors, false, &MdsdInsightsMetricsTagRefreshTracker)
 	}
 
 	if strings.Compare(strings.ToLower(os.Getenv("CONTROLLER_TYPE")), "daemonset") == 0 {

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -53,6 +53,8 @@ var (
 	ContainerLogsWindowsAMAClientCreateErrors float64
 	//Tracks the number of mdsd client create errors for insightsmetrics (uses ContainerLogTelemetryTicker)
 	InsightsMetricsMDSDClientCreateErrors float64
+	//Tracks the number of windows ama client create errors for insightsmetrics (uses ContainerLogTelemetryTicker)
+	InsightsMetricsWindowsAMAClientCreateErrors float64
 	//Tracks the number of mdsd client create errors for Input plugin records (uses ContainerLogTelemetryTicker)
 	InputPluginRecordsErrors float64
 	//Tracks the number of mdsd client create errors for kubemonevents (uses ContainerLogTelemetryTicker)
@@ -109,6 +111,7 @@ const (
 	metricNameErrorCountInsightsMetricsMDSDClientCreateError          = "InsightsMetricsMDSDClientCreateErrorsCount"
 	metricNameErrorCountContainerLogsSendErrorsToWindowsAMAFromFluent = "ContainerLogsSendErrorsToWindowsAMAFromFluent"
 	metricNameErrorCountContainerLogsWindowsAMAClientCreateError      = "ContainerLogsWindowsAMAClientCreateErrors"
+	metricNameErrorCountInsightsMetricsWindowsAMAClientCreateError    = "InsightsMetricsWindowsAMAClientCreateErrors"
 	metricNameErrorCountKubeMonEventsWindowsAMAClientCreateError      = "KubeMonEventsWindowsAMAClientCreateErrors"
 	metricNameErrorCountKubeMonEventsMDSDClientCreateError            = "KubeMonEventsMDSDClientCreateErrorsCount"
 	metricNameErrorCountContainerLogsSendErrorsToADXFromFluent        = "ContainerLogs2ADXSendErrorCount"
@@ -155,6 +158,7 @@ func SendContainerLogPluginMetrics(telemetryPushIntervalProperty string) {
 		containerLogsSendErrorsToWindowsAMAFromFluent := ContainerLogsSendErrorsToWindowsAMAFromFluent
 		containerLogsWindowsAMAClientCreateErrors := ContainerLogsWindowsAMAClientCreateErrors
 		insightsMetricsMDSDClientCreateErrors := InsightsMetricsMDSDClientCreateErrors
+		insightsMetricsWindowsAMAClientCreateErrors := InsightsMetricsWindowsAMAClientCreateErrors
 		kubeMonEventsMDSDClientCreateErrors := KubeMonEventsMDSDClientCreateErrors
 		kubeMonEventsWindowsAMAClientCreateErrors := KubeMonEventsWindowsAMAClientCreateErrors
 		osmNamespaceCount := OSMNamespaceCount
@@ -182,9 +186,9 @@ func SendContainerLogPluginMetrics(telemetryPushIntervalProperty string) {
 		ContainerLogsWindowsAMAClientCreateErrors = 0.0
 		ContainerLogsSendErrorsToADXFromFluent = 0.0
 		ContainerLogsSendErrorsToWindowsAMAFromFluent = 0.0
-		ContainerLogsWindowsAMAClientCreateErrors = 0.0
 		ContainerLogsADXClientCreateErrors = 0.0
 		InsightsMetricsMDSDClientCreateErrors = 0.0
+		InsightsMetricsWindowsAMAClientCreateErrors = 0.0
 		KubeMonEventsMDSDClientCreateErrors = 0.0
 		KubeMonEventsWindowsAMAClientCreateErrors = 0.0
 		ContainerLogRecordCountWithEmptyTimeStamp = 0.0
@@ -321,6 +325,9 @@ func SendContainerLogPluginMetrics(telemetryPushIntervalProperty string) {
 		}
 		if insightsMetricsMDSDClientCreateErrors > 0.0 {
 			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricNameErrorCountInsightsMetricsMDSDClientCreateError, insightsMetricsMDSDClientCreateErrors))
+		}
+		if insightsMetricsWindowsAMAClientCreateErrors > 0.0 {
+			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricNameErrorCountInsightsMetricsWindowsAMAClientCreateError, insightsMetricsWindowsAMAClientCreateErrors))
 		}
 		if kubeMonEventsMDSDClientCreateErrors > 0.0 {
 			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricNameErrorCountKubeMonEventsMDSDClientCreateError, kubeMonEventsMDSDClientCreateErrors))


### PR DESCRIPTION
This pull request primarily focuses on enhancing the `oms.go` file in the `source/plugins/go/src/` directory. The changes primarily revolve around the addition of a new named pipe connection for InsightsMetrics in the AMA (Azure Monitor for containers) context, and modifications to the `PostTelegrafMetricsToLA` function to accommodate both Linux and Windows MSI Auth modes.

New Named Pipe Connection:

* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eR219-R220): Added a new named pipe connection, `InsightsMetricsNamedPipe`, for sending InsightsMetrics in the AMA context.

Changes to `PostTelegrafMetricsToLA` function:

* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eL1019-R1021): Modified the condition to check for either Linux or Windows MSI Auth mode.
* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eR1064-R1066): Added variables `bts` and `er` to handle bytes and errors respectively.
* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eL1076-R1101): Extended the logic to handle the case when the OS is Windows and to use the `InsightsMetricsNamedPipe` for writing metrics.
* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eL1095-R1119): Updated log messages to reflect the changes in the function's behavior.

Changes to `InitializePlugin` function:

* [`source/plugins/go/src/oms.go`](diffhunk://#diff-b11de461d67b679d0a9f2fe929616504690bd41bf4e9cec27d7a5791933a171eR2384-R2385): Added logic to create an AMA client for InsightsMetrics in the case of Windows with AAD MSI Auth mode.