### PR TITLE
disable custom metrics

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -131,6 +131,7 @@ def substituteFluentBitPlaceHolders
     multilineLogging = ENV["AZMON_MULTILINE_ENABLED"]
     stacktraceLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
     resourceOptimizationEnabled = ENV["AZMON_RESOURCE_OPTIMIZATION_ENABLED"]
+    enableCustomMetrics = ENV["ENABLE_CUSTOM_METRICS"]
     windowsFluentBitDisabled = ENV["AZMON_WINDOWS_FLUENT_BIT_DISABLED"]
     kubernetesMetadataCollection = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
     annotationBasedLogFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]
@@ -194,7 +195,10 @@ def substituteFluentBitPlaceHolders
 
     new_contents = substituteMultiline(multilineLogging, stacktraceLanguages, new_contents)
 
-    if !@isWindows || (@isWindows && (!windowsFluentBitDisabled.nil? && windowsFluentBitDisabled.to_s.downcase == "false"))
+    # Valid resource optimization scenarios
+    # if Linux and Custom Metrics not enabled
+    # or if Windows and Fluent Bit is not disabled
+    if (!@isWindows && (enableCustomMetrics.nil? || enableCustomMetrics.to_s.downcase == "false")) || (@isWindows && (!windowsFluentBitDisabled.nil? && windowsFluentBitDisabled.to_s.downcase == "false"))
       new_contents = substituteResourceOptimization(resourceOptimizationEnabled, new_contents)
     end
     File.open(@fluent_bit_conf_path, "w") { |file| file.puts new_contents }

--- a/build/common/installer/scripts/tomlparser-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-agent-config.rb
@@ -384,10 +384,16 @@ def populateSettingValuesFromConfigMap(parsedConfig)
         end
       end
 
+      enable_custom_metrics = ENV["ENABLE_CUSTOM_METRICS"]
+      if !enable_custom_metrics.nil? && enable_custom_metrics.to_s.downcase == "true"
+        @resource_optimization_enabled = false
+        puts "Resource Optimization disabled since custom metrics is enabled"
+      end
+
       windows_fluent_bit_config = parsedConfig[:agent_settings][:windows_fluent_bit]
       if !windows_fluent_bit_config.nil?
         windows_fluent_bit_disabled = windows_fluent_bit_config[:disabled]
-        if !windows_fluent_bit_disabled.nil? && windows_fluent_bit_disabled.downcase == "false"
+        if !windows_fluent_bit_disabled.nil? && windows_fluent_bit_disabled.to_s.downcase == "false"
           @windows_fluent_bit_disabled = false
         end
         puts "Using config map value: AZMON_WINDOWS_FLUENT_BIT_DISABLED = #{@windows_fluent_bit_disabled}"

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -83,8 +83,8 @@ def populateSettingValuesFromConfigMap(parsedConfig)
     end
 
     if !parsedConfig.nil? && !parsedConfig[:agent_settings].nil?
-      enable_custom_metrics = parsedConfig[:agent_settings][:enable_custom_metrics]
-      if !enable_custom_metrics.nil? && !enable_custom_metrics[:enabled].nil?
+      custom_metrics = parsedConfig[:agent_settings][:custom_metrics]
+      if !custom_metrics.nil? && !custom_metrics[:enabled].nil?
         @enableCustomMetrics = enable_custom_metrics[:enabled]
         puts "Using config map value: enabled = #{@enableCustomMetrics} for custom metrics"
       end

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -85,7 +85,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
     if !parsedConfig.nil? && !parsedConfig[:agent_settings].nil?
       custom_metrics = parsedConfig[:agent_settings][:custom_metrics]
       if !custom_metrics.nil? && !custom_metrics[:enabled].nil?
-        @enableCustomMetrics = enable_custom_metrics[:enabled]
+        @enableCustomMetrics = custom_metrics[:enabled]
         puts "Using config map value: enabled = #{@enableCustomMetrics} for custom metrics"
       end
     end

--- a/build/common/installer/scripts/tomlparser-common-agent-config.rb
+++ b/build/common/installer/scripts/tomlparser-common-agent-config.rb
@@ -11,6 +11,7 @@ require_relative "ConfigParseErrorLogger"
 @disableTelemetry = false
 @logEnableKubernetesMetadataCacheTTLSeconds = 60
 @enableHighLogScaleMode = false
+@enableCustomMetrics = false
 
 def is_windows?
   return !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
@@ -81,6 +82,14 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       end
     end
 
+    if !parsedConfig.nil? && !parsedConfig[:agent_settings].nil?
+      enable_custom_metrics = parsedConfig[:agent_settings][:enable_custom_metrics]
+      if !enable_custom_metrics.nil? && !enable_custom_metrics[:enabled].nil?
+        @enableCustomMetrics = enable_custom_metrics[:enabled]
+        puts "Using config map value: enabled = #{@enableCustomMetrics} for custom metrics"
+      end
+    end
+
   rescue => errorStr
     puts "config::error:Exception while reading config settings for agent configuration setting - #{errorStr}, using defaults"
   end
@@ -117,6 +126,11 @@ if is_windows?
       file.write(commands)
     end
 
+    if @enableCustomMetrics
+      commands = get_command_windows("ENABLE_CUSTOM_METRICS", @enableCustomMetrics)
+      file.write(commands)
+    end
+
     commands = get_command_windows("AZMON_KUBERNETES_METADATA_CACHE_TTL_SECONDS", @logEnableKubernetesMetadataCacheTTLSeconds)
     file.write(commands)
     # Close file after writing all environment variables
@@ -135,6 +149,9 @@ else
     end
     if @enableHighLogScaleMode
       file.write("export ENABLE_HIGH_LOG_SCALE_MODE=#{@enableHighLogScaleMode}\n")
+    end
+    if @enableCustomMetrics
+      file.write("export ENABLE_CUSTOM_METRICS=#{@enableCustomMetrics}\n")
     end
     file.write("export AZMON_KUBERNETES_METADATA_CACHE_TTL_SECONDS=#{@logEnableKubernetesMetadataCacheTTLSeconds}\n")
     # Close file after writing all environment variables

--- a/build/linux/installer/conf/container-cm.conf
+++ b/build/linux/installer/conf/container-cm.conf
@@ -8,6 +8,15 @@
     bind 127.0.0.1
   </source>
 
+  # MDM metrics from telegraf
+  <source>
+    @type tcp
+    tag oms.mdm.container.perf.telegraf.*
+    bind 0.0.0.0
+    port 25228
+    format json
+  </source>
+
   # Container inventory
   <source>
     @type containerinventory
@@ -23,6 +32,18 @@
     run_interval 60
     @log_level info
   </source>
+
+  #custom_metrics_mdm filter plugin
+  <filter mdm.cadvisorperf**>
+    @type cadvisor2mdm
+    metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,memoryRssBytes,pvUsedBytes
+    @log_level info
+  </filter>
+
+  <filter oms.mdm.container.perf.telegraf**>
+   @type telegraf2mdm
+   @log_level info
+  </filter>
 
   #containerinventory
   <match **CONTAINER_INVENTORY_BLOB**>
@@ -74,6 +95,23 @@
      flush_thread_count 5
     </buffer>
     keepalive true
+  </match>
+
+  <match mdm.cadvisorperf** oms.mdm.container.perf.telegraf**>
+    @type mdm
+    @log_level info
+    <buffer>
+      @type file
+      path /var/opt/microsoft/docker-cimprov/state/out_mdm_cdvisorperf*.buffer
+      overflow_action drop_oldest_chunk
+      chunk_limit_size 4m
+      flush_interval 20s
+      retry_max_times 10
+      retry_wait 5s
+      retry_max_interval 5m
+      flush_thread_count 5
+    </buffer>
+    retry_mdm_post_wait_minutes 30
   </match>
 
   #InsightsMetrics

--- a/build/linux/installer/conf/container.conf
+++ b/build/linux/installer/conf/container.conf
@@ -8,6 +8,7 @@
     bind 127.0.0.1
   </source>
 
+#CustomMetricsStart
   # MDM metrics from telegraf
   <source>
     @type tcp
@@ -16,6 +17,7 @@
     port 25228
     format json
   </source>
+#CustomMetricsEnd
 
   # Container inventory
   <source>
@@ -33,6 +35,7 @@
     @log_level info
   </source>
 
+#CustomMetricsStart
   #custom_metrics_mdm filter plugin
   <filter mdm.cadvisorperf**>
     @type cadvisor2mdm
@@ -44,6 +47,7 @@
    @type telegraf2mdm
    @log_level info
   </filter>
+#CustomMetricsEnd
 
   #containerinventory
   <match **CONTAINER_INVENTORY_BLOB**>
@@ -97,6 +101,7 @@
     keepalive true
   </match>
 
+#CustomMetricsStart
   <match mdm.cadvisorperf** oms.mdm.container.perf.telegraf**>
     @type mdm
     @log_level info
@@ -113,6 +118,7 @@
     </buffer>
     retry_mdm_post_wait_minutes 30
   </match>
+#CustomMetricsEnd
 
   #InsightsMetrics
   <match **INSIGHTS_METRICS_BLOB**>

--- a/build/linux/installer/conf/container.conf
+++ b/build/linux/installer/conf/container.conf
@@ -8,7 +8,6 @@
     bind 127.0.0.1
   </source>
 
-#CustomMetricsStart
   # MDM metrics from telegraf
   <source>
     @type tcp
@@ -17,7 +16,6 @@
     port 25228
     format json
   </source>
-#CustomMetricsEnd
 
   # Container inventory
   <source>
@@ -35,7 +33,6 @@
     @log_level info
   </source>
 
-#CustomMetricsStart
   #custom_metrics_mdm filter plugin
   <filter mdm.cadvisorperf**>
     @type cadvisor2mdm
@@ -47,7 +44,6 @@
    @type telegraf2mdm
    @log_level info
   </filter>
-#CustomMetricsEnd
 
   #containerinventory
   <match **CONTAINER_INVENTORY_BLOB**>
@@ -101,7 +97,6 @@
     keepalive true
   </match>
 
-#CustomMetricsStart
   <match mdm.cadvisorperf** oms.mdm.container.perf.telegraf**>
     @type mdm
     @log_level info
@@ -118,7 +113,6 @@
     </buffer>
     retry_mdm_post_wait_minutes 30
   </match>
-#CustomMetricsEnd
 
   #InsightsMetrics
   <match **INSIGHTS_METRICS_BLOB**>

--- a/build/linux/installer/conf/kube-cm.conf
+++ b/build/linux/installer/conf/kube-cm.conf
@@ -59,6 +59,14 @@
      keepalive true
    </match>
 
+   #custom_metrics_mdm filter plugin for perf data from windows nodes
+    <filter mdm.cadvisorperf**>
+     @type cadvisor2mdm
+     metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
+     @log_level info
+    </filter>
+
+
   <worker "#{ENV['FLUENTD_POD_INVENTORY_WORKER_ID']}">
     #Kubernetes pod inventory
     <source>
@@ -155,6 +163,11 @@
      keepalive true
     </match>
 
+    <filter mdm.kubenodeinventory**>
+     @type inventory2mdm
+     @log_level info
+    </filter>
+
     #kubenodeinventory
     <match **KUBE_NODE_INVENTORY_BLOB**>
      @type forward
@@ -181,6 +194,24 @@
      keepalive true
     </match>
 
+    <match mdm.kubenodeinventory** >
+     @type mdm
+     @id out_mdm_nodeinventory
+     @log_level info
+     <buffer>
+      @type file
+      path /var/opt/microsoft/docker-cimprov/state/out_mdm_nodeinventory*.buffer
+      overflow_action drop_oldest_chunk
+      chunk_limit_size 4m
+      queue_limit_length "#{ENV['FLUENTD_QUEUE_LIMIT_LENGTH']}"
+      flush_interval "#{ENV['FLUENTD_FLUSH_INTERVAL']}"
+      retry_max_times 10
+      retry_wait 5s
+      retry_max_interval 5m
+      flush_thread_count 5
+     </buffer>
+     retry_mdm_post_wait_minutes 30
+    </match>
   </worker>
   <worker "#{ENV['FLUENTD_EVENT_INVENTORY_WORKER_ID']}">
     #Kubernetes events
@@ -215,6 +246,33 @@
       flush_thread_count 5
      </buffer>
      keepalive true
+    </match>
+  </worker>
+  <worker "#{ENV['FLUENTD_POD_MDM_INVENTORY_WORKER_ID']}">
+    #Kubernetes podmdm inventory
+    <source>
+     @type kube_podmdminventory
+     run_interval 60
+     @log_level info
+    </source>
+
+    <match mdm.kubepodinventory**>
+     @type mdm
+     @id out_mdm_podinventory
+     @log_level info
+     <buffer>
+      @type file
+      path /var/opt/microsoft/docker-cimprov/state/out_mdm_podinventory*.buffer
+      overflow_action drop_oldest_chunk
+      chunk_limit_size 4m
+      queue_limit_length "#{ENV['FLUENTD_QUEUE_LIMIT_LENGTH']}"
+      flush_interval "#{ENV['FLUENTD_FLUSH_INTERVAL']}"
+      retry_max_times 10
+      retry_wait 5s
+      retry_max_interval 5m
+      flush_thread_count "#{ENV['FLUENTD_MDM_FLUSH_THREAD_COUNT']}"
+     </buffer>
+     retry_mdm_post_wait_minutes 30
     </match>
   </worker>
   <worker "#{ENV['FLUENTD_OTHER_INVENTORY_WORKER_ID']}">
@@ -277,5 +335,24 @@
       flush_thread_count 5
      </buffer>
      keepalive true
+    </match>
+
+    <match mdm.cadvisorperf**>
+     @type mdm
+     @id out_mdm_perf
+     @log_level info
+     <buffer>
+      @type file
+      path /var/opt/microsoft/docker-cimprov/state/out_mdm_cdvisorperf*.buffer
+      overflow_action drop_oldest_chunk
+      chunk_limit_size 4m
+      queue_limit_length "#{ENV['FLUENTD_QUEUE_LIMIT_LENGTH']}"
+      flush_interval "#{ENV['FLUENTD_FLUSH_INTERVAL']}"
+      retry_max_times 10
+      retry_wait 5s
+      retry_max_interval 5m
+      flush_thread_count 5
+     </buffer>
+     retry_mdm_post_wait_minutes 30
     </match>
   </worker>

--- a/build/linux/installer/conf/kube.conf
+++ b/build/linux/installer/conf/kube.conf
@@ -164,10 +164,12 @@
      keepalive true
     </match>
 
+#CustomMetricsStart
     <filter mdm.kubenodeinventory**>
      @type inventory2mdm
      @log_level info
     </filter>
+#CustomMetricsEnd
 
     #kubenodeinventory
     <match **KUBE_NODE_INVENTORY_BLOB**>

--- a/build/linux/installer/conf/kube.conf
+++ b/build/linux/installer/conf/kube.conf
@@ -59,14 +59,13 @@
      keepalive true
    </match>
 
-#CustomMetricsStart
    #custom_metrics_mdm filter plugin for perf data from windows nodes
     <filter mdm.cadvisorperf**>
      @type cadvisor2mdm
      metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
      @log_level info
     </filter>
-#CustomMetricsEnd
+
 
   <worker "#{ENV['FLUENTD_POD_INVENTORY_WORKER_ID']}">
     #Kubernetes pod inventory
@@ -164,12 +163,10 @@
      keepalive true
     </match>
 
-#CustomMetricsStart
     <filter mdm.kubenodeinventory**>
      @type inventory2mdm
      @log_level info
     </filter>
-#CustomMetricsEnd
 
     #kubenodeinventory
     <match **KUBE_NODE_INVENTORY_BLOB**>
@@ -197,7 +194,6 @@
      keepalive true
     </match>
 
-#CustomMetricsStart
     <match mdm.kubenodeinventory** >
      @type mdm
      @id out_mdm_nodeinventory
@@ -216,7 +212,6 @@
      </buffer>
      retry_mdm_post_wait_minutes 30
     </match>
-#CustomMetricsEnd
   </worker>
   <worker "#{ENV['FLUENTD_EVENT_INVENTORY_WORKER_ID']}">
     #Kubernetes events
@@ -253,7 +248,6 @@
      keepalive true
     </match>
   </worker>
-#CustomMetricsStart
   <worker "#{ENV['FLUENTD_POD_MDM_INVENTORY_WORKER_ID']}">
     #Kubernetes podmdm inventory
     <source>
@@ -281,7 +275,6 @@
      retry_mdm_post_wait_minutes 30
     </match>
   </worker>
-#CustomMetricsEnd
   <worker "#{ENV['FLUENTD_OTHER_INVENTORY_WORKER_ID']}">
 
     #Kubernetes perf inventory
@@ -344,7 +337,6 @@
      keepalive true
     </match>
 
-#CustomMetricsStart
     <match mdm.cadvisorperf**>
      @type mdm
      @id out_mdm_perf
@@ -363,5 +355,4 @@
      </buffer>
      retry_mdm_post_wait_minutes 30
     </match>
-#CustomMetricsEnd
   </worker>

--- a/build/linux/installer/conf/kube.conf
+++ b/build/linux/installer/conf/kube.conf
@@ -59,13 +59,14 @@
      keepalive true
    </match>
 
+#CustomMetricsStart
    #custom_metrics_mdm filter plugin for perf data from windows nodes
     <filter mdm.cadvisorperf**>
      @type cadvisor2mdm
      metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes,pvUsedBytes
      @log_level info
     </filter>
-
+#CustomMetricsEnd
 
   <worker "#{ENV['FLUENTD_POD_INVENTORY_WORKER_ID']}">
     #Kubernetes pod inventory
@@ -194,6 +195,7 @@
      keepalive true
     </match>
 
+#CustomMetricsStart
     <match mdm.kubenodeinventory** >
      @type mdm
      @id out_mdm_nodeinventory
@@ -212,6 +214,7 @@
      </buffer>
      retry_mdm_post_wait_minutes 30
     </match>
+#CustomMetricsEnd
   </worker>
   <worker "#{ENV['FLUENTD_EVENT_INVENTORY_WORKER_ID']}">
     #Kubernetes events
@@ -248,6 +251,7 @@
      keepalive true
     </match>
   </worker>
+#CustomMetricsStart
   <worker "#{ENV['FLUENTD_POD_MDM_INVENTORY_WORKER_ID']}">
     #Kubernetes podmdm inventory
     <source>
@@ -275,6 +279,7 @@
      retry_mdm_post_wait_minutes 30
     </match>
   </worker>
+#CustomMetricsEnd
   <worker "#{ENV['FLUENTD_OTHER_INVENTORY_WORKER_ID']}">
 
     #Kubernetes perf inventory
@@ -337,6 +342,7 @@
      keepalive true
     </match>
 
+#CustomMetricsStart
     <match mdm.cadvisorperf**>
      @type mdm
      @id out_mdm_perf
@@ -355,4 +361,5 @@
      </buffer>
      retry_mdm_post_wait_minutes 30
     </match>
+#CustomMetricsEnd
   </worker>

--- a/build/linux/installer/datafiles/base_container.data
+++ b/build/linux/installer/datafiles/base_container.data
@@ -132,7 +132,9 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/fluent/plugin/extension_utils.rb;                                                  source/plugins/ruby/extension_utils.rb; 644; root; root
 
 /etc/fluent/kube.conf;			                                                          build/linux/installer/conf/kube.conf;                  644; root; root
+/etc/fluent/kube-cm.conf;			                                                       build/linux/installer/conf/kube-cm.conf;                  644; root; root
 /etc/fluent/container.conf;			                                                    build/linux/installer/conf/container.conf;                  644; root; root
+/etc/fluent/container-cm.conf;			                                                 build/linux/installer/conf/container-cm.conf;                  644; root; root
 /etc/fluent/windows_rs_containerinventory.conf;                                         build/linux/installer/conf/windows_rs_containerinventory.conf;                  644; root; root
 /etc/fluent/windows_rs_perf.conf;                                                       build/linux/installer/conf/windows_rs_perf.conf;                  644; root; root
 

--- a/build/windows/installer/conf/fluent-cm.conf
+++ b/build/windows/installer/conf/fluent-cm.conf
@@ -1,0 +1,37 @@
+<source>
+  @type heartbeat_request
+  run_interval 30m
+  @log_level info
+</source>
+
+<source>
+  @type cadvisor_perf
+  tag oms.api.cadvisorperf
+  run_interval 60
+  @log_level info
+</source>
+
+#custom_metrics_mdm filter plugin
+<filter mdm.cadvisorperf**>
+  @type cadvisor2mdm
+  metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes
+  log_path /etc/amalogswindows/filter_cadvisor2mdm.log
+  @log_level info
+</filter>
+
+<match mdm.cadvisorperf**>
+  @type mdm
+  @log_level info
+  <buffer>
+    @type file
+    path /etc/amalogswindows/out_mdm_cdvisorperf.buffer
+    overflow_action drop_oldest_chunk
+    chunk_limit_size 4m
+    flush_interval 20s
+    retry_max_times 10
+    retry_wait 5s
+    retry_max_interval 5m
+    flush_thread_count 5
+  </buffer>
+  retry_mdm_post_wait_minutes 30
+</match>

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -4,7 +4,6 @@
   @log_level info
 </source>
 
-#CustomMetricsStart
 <source>
   @type cadvisor_perf
   tag oms.api.cadvisorperf
@@ -36,4 +35,3 @@
   </buffer>
   retry_mdm_post_wait_minutes 30
 </match>
-#CustomMetricsEnd

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -4,6 +4,7 @@
   @log_level info
 </source>
 
+#CustomMetricsStart
 <source>
   @type cadvisor_perf
   tag oms.api.cadvisorperf
@@ -35,3 +36,4 @@
   </buffer>
   retry_mdm_post_wait_minutes 30
 </match>
+#CustomMetricsEnd

--- a/build/windows/installer/conf/fluent.conf
+++ b/build/windows/installer/conf/fluent.conf
@@ -3,35 +3,3 @@
   run_interval 30m
   @log_level info
 </source>
-
-<source>
-  @type cadvisor_perf
-  tag oms.api.cadvisorperf
-  run_interval 60
-  @log_level info
-</source>
-
-#custom_metrics_mdm filter plugin
-<filter mdm.cadvisorperf**>
-  @type cadvisor2mdm
-  metrics_to_collect cpuUsageNanoCores,memoryWorkingSetBytes
-  log_path /etc/amalogswindows/filter_cadvisor2mdm.log
-  @log_level info
-</filter>
-
-<match mdm.cadvisorperf**>
-  @type mdm
-  @log_level info
-  <buffer>
-    @type file
-    path /etc/amalogswindows/out_mdm_cdvisorperf.buffer
-    overflow_action drop_oldest_chunk
-    chunk_limit_size 4m
-    flush_interval 20s
-    retry_max_times 10
-    retry_wait 5s
-    retry_max_interval 5m
-    flush_thread_count 5
-  </buffer>
-  retry_mdm_post_wait_minutes 30
-</match>

--- a/build/windows/installer/livenessprobe/livenessprobe.cpp
+++ b/build/windows/installer/livenessprobe/livenessprobe.cpp
@@ -113,10 +113,13 @@ int _tmain(int argc, wchar_t *argv[])
         wprintf_s(L"ERROR:Process:%s is not running\n", argv[1]);
         return NO_FLUENT_BIT_PROCESS;
     }
+    const DWORD bufferSize = 256;
+    wchar_t enableCustomMetricsValue[bufferSize];
+    wchar_t msiModeValue[bufferSize];
+    GetEnvironmentVariable(L"ENABLE_CUSTOM_METRICS", enableCustomMetricsValue, bufferSize);
+    GetEnvironmentVariable(L"USING_AAD_MSI_AUTH", msiModeValue, bufferSize);
 
-    DWORD enableCustomMetrics = GetEnvironmentVariable(L"ENABLE_CUSTOM_METRICS", nullptr, 0);
-    DWORD msiMode = GetEnvironmentVariable(L"USING_AAD_MSI_AUTH", nullptr, 0);
-    if (enableCustomMetrics == "true" || msiMode != "true")
+    if (_wcsicmp(enableCustomMetricsValue, L"true") == 0 || _wcsicmp(msiModeValue, L"true") != 0)
     {
         DWORD dwStatus = GetServiceStatus(argv[2]);
         if (dwStatus != SERVICE_RUNNING)

--- a/build/windows/installer/livenessprobe/livenessprobe.cpp
+++ b/build/windows/installer/livenessprobe/livenessprobe.cpp
@@ -113,7 +113,7 @@ int _tmain(int argc, wchar_t *argv[])
         wprintf_s(L"ERROR:Process:%s is not running\n", argv[1]);
         return NO_FLUENT_BIT_PROCESS;
     }
-    const DWORD bufferSize = 256;
+    const DWORD bufferSize = 16;
     wchar_t enableCustomMetricsValue[bufferSize];
     wchar_t msiModeValue[bufferSize];
     GetEnvironmentVariable(L"ENABLE_CUSTOM_METRICS", enableCustomMetricsValue, bufferSize);

--- a/build/windows/installer/livenessprobe/livenessprobe.cpp
+++ b/build/windows/installer/livenessprobe/livenessprobe.cpp
@@ -114,12 +114,16 @@ int _tmain(int argc, wchar_t *argv[])
         return NO_FLUENT_BIT_PROCESS;
     }
 
-    DWORD dwStatus = GetServiceStatus(argv[2]);
-
-    if (dwStatus != SERVICE_RUNNING)
+    DWORD enableCustomMetrics = GetEnvironmentVariable(L"ENABLE_CUSTOM_METRICS", nullptr, 0);
+    DWORD msiMode = GetEnvironmentVariable(L"USING_AAD_MSI_AUTH", nullptr, 0);
+    if (enableCustomMetrics == "true" || msiMode != "true")
     {
-        wprintf_s(L"ERROR:Service:%s is not running\n", argv[2]);
-        return FLUENTDWINAKS_SERVICE_NOT_RUNNING;
+        DWORD dwStatus = GetServiceStatus(argv[2]);
+        if (dwStatus != SERVICE_RUNNING)
+        {
+            wprintf_s(L"ERROR:Service:%s is not running\n", argv[2]);
+            return FLUENTDWINAKS_SERVICE_NOT_RUNNING;
+        }
     }
 
     if (IsFileExists(argv[3]))
@@ -134,7 +138,8 @@ int _tmain(int argc, wchar_t *argv[])
         return CERTIFICATE_RENEWAL_REQUIRED;
     }
 
-    if (argc > 5) {
+    if (argc > 5)
+    {
         if (!IsProcessRunning(argv[5]))
         {
             wprintf_s(L"ERROR:Process:%s is not running\n", argv[5]);

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset-windows.yaml
@@ -97,6 +97,8 @@ spec:
               fieldPath: metadata.name
        - name: SIDECAR_SCRAPING_ENABLED
          value: {{ .Values.amalogs.sidecarscraping | quote }}
+       - name: ENABLE_CUSTOM_METRICS
+         value: {{ .Values.amalogs.enableCustomMetrics | quote }}
        volumeMounts:
         #  Uncomment when telegraf upgraded to 1.28.5 or higher
         # {{- if .Values.amalogs.enableServiceAccountTimeBoundToken }}

--- a/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-daemonset.yaml
@@ -129,6 +129,8 @@ spec:
        {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
+       - name: ENABLE_CUSTOM_METRICS
+         value: {{ .Values.amalogs.enableCustomMetrics | quote }}
        - name: HOSTNAME
          valueFrom:
             fieldRef:

--- a/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-deployment.yaml
@@ -112,6 +112,8 @@ spec:
        {{- end }}
        - name: IS_CUSTOM_CERT
          value: {{ .Values.Azure.proxySettings.isCustomCert | quote }}
+       - name: ENABLE_CUSTOM_METRICS
+         value: {{ .Values.amalogs.enableCustomMetrics | quote }}
        - name: HOSTNAME
          valueFrom:
             fieldRef:

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -66,6 +66,9 @@ amalogs:
   # This flag to enable and disable service account timebound token and default is enabled
   enableServiceAccountTimeBoundToken: true
 
+  # This flag to enable and disable custom metrics and default is enabled
+  enableCustomMetrics: true
+
   ## To get your workspace id and key do the following
   ## You can create a Azure Loganalytics workspace from portal.azure.com and get its ID & PRIMARY KEY from 'Advanced Settings' tab in the Ux.
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1050,6 +1050,7 @@ if [ "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" == "true" ] || [ -z "${AZMON_WINDOWS
       if [ -e "/etc/config/kube.conf" ]; then
            # Replace a string in the configmap file
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube.conf
+            sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube-cm.conf
       fi
 fi
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1073,7 +1073,14 @@ if [ -e "/opt/dcr_env_var" ]; then
       setGlobalEnvVar LOGS_AND_EVENTS_ONLY "${LOGS_AND_EVENTS_ONLY}"
 fi
 
-setGlobalEnvVar AZMON_RESOURCE_OPTIMIZATION_ENABLED "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}"
+setGlobalEnvVar ENABLE_CUSTOM_METRICS "${ENABLE_CUSTOM_METRICS}"
+if [ "${ENABLE_CUSTOM_METRICS}" == "true" ]; then
+      setGlobalEnvVar AZMON_RESOURCE_OPTIMIZATION_ENABLED "false"
+      export AZMON_RESOURCE_OPTIMIZATION_ENABLED="false"
+else
+      setGlobalEnvVar AZMON_RESOURCE_OPTIMIZATION_ENABLED "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}"
+fi
+
 if [ "$AZMON_RESOURCE_OPTIMIZATION_ENABLED" != "true" ]; then
       # no dependency on fluentd for prometheus side car container
       if [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ] && [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" != "true" ]; then
@@ -1226,7 +1233,7 @@ if [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" != "true" ]; then
       sed -i -e "s/placeholder_hostname/$nodename/g" $telegrafConfFile
 fi
 
-if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" == "true" ] || [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
+if [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
       sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' $telegrafConfFile
 fi
 
@@ -1255,7 +1262,7 @@ if [ ! -e "/etc/config/kube.conf" ] && [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE
             else
                   echo "checking for listener on tcp #25226 and waiting for $WAITTIME_PORT_25226 secs if not.."
                   waitforlisteneronTCPport 25226 $WAITTIME_PORT_25226
-                    if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" != "true" ] || [ "${ENABLE_CUSTOM_METRICS}" == true ]; then
+                    if [ "${ENABLE_CUSTOM_METRICS}" == true ]; then
                         echo "checking for listener on tcp #25228 and waiting for $WAITTIME_PORT_25228 secs if not.."
                         waitforlisteneronTCPport 25228 $WAITTIME_PORT_25228
                   fi

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1080,12 +1080,18 @@ if [ "$AZMON_RESOURCE_OPTIMIZATION_ENABLED" != "true" ]; then
             if [ ! -e "/etc/config/kube.conf" ]; then
                   if [ "$LOGS_AND_EVENTS_ONLY" != "true" ]; then
                         echo "*** starting fluentd v1 in daemonset"
+                        if [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
+                              sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' /etc/fluent/container.conf
+                        fi
                         fluentd -c /etc/fluent/container.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
                   else
                         echo "Skipping fluentd since LOGS_AND_EVENTS_ONLY is set to true"
                   fi
             else
                   echo "*** starting fluentd v1 in replicaset"
+                  if [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
+                        sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' /etc/fluent/kube.conf
+                  fi
                   fluentd -c /etc/fluent/kube.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
             fi
       fi
@@ -1220,7 +1226,7 @@ if [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE}" != "true" ]; then
       sed -i -e "s/placeholder_hostname/$nodename/g" $telegrafConfFile
 fi
 
-if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" == "true" ]; then
+if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" == "true" ] || [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
       sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' $telegrafConfFile
 fi
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1255,7 +1255,7 @@ if [ ! -e "/etc/config/kube.conf" ] && [ "${GENEVA_LOGS_INTEGRATION_SERVICE_MODE
             else
                   echo "checking for listener on tcp #25226 and waiting for $WAITTIME_PORT_25226 secs if not.."
                   waitforlisteneronTCPport 25226 $WAITTIME_PORT_25226
-                  if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" != "true" ]; then
+                    if [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" != "true" ] || [ "${ENABLE_CUSTOM_METRICS}" == true ]; then
                         echo "checking for listener on tcp #25228 and waiting for $WAITTIME_PORT_25228 secs if not.."
                         waitforlisteneronTCPport 25228 $WAITTIME_PORT_25228
                   fi

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1080,8 +1080,8 @@ if [ "$AZMON_RESOURCE_OPTIMIZATION_ENABLED" != "true" ]; then
             if [ ! -e "/etc/config/kube.conf" ]; then
                   if [ "$LOGS_AND_EVENTS_ONLY" != "true" ]; then
                         echo "*** starting fluentd v1 in daemonset"
-                        if [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
-                              sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' /etc/fluent/container.conf
+                        if [ "${ENABLE_CUSTOM_METRICS}" == "true" ]; then
+                              mv /etc/fluent/container-cm.conf /etc/fluent/container.conf
                         fi
                         fluentd -c /etc/fluent/container.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
                   else
@@ -1089,8 +1089,8 @@ if [ "$AZMON_RESOURCE_OPTIMIZATION_ENABLED" != "true" ]; then
                   fi
             else
                   echo "*** starting fluentd v1 in replicaset"
-                  if [ "${ENABLE_CUSTOM_METRICS}" != "true" ]; then
-                        sed -i '/^#CustomMetricsStart/,/^#CustomMetricsEnd/ s/^/# /' /etc/fluent/kube.conf
+                  if [ "${ENABLE_CUSTOM_METRICS}" == "true" ]; then
+                        mv /etc/fluent/kube-cm.conf /etc/fluent/kube.conf
                   fi
                   fluentd -c /etc/fluent/kube.conf -o /var/opt/microsoft/docker-cimprov/log/fluentd.log --log-rotate-age 5 --log-rotate-size 20971520 &
             fi

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -68,6 +68,7 @@ COPY ./amalogswindows/perf.so /opt/fluent-bit/bin/perf.so
 
 # copy fluent, fluent-bit and out_oms conf files
 COPY ./amalogswindows/installer/conf/fluent.conf /etc/fluent/
+COPY ./amalogswindows/installer/conf/fluent-cm.conf /etc/fluent/
 COPY ./amalogswindows/installer/conf/fluent-bit.conf /etc/fluent-bit
 COPY ./amalogswindows/installer/conf/azm-containers-parser.conf /etc/fluent-bit/
 COPY ./amalogswindows/installer/conf/azm-containers-parser-multiline.conf /etc/fluent-bit/

--- a/kubernetes/windows/Dockerfile-dev-image
+++ b/kubernetes/windows/Dockerfile-dev-image
@@ -19,6 +19,7 @@ COPY ./amalogswindows/out_oms.so /opt/amalogswindows/out_oms.so
 
 # copy fluent, fluent-bit and out_oms conf files
 COPY ./amalogswindows/installer/conf/fluent.conf /etc/fluent/
+COPY ./amalogswindows/installer/conf/fluent-cm.conf /etc/fluent/
 COPY ./amalogswindows/installer/conf/fluent-bit.conf /etc/fluent-bit
 COPY ./amalogswindows/installer/conf/azm-containers-parser.conf /etc/fluent-bit/
 COPY ./amalogswindows/installer/conf/azm-containers-parser-multiline.conf /etc/fluent-bit/

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -756,12 +756,11 @@ function Start-Fluent-Telegraf {
     }
 
     $enableCustomMetrics = [System.Environment]::GetEnvironmentVariable("ENABLE_CUSTOM_METRICS", "process")
-    if ([string]::IsNullOrEmpty($enableCustomMetrics) -or $enableCustomMetrics.ToLower() -ne 'true') {
-        Disable-CustomMetrics-Config -filePath 'C:/etc/fluent/fluent.conf'
+    if ($enableCustomMetrics.ToLower() -eq 'true') {
+        Move-Item -Path "C:/etc/fluent/fluent-cm.conf" -Destination "C:/etc/fluent/fluent.conf" -Force
     }
 
     $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
-
     # Start fluentd as a windows service only if custom metrics is enabled or legacy mode
     if ($enableCustomMetrics.ToLower() -eq 'true' -or [string]::IsNullOrEmpty($isAADMSIAuth) -or $isAADMSIAuth.ToLower() -eq "false") {
         fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -45,7 +45,8 @@ function Test-FluentbitTcpListener {
         [System.Environment]::SetEnvironmentVariable("WAITTIME_PORT_25229", $waitTimeSecs, "Process")
         [System.Environment]::SetEnvironmentVariable("WAITTIME_PORT_25229", $waitTimeSecs, "Machine")
         Write-Host "Successfully set environment variable WAITTIME_PORT_25229 - $($waitTimeSecs) for target 'machine'..."
-    } else {
+    }
+    else {
         Write-Host "Failed to set environment variable WAITTIME_PORT_25229 for target 'machine' since it is either null or empty"
         $waitTimeSecs = 30
     }
@@ -187,13 +188,13 @@ function Set-AMA3PEnvironmentVariables {
 }
 
 function Generate-GenevaTenantNameSpaceConfig {
-     $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
+    $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
     if (![string]::IsNullOrEmpty($genevaLogsTenantNameSpaces)) {
         [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", $genevaLogsTenantNameSpaces, "machine")
         $genevaLogsTenantNameSpacesArray = $genevaLogsTenantNameSpaces.Split(",")
         for ($i = 0; $i -lt $genevaLogsTenantNameSpacesArray.Length; $i = $i + 1) {
-          $tenantName = $genevaLogsTenantNameSpacesArray[$i]
-          Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_tenant.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
+            $tenantName = $genevaLogsTenantNameSpacesArray[$i]
+            Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_tenant.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
           (Get-Content -Path C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf  -Raw) -replace '<TENANT_NAMESPACE>', $tenantName | Set-Content C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
         }
     }
@@ -201,18 +202,18 @@ function Generate-GenevaTenantNameSpaceConfig {
 }
 
 function Generate-GenevaInfraNameSpaceConfig {
-   $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", "process")
-   if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
-       [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", $genevaLogsInfraNameSpaces, "machine")
-       $genevaLogsInfraNameSpacesArray = $genevaLogsInfraNameSpaces.Split(",")
-       for ($i = 0; $i -lt $genevaLogsInfraNameSpacesArray.Length; $i = $i + 1) {
-         $infraNameSpaceName = $genevaLogsInfraNameSpacesArray[$i]
-         $infraNamespaceWithoutSuffix = $infraNameSpaceName.TrimEnd("_*")
-         Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
+    $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", "process")
+    if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
+        [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", $genevaLogsInfraNameSpaces, "machine")
+        $genevaLogsInfraNameSpacesArray = $genevaLogsInfraNameSpaces.Split(",")
+        for ($i = 0; $i -lt $genevaLogsInfraNameSpacesArray.Length; $i = $i + 1) {
+            $infraNameSpaceName = $genevaLogsInfraNameSpacesArray[$i]
+            $infraNamespaceWithoutSuffix = $infraNameSpaceName.TrimEnd("_*")
+            Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
          (Get-Content -Path C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf  -Raw) -replace '<INFRA_NAMESPACE>', $infraNameSpaceName | Set-Content C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
-       }
-   }
-   Remove-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf
+        }
+    }
+    Remove-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf
 }
 
 #register fluentd as a windows service
@@ -291,39 +292,40 @@ function Set-EnvironmentVariables {
     }
     if (![string]::IsNullOrEmpty($isIgnoreProxySettings) -and $isIgnoreProxySettings.ToLower() -eq 'true') {
         Write-Host "Ignoring Proxy Setttings since IGNORE_PROXY_SETTINGS is - $($isIgnoreProxySettings)"
-    } else {
-      $proxy = ""
-      if (Test-Path /etc/ama-logs-secret/PROXY) {
-        # TODO: Change to ama-logs-secret before merging
-        $proxy = Get-Content /etc/ama-logs-secret/PROXY
-        Write-Host "Validating the proxy configuration since proxy configuration provided"
-        # valide the proxy endpoint configuration
-        if (![string]::IsNullOrEmpty($proxy)) {
-            $proxy = [string]$proxy.Trim();
+    }
+    else {
+        $proxy = ""
+        if (Test-Path /etc/ama-logs-secret/PROXY) {
+            # TODO: Change to ama-logs-secret before merging
+            $proxy = Get-Content /etc/ama-logs-secret/PROXY
+            Write-Host "Validating the proxy configuration since proxy configuration provided"
+            # valide the proxy endpoint configuration
             if (![string]::IsNullOrEmpty($proxy)) {
                 $proxy = [string]$proxy.Trim();
-                $parts = $proxy -split "@"
-                if ($parts.Length -ne 2) {
-                    Write-Host "Proxy is not using credentials..."
-                }
-                $subparts1 = $parts[0] -split "//"
-                if ($subparts1.Length -ne 2) {
-                    Write-Host "Invalid ProxyConfiguration. EXITING....."
-                    exit 1
-                }
-                $protocol = $subparts1[0].ToLower().TrimEnd(":")
-                if (!($protocol -eq "http") -and !($protocol -eq "https")) {
-                    Write-Host "Unsupported protocol in ProxyConfiguration $($proxy). EXITING....."
-                    exit 1
-                }
+                if (![string]::IsNullOrEmpty($proxy)) {
+                    $proxy = [string]$proxy.Trim();
+                    $parts = $proxy -split "@"
+                    if ($parts.Length -ne 2) {
+                        Write-Host "Proxy is not using credentials..."
+                    }
+                    $subparts1 = $parts[0] -split "//"
+                    if ($subparts1.Length -ne 2) {
+                        Write-Host "Invalid ProxyConfiguration. EXITING....."
+                        exit 1
+                    }
+                    $protocol = $subparts1[0].ToLower().TrimEnd(":")
+                    if (!($protocol -eq "http") -and !($protocol -eq "https")) {
+                        Write-Host "Unsupported protocol in ProxyConfiguration $($proxy). EXITING....."
+                        exit 1
+                    }
 
+                }
             }
+            Write-Host "Provided Proxy configuration is valid"
         }
-       Write-Host "Provided Proxy configuration is valid"
-      }
 
 
-       if (Test-Path /etc/ama-logs-secret/PROXYCERT.crt) {
+        if (Test-Path /etc/ama-logs-secret/PROXYCERT.crt) {
             Write-Host "Importing Proxy CA cert since Proxy CA cert configured"
             Import-Certificate -FilePath /etc/ama-logs-secret/PROXYCERT.crt -CertStoreLocation 'Cert:\LocalMachine\Root' -Verbose
         }
@@ -487,15 +489,16 @@ function Read-Configs {
 
     if (![string]::IsNullOrEmpty($enableFbitInternalMetrics) -and $enableFbitInternalMetrics.ToLower() -eq 'true') {
         Write-Host "Fluent-bit Internal metrics configured"
-    } else {
+    }
+    else {
         Clear-Content C:/etc/fluent-bit/fluent-bit-internal-metrics.conf
     }
 
     $genevaLogsMultitenancy = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", "process")
     if (![string]::IsNullOrEmpty($genevaLogsMultitenancy)) {
         if ($genevaLogsMultitenancy.ToLower() -eq 'true') {
-          [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", $genevaLogsMultitenancy, "machine")
-          Write-Host "Successfully set environment variable GENEVA_LOGS_MULTI_TENANCY - $($genevaLogsMultitenancy) for target 'machine'..."
+            [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", $genevaLogsMultitenancy, "machine")
+            Write-Host "Successfully set environment variable GENEVA_LOGS_MULTI_TENANCY - $($genevaLogsMultitenancy) for target 'machine'..."
         }
     }
     else {
@@ -513,7 +516,8 @@ function Read-Configs {
             Generate-GenevaTenantNameSpaceConfig
             Generate-GenevaInfraNameSpaceConfig
         }
-    } else {
+    }
+    else {
         $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH", "process")
         if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
             Set-CommonAMAEnvironmentVariables
@@ -549,16 +553,16 @@ function Set-EnvironmentVariablesFromFile {
 }
 
 function Set-AgentConfigSchemaVersion {
-      #set agent config schema version
-      $schemaVersionFile = '/etc/config/settings/schema-version'
-      if (Test-Path $schemaVersionFile) {
-          $schemaVersion = Get-Content $schemaVersionFile | ForEach-Object { $_.TrimEnd() }
-          if ($schemaVersion.GetType().Name -eq 'String') {
-              [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Process")
-              [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Machine")
-          }
-          $env:AZMON_AGENT_CFG_SCHEMA_VERSION
-      }
+    #set agent config schema version
+    $schemaVersionFile = '/etc/config/settings/schema-version'
+    if (Test-Path $schemaVersionFile) {
+        $schemaVersion = Get-Content $schemaVersionFile | ForEach-Object { $_.TrimEnd() }
+        if ($schemaVersion.GetType().Name -eq 'String') {
+            [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Process")
+            [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Machine")
+        }
+        $env:AZMON_AGENT_CFG_SCHEMA_VERSION
+    }
 }
 function Get-ContainerRuntime {
     # containerd is the default runtime on AKS windows
@@ -672,6 +676,37 @@ function Get-ContainerRuntime {
     return $containerRuntime
 }
 
+function Disable-CustomMetrics-Config {
+    param (
+        [string]$filePath
+    )
+    $content = Get-Content -Path $filePath
+
+    $inCustomMetricsBlock = $false
+    $customMetricsStart = "#CustomMetricsStart"
+    $customMetricsEnd = "#CustomMetricsEnd"
+
+    $updatedContent = $content | ForEach-Object {
+        if ($_ -eq $customMetricsStart) {
+            $inCustomMetricsBlock = $true
+        }
+
+        if ($inCustomMetricsBlock) {
+            $_ = "# " + $_
+        }
+
+        if ($_ -eq "# " + $customMetricsEnd) {
+            $inCustomMetricsBlock = $false
+        }
+
+        $_
+    }
+
+    $updatedContent | Set-Content -Path $filePath
+
+    Write-Output "Successfully commented the custom metrics block."
+}
+
 function Start-Fluent-Telegraf {
 
     Set-ProcessAndMachineEnvVariables "TELEMETRY_CUSTOM_PROM_MONITOR_PODS" "false"
@@ -705,7 +740,8 @@ function Start-Fluent-Telegraf {
         # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
         # Run fluent-bit as a background job. Switch this to a windows service once fluent-bit supports natively running as a windows service
         Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\fluent-bit\bin\fluent-bit.exe" -ArgumentList @("-c", "C:/etc/fluent-bit/fluent-bit-geneva.conf", "-e", "C:\opt\amalogswindows\out_oms.so") }
-    } else {
+    }
+    else {
         $fluentbitConfFile = "C:/etc/fluent-bit/fluent-bit.conf"
         Write-Host "Using fluent-bit config: $($fluentbitConfFile)"
         # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
@@ -719,7 +755,17 @@ function Start-Fluent-Telegraf {
         Start-Telegraf
     }
 
-    fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
+    $enableCustomMetrics = [System.Environment]::GetEnvironmentVariable("ENABLE_CUSTOM_METRICS", "process")
+    if ([string]::IsNullOrEmpty($enableCustomMetrics) -or $enableCustomMetrics.ToLower() -ne 'true') {
+        Disable-CustomMetrics-Config -filePath 'C:/etc/fluent/fluent.conf'
+    }
+
+    $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
+
+    # Start fluentd as a windows service only if custom metrics is enabled or legacy mode
+    if ($enableCustomMetrics.ToLower() -eq 'true' -or [string]::IsNullOrEmpty($isAADMSIAuth) -or $isAADMSIAuth.ToLower() -eq "false") {
+        fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
+    }
 
     Notepad.exe | Out-Null
 }
@@ -802,7 +848,8 @@ function Start-Telegraf {
                 C:\opt\telegraf\telegraf.exe --service start
                 Get-Service telegraf
             }
-        } else {
+        }
+        else {
             Write-Host "Telegraf not started since Fluentbit tcp listener is not up and running on port 25229"
         }
     }
@@ -852,24 +899,24 @@ function Bootstrap-CACertificates {
 }
 
 function IsGenevaMode() {
-    $isGenevaLogsIntegration=$false
-    $isGenevaLogsMultitenancy=$false
+    $isGenevaLogsIntegration = $false
+    $isGenevaLogsMultitenancy = $false
     $genevaLogsIntegration = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INTEGRATION")
     $genevaLogsMultitenancy = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY")
     $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES")
-    $isGenevaLogsInfraNameSpacesEmpty=$true
+    $isGenevaLogsInfraNameSpacesEmpty = $true
 
     if (![string]::IsNullOrEmpty($genevaLogsIntegration) -and $genevaLogsIntegration.ToLower() -eq 'true') {
-        $isGenevaLogsIntegration=$true
+        $isGenevaLogsIntegration = $true
     }
     if (![string]::IsNullOrEmpty($genevaLogsMultitenancy) -and $genevaLogsMultitenancy.ToLower() -eq 'true') {
-        $isGenevaLogsMultitenancy=$true
+        $isGenevaLogsMultitenancy = $true
     }
     if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
-        $isGenevaLogsInfraNameSpacesEmpty=$false
+        $isGenevaLogsInfraNameSpacesEmpty = $false
     }
-    if ($isGenevaLogsIntegration -and (!$isGenevaLogsMultitenancy -or !$isGenevaLogsInfraNameSpacesEmpty)){
-      return $true
+    if ($isGenevaLogsIntegration -and (!$isGenevaLogsMultitenancy -or !$isGenevaLogsInfraNameSpacesEmpty)) {
+        return $true
     }
     return $false
 }
@@ -898,7 +945,7 @@ $isGenevaModeVar = IsGenevaMode
 if ($isGenevaModeVar) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
-    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
+    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv") }
     if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
         Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
     }
@@ -913,7 +960,7 @@ else {
         Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
         #start Windows AMA
-        Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
+        Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv") }
         $version = Get-Content -Path "C:\opt\windowsazuremonitoragent\version.txt"
         Write-Host $version
     }

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -45,8 +45,7 @@ function Test-FluentbitTcpListener {
         [System.Environment]::SetEnvironmentVariable("WAITTIME_PORT_25229", $waitTimeSecs, "Process")
         [System.Environment]::SetEnvironmentVariable("WAITTIME_PORT_25229", $waitTimeSecs, "Machine")
         Write-Host "Successfully set environment variable WAITTIME_PORT_25229 - $($waitTimeSecs) for target 'machine'..."
-    }
-    else {
+    } else {
         Write-Host "Failed to set environment variable WAITTIME_PORT_25229 for target 'machine' since it is either null or empty"
         $waitTimeSecs = 30
     }
@@ -188,13 +187,13 @@ function Set-AMA3PEnvironmentVariables {
 }
 
 function Generate-GenevaTenantNameSpaceConfig {
-    $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
+     $genevaLogsTenantNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", "process")
     if (![string]::IsNullOrEmpty($genevaLogsTenantNameSpaces)) {
         [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_TENANT_NAMESPACES", $genevaLogsTenantNameSpaces, "machine")
         $genevaLogsTenantNameSpacesArray = $genevaLogsTenantNameSpaces.Split(",")
         for ($i = 0; $i -lt $genevaLogsTenantNameSpacesArray.Length; $i = $i + 1) {
-            $tenantName = $genevaLogsTenantNameSpacesArray[$i]
-            Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_tenant.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
+          $tenantName = $genevaLogsTenantNameSpacesArray[$i]
+          Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_tenant.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
           (Get-Content -Path C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf  -Raw) -replace '<TENANT_NAMESPACE>', $tenantName | Set-Content C:/etc/fluent-bit/fluent-bit-geneva-logs_$tenantName.conf
         }
     }
@@ -202,18 +201,18 @@ function Generate-GenevaTenantNameSpaceConfig {
 }
 
 function Generate-GenevaInfraNameSpaceConfig {
-    $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", "process")
-    if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
-        [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", $genevaLogsInfraNameSpaces, "machine")
-        $genevaLogsInfraNameSpacesArray = $genevaLogsInfraNameSpaces.Split(",")
-        for ($i = 0; $i -lt $genevaLogsInfraNameSpacesArray.Length; $i = $i + 1) {
-            $infraNameSpaceName = $genevaLogsInfraNameSpacesArray[$i]
-            $infraNamespaceWithoutSuffix = $infraNameSpaceName.TrimEnd("_*")
-            Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
+   $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", "process")
+   if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
+       [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES", $genevaLogsInfraNameSpaces, "machine")
+       $genevaLogsInfraNameSpacesArray = $genevaLogsInfraNameSpaces.Split(",")
+       for ($i = 0; $i -lt $genevaLogsInfraNameSpacesArray.Length; $i = $i + 1) {
+         $infraNameSpaceName = $genevaLogsInfraNameSpacesArray[$i]
+         $infraNamespaceWithoutSuffix = $infraNameSpaceName.TrimEnd("_*")
+         Copy-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf -Destination C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
          (Get-Content -Path C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf  -Raw) -replace '<INFRA_NAMESPACE>', $infraNameSpaceName | Set-Content C:/etc/fluent-bit/fluent-bit-geneva-logs_$infraNamespaceWithoutSuffix.conf
-        }
-    }
-    Remove-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf
+       }
+   }
+   Remove-Item C:/etc/fluent-bit/fluent-bit-geneva-logs_infra.conf
 }
 
 #register fluentd as a windows service
@@ -292,40 +291,39 @@ function Set-EnvironmentVariables {
     }
     if (![string]::IsNullOrEmpty($isIgnoreProxySettings) -and $isIgnoreProxySettings.ToLower() -eq 'true') {
         Write-Host "Ignoring Proxy Setttings since IGNORE_PROXY_SETTINGS is - $($isIgnoreProxySettings)"
-    }
-    else {
-        $proxy = ""
-        if (Test-Path /etc/ama-logs-secret/PROXY) {
-            # TODO: Change to ama-logs-secret before merging
-            $proxy = Get-Content /etc/ama-logs-secret/PROXY
-            Write-Host "Validating the proxy configuration since proxy configuration provided"
-            # valide the proxy endpoint configuration
+    } else {
+      $proxy = ""
+      if (Test-Path /etc/ama-logs-secret/PROXY) {
+        # TODO: Change to ama-logs-secret before merging
+        $proxy = Get-Content /etc/ama-logs-secret/PROXY
+        Write-Host "Validating the proxy configuration since proxy configuration provided"
+        # valide the proxy endpoint configuration
+        if (![string]::IsNullOrEmpty($proxy)) {
+            $proxy = [string]$proxy.Trim();
             if (![string]::IsNullOrEmpty($proxy)) {
                 $proxy = [string]$proxy.Trim();
-                if (![string]::IsNullOrEmpty($proxy)) {
-                    $proxy = [string]$proxy.Trim();
-                    $parts = $proxy -split "@"
-                    if ($parts.Length -ne 2) {
-                        Write-Host "Proxy is not using credentials..."
-                    }
-                    $subparts1 = $parts[0] -split "//"
-                    if ($subparts1.Length -ne 2) {
-                        Write-Host "Invalid ProxyConfiguration. EXITING....."
-                        exit 1
-                    }
-                    $protocol = $subparts1[0].ToLower().TrimEnd(":")
-                    if (!($protocol -eq "http") -and !($protocol -eq "https")) {
-                        Write-Host "Unsupported protocol in ProxyConfiguration $($proxy). EXITING....."
-                        exit 1
-                    }
-
+                $parts = $proxy -split "@"
+                if ($parts.Length -ne 2) {
+                    Write-Host "Proxy is not using credentials..."
                 }
+                $subparts1 = $parts[0] -split "//"
+                if ($subparts1.Length -ne 2) {
+                    Write-Host "Invalid ProxyConfiguration. EXITING....."
+                    exit 1
+                }
+                $protocol = $subparts1[0].ToLower().TrimEnd(":")
+                if (!($protocol -eq "http") -and !($protocol -eq "https")) {
+                    Write-Host "Unsupported protocol in ProxyConfiguration $($proxy). EXITING....."
+                    exit 1
+                }
+
             }
-            Write-Host "Provided Proxy configuration is valid"
         }
+       Write-Host "Provided Proxy configuration is valid"
+      }
 
 
-        if (Test-Path /etc/ama-logs-secret/PROXYCERT.crt) {
+       if (Test-Path /etc/ama-logs-secret/PROXYCERT.crt) {
             Write-Host "Importing Proxy CA cert since Proxy CA cert configured"
             Import-Certificate -FilePath /etc/ama-logs-secret/PROXYCERT.crt -CertStoreLocation 'Cert:\LocalMachine\Root' -Verbose
         }
@@ -489,16 +487,15 @@ function Read-Configs {
 
     if (![string]::IsNullOrEmpty($enableFbitInternalMetrics) -and $enableFbitInternalMetrics.ToLower() -eq 'true') {
         Write-Host "Fluent-bit Internal metrics configured"
-    }
-    else {
+    } else {
         Clear-Content C:/etc/fluent-bit/fluent-bit-internal-metrics.conf
     }
 
     $genevaLogsMultitenancy = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", "process")
     if (![string]::IsNullOrEmpty($genevaLogsMultitenancy)) {
         if ($genevaLogsMultitenancy.ToLower() -eq 'true') {
-            [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", $genevaLogsMultitenancy, "machine")
-            Write-Host "Successfully set environment variable GENEVA_LOGS_MULTI_TENANCY - $($genevaLogsMultitenancy) for target 'machine'..."
+          [System.Environment]::SetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY", $genevaLogsMultitenancy, "machine")
+          Write-Host "Successfully set environment variable GENEVA_LOGS_MULTI_TENANCY - $($genevaLogsMultitenancy) for target 'machine'..."
         }
     }
     else {
@@ -516,8 +513,7 @@ function Read-Configs {
             Generate-GenevaTenantNameSpaceConfig
             Generate-GenevaInfraNameSpaceConfig
         }
-    }
-    else {
+    } else {
         $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH", "process")
         if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
             Set-CommonAMAEnvironmentVariables
@@ -553,16 +549,16 @@ function Set-EnvironmentVariablesFromFile {
 }
 
 function Set-AgentConfigSchemaVersion {
-    #set agent config schema version
-    $schemaVersionFile = '/etc/config/settings/schema-version'
-    if (Test-Path $schemaVersionFile) {
-        $schemaVersion = Get-Content $schemaVersionFile | ForEach-Object { $_.TrimEnd() }
-        if ($schemaVersion.GetType().Name -eq 'String') {
-            [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Process")
-            [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Machine")
-        }
-        $env:AZMON_AGENT_CFG_SCHEMA_VERSION
-    }
+      #set agent config schema version
+      $schemaVersionFile = '/etc/config/settings/schema-version'
+      if (Test-Path $schemaVersionFile) {
+          $schemaVersion = Get-Content $schemaVersionFile | ForEach-Object { $_.TrimEnd() }
+          if ($schemaVersion.GetType().Name -eq 'String') {
+              [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Process")
+              [System.Environment]::SetEnvironmentVariable("AZMON_AGENT_CFG_SCHEMA_VERSION", $schemaVersion, "Machine")
+          }
+          $env:AZMON_AGENT_CFG_SCHEMA_VERSION
+      }
 }
 function Get-ContainerRuntime {
     # containerd is the default runtime on AKS windows
@@ -709,8 +705,7 @@ function Start-Fluent-Telegraf {
         # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
         # Run fluent-bit as a background job. Switch this to a windows service once fluent-bit supports natively running as a windows service
         Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\fluent-bit\bin\fluent-bit.exe" -ArgumentList @("-c", "C:/etc/fluent-bit/fluent-bit-geneva.conf", "-e", "C:\opt\amalogswindows\out_oms.so") }
-    }
-    else {
+    } else {
         $fluentbitConfFile = "C:/etc/fluent-bit/fluent-bit.conf"
         Write-Host "Using fluent-bit config: $($fluentbitConfFile)"
         # Run fluent-bit service first so that we do not miss any logs being forwarded by the telegraf service.
@@ -816,8 +811,7 @@ function Start-Telegraf {
                 C:\opt\telegraf\telegraf.exe --service start
                 Get-Service telegraf
             }
-        }
-        else {
+        } else {
             Write-Host "Telegraf not started since Fluentbit tcp listener is not up and running on port 25229"
         }
     }
@@ -867,24 +861,24 @@ function Bootstrap-CACertificates {
 }
 
 function IsGenevaMode() {
-    $isGenevaLogsIntegration = $false
-    $isGenevaLogsMultitenancy = $false
+    $isGenevaLogsIntegration=$false
+    $isGenevaLogsMultitenancy=$false
     $genevaLogsIntegration = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INTEGRATION")
     $genevaLogsMultitenancy = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_MULTI_TENANCY")
     $genevaLogsInfraNameSpaces = [System.Environment]::GetEnvironmentVariable("GENEVA_LOGS_INFRA_NAMESPACES")
-    $isGenevaLogsInfraNameSpacesEmpty = $true
+    $isGenevaLogsInfraNameSpacesEmpty=$true
 
     if (![string]::IsNullOrEmpty($genevaLogsIntegration) -and $genevaLogsIntegration.ToLower() -eq 'true') {
-        $isGenevaLogsIntegration = $true
+        $isGenevaLogsIntegration=$true
     }
     if (![string]::IsNullOrEmpty($genevaLogsMultitenancy) -and $genevaLogsMultitenancy.ToLower() -eq 'true') {
-        $isGenevaLogsMultitenancy = $true
+        $isGenevaLogsMultitenancy=$true
     }
     if (![string]::IsNullOrEmpty($genevaLogsInfraNameSpaces)) {
-        $isGenevaLogsInfraNameSpacesEmpty = $false
+        $isGenevaLogsInfraNameSpacesEmpty=$false
     }
-    if ($isGenevaLogsIntegration -and (!$isGenevaLogsMultitenancy -or !$isGenevaLogsInfraNameSpacesEmpty)) {
-        return $true
+    if ($isGenevaLogsIntegration -and (!$isGenevaLogsMultitenancy -or !$isGenevaLogsInfraNameSpacesEmpty)){
+      return $true
     }
     return $false
 }
@@ -913,7 +907,7 @@ $isGenevaModeVar = IsGenevaMode
 if ($isGenevaModeVar) {
     Write-Host "Starting Windows AMA in 1P Mode"
     #start Windows AMA
-    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv") }
+    Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
     if (![string]::IsNullOrEmpty($isAADMSIAuth) -and $isAADMSIAuth.ToLower() -eq 'true') {
         Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
     }
@@ -928,7 +922,7 @@ else {
         Write-Host "skipping agent onboarding via cert since AAD MSI Auth configured"
 
         #start Windows AMA
-        Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv") }
+        Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath "C:\opt\windowsazuremonitoragent\windowsazuremonitoragent\Monitoring\Agent\MonAgentLauncher.exe" -ArgumentList @("-useenv")}
         $version = Get-Content -Path "C:\opt\windowsazuremonitoragent\version.txt"
         Write-Host $version
     }

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -725,13 +725,13 @@ function Start-Fluent-Telegraf {
     }
 
     $enableCustomMetrics = [System.Environment]::GetEnvironmentVariable("ENABLE_CUSTOM_METRICS", "process")
-    if ($enableCustomMetrics.ToLower() -eq 'true') {
+    if (![string]::IsNullOrEmpty($enableCustomMetrics) -and $enableCustomMetrics.ToLower() -eq 'true') {
         Move-Item -Path "C:/etc/fluent/fluent-cm.conf" -Destination "C:/etc/fluent/fluent.conf" -Force
     }
 
     $isAADMSIAuth = [System.Environment]::GetEnvironmentVariable("USING_AAD_MSI_AUTH")
     # Start fluentd as a windows service only if custom metrics is enabled or legacy mode
-    if ($enableCustomMetrics.ToLower() -eq 'true' -or [string]::IsNullOrEmpty($isAADMSIAuth) -or $isAADMSIAuth.ToLower() -eq "false") {
+    if ((![string]::IsNullOrEmpty($enableCustomMetrics) -and $enableCustomMetrics.ToLower() -eq 'true') -or [string]::IsNullOrEmpty($isAADMSIAuth) -or $isAADMSIAuth.ToLower() -eq "false") {
         fluentd --reg-winsvc i --reg-winsvc-auto-start --winsvc-name fluentdwinaks --reg-winsvc-fluentdopt '-c C:/etc/fluent/fluent.conf -o C:/etc/fluent/fluent.log'
     }
 

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -676,37 +676,6 @@ function Get-ContainerRuntime {
     return $containerRuntime
 }
 
-function Disable-CustomMetrics-Config {
-    param (
-        [string]$filePath
-    )
-    $content = Get-Content -Path $filePath
-
-    $inCustomMetricsBlock = $false
-    $customMetricsStart = "#CustomMetricsStart"
-    $customMetricsEnd = "#CustomMetricsEnd"
-
-    $updatedContent = $content | ForEach-Object {
-        if ($_ -eq $customMetricsStart) {
-            $inCustomMetricsBlock = $true
-        }
-
-        if ($inCustomMetricsBlock) {
-            $_ = "# " + $_
-        }
-
-        if ($_ -eq "# " + $customMetricsEnd) {
-            $inCustomMetricsBlock = $false
-        }
-
-        $_
-    }
-
-    $updatedContent | Set-Content -Path $filePath
-
-    Write-Output "Successfully commented the custom metrics block."
-}
-
 function Start-Fluent-Telegraf {
 
     Set-ProcessAndMachineEnvVariables "TELEMETRY_CUSTOM_PROM_MONITOR_PODS" "false"

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -269,6 +269,11 @@ func SendContainerLogPluginMetrics(telemetryPushIntervalProperty string) {
 					telemetryDimensions["isHighLogScaleMode"] = isHighLogScaleMode
 				}
 
+				enableCustomMetrics := os.Getenv("ENABLE_CUSTOM_METRICS")
+				if enableCustomMetrics != "" {
+					telemetryDimensions["enableCustomMetrics"] = enableCustomMetrics
+				}
+
 				telemetryDimensions["PromFbitChunkSize"] = os.Getenv("AZMON_FBIT_CHUNK_SIZE")
 				telemetryDimensions["PromFbitBufferSize"] = os.Getenv("AZMON_FBIT_BUFFER_SIZE")
 				telemetryDimensions["PromFbitMemBufLimit"] = os.Getenv("AZMON_FBIT_MEM_BUF_LIMIT")

--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -10,6 +10,7 @@ class CustomMetricsUtils
             aks_region = ENV['AKS_REGION']
             aks_resource_id = ENV['AKS_RESOURCE_ID']
             aks_cloud_environment = ENV['CLOUD_ENVIRONMENT']
+            enable_custom_metrics = ENV['ENABLE_CUSTOM_METRICS']
             if aks_region.to_s.empty? || aks_resource_id.to_s.empty?
                 return false # This will also take care of AKS-Engine Scenario. AKS_REGION/AKS_RESOURCE_ID is not set for AKS-Engine. Only ACS_RESOURCE_NAME is set
             end
@@ -17,6 +18,10 @@ class CustomMetricsUtils
             is_arca_cluster = ENV['IS_ARCA_CLUSTER']
             if is_arca_cluster.to_s.downcase == "true" && !ENV['CUSTOM_METRICS_ENDPOINT'].to_s.empty?
                 return true
+            end
+
+            if enable_custom_metrics.nil? || enable_custom_metrics.to_s.downcase == 'false'
+                return false
             end
 
             return aks_cloud_environment.to_s.downcase == 'azurepubliccloud'

--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "fluent/plugin/input"
+require "oms_common"
 
 module Fluent::Plugin
   class Kube_PodInventory_Input < Input

--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "fluent/plugin/input"
-require "oms_common"
+require_relative "oms_common"
 
 module Fluent::Plugin
   class Kube_PodInventory_Input < Input


### PR DESCRIPTION
This pull request primarily introduces the ability to enable custom metrics in the system. It also makes adjustments to the conditions under which resource optimization is performed and modifies several configuration files. 

The key changes are as follows:

Environment Variable Introduction:

* [`build/common/installer/scripts/fluent-bit-conf-customizer.rb`](diffhunk://#diff-9ddf023aaa9b5992b30250db0faebd74e2ee801c09a1d1cc46f6ec7781bf9a16R134): Introduced a new environment variable `ENABLE_CUSTOM_METRICS` to enable or disable custom metrics.

Condition Modification:

* [`build/common/installer/scripts/fluent-bit-conf-customizer.rb`](diffhunk://#diff-9ddf023aaa9b5992b30250db0faebd74e2ee801c09a1d1cc46f6ec7781bf9a16L197-R201): Modified the condition for resource optimization. Now, resource optimization will be performed if the system is Linux and custom metrics are not enabled, or if the system is Windows and Fluent Bit is not disabled.

Disabling Resource Optimization:

* [`build/common/installer/scripts/tomlparser-agent-config.rb`](diffhunk://#diff-fa01e80dbcfab688d985fab24ffe79cc94d5246e1cc10a55cf477c0146dabd43R387-R396): If custom metrics are enabled, resource optimization is disabled.

Custom Metrics Enabling:

* [`build/common/installer/scripts/tomlparser-common-agent-config.rb`](diffhunk://#diff-8febaeaf011c6173c3f18a49405a41e1a4bf6896d94872c35ff258d50b3d0141R85-R92): Added the ability to enable custom metrics through the parsed configuration.

Configuration File Changes:

* `build/linux/installer/conf/container-cm.conf`, `build/linux/installer/conf/kube-cm.conf`: Added new configurations for custom metrics. [[1]](diffhunk://#diff-679d087b044d84191ea26bcd8a521022facf28b874f7597b751be003597fa90bR1-R141) [[2]](diffhunk://#diff-b67ef7026f9725c7d3093b529001fc6545110cd20d3f4ec2fa173631e76560fbR1-R358)
* `build/linux/installer/conf/container.conf`, `build/linux/installer/conf/kube.conf`: Removed configurations related to custom metrics. [[1]](diffhunk://#diff-e500149c08ad346f4135f753d5d0ae4ec6eb9dd2c2d84ee3db11f768b9694716L11-L19) [[2]](diffhunk://#diff-e500149c08ad346f4135f753d5d0ae4ec6eb9dd2c2d84ee3db11f768b9694716L36-L47) [[3]](diffhunk://#diff-e500149c08ad346f4135f753d5d0ae4ec6eb9dd2c2d84ee3db11f768b9694716L100-L116) [[4]](diffhunk://#diff-ecda4597169f4e3a53863d5aaddcfef190cc4f914a6de42dfd67539e617e2396L62-L69) [[5]](diffhunk://#diff-ecda4597169f4e3a53863d5aaddcfef190cc4f914a6de42dfd67539e617e2396L166-L170) [[6]](diffhunk://#diff-ecda4597169f4e3a53863d5aaddcfef190cc4f914a6de42dfd67539e617e2396L197-L214)