### PR TITLE
Add unit tests for containerlogv2 kubernetesmetadata

### DIFF
--- a/source/plugins/go/src/go.mod
+++ b/source/plugins/go/src/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/microsoft/ApplicationInsights-Go v0.4.4
+	github.com/stretchr/testify v1.9.0
 	github.com/tinylib/msgp v1.1.9
 	github.com/ugorji/go/codec v1.2.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -74,6 +75,7 @@ require (
 )
 
 require (
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/source/plugins/go/src/go.sum
+++ b/source/plugins/go/src/go.sum
@@ -142,6 +142,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tinylib/msgp v1.1.9 h1:SHf3yoO2sGA0veCJeCBYLHuttAVFHGm2RHgNodW7wQU=
 github.com/tinylib/msgp v1.1.9/go.mod h1:BCXGB54lDD8qUEPmiG0cQQUANC4IUQyB2ItS2UDlO/k=

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"fmt"
+)
+
+var kubernetesJSON = `{
+	"pod_name":"microsoft-defender-publisher-ds-bssg6",
+	"namespace_name":"kube-system",
+	"pod_id":"93bf47d2-5c1a-42bc-9a22-481939a93a66",
+	"labels":{
+		"app":"defender",
+		"controller-revision-hash":"f48799794",
+		"dsName":"microsoft-defender-publisher-ds",
+		"kubernetes.azure.com/managedby":"aks",
+		"pod-template-generation":"2"
+	},
+	"annotations":{
+		"kubernetes.io/config.seen":"2023-10-02T08:21:49.954540360Z",
+		"kubernetes.io/config.source":"api"
+	},
+	"host":"aks-agentpool-15410898-vmss000001",
+	"container_name":"microsoft-defender-publisher",
+	"docker_id":"c695de72af6b3f5a6ed9770813f3235c20225ca344172335e030abc8431a1216",
+	"container_hash":"mcr.microsoft.com/azuredefender/stable/security-publisher@sha256:f64bbdbd552c18dcd6455508ba7282ee03cf86de5dbfbca665e9573f29218d69",
+	"container_image":"mcr.microsoft.com/azuredefender/stable/security-publisher:1.0.67"
+}`
+
+func toInterfaceMap(m map[string]interface{}) map[interface{}]interface{} {
+	result := make(map[interface{}]interface{})
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// Test PostDataHelper
+func TestPostDataHelper(t *testing.T) {
+	var intermediateMap map[string]interface{}
+    // Unmarshal JSON data into a map
+    err := json.Unmarshal([]byte(kubernetesJSON), &intermediateMap)
+    if err != nil {
+        fmt.Println("Error unmarshalling JSON:", err)
+        return
+    }
+	kubernetesMetadata := toInterfaceMap(intermediateMap)
+
+	record := map[interface{}]interface{}{
+		"filepath": "/var/log/containers/pod_xyz.log",
+		"stream": "stdout",
+		"kubernetes": kubernetesMetadata,
+	}
+	
+	KubernetesMetadataIncludeList = []string{
+		"podlabels", "podannotations", "poduid", "image", "imageid", "imagerepo", "imagetag",
+	}
+	KubernetesMetadataEnabled = true
+
+	output := PostDataHelper([]map[interface{}]interface{}{record})
+
+	assert.Greater(t, output, 0, "Expected output to be greater than 0 indicating processing occurred")
+}

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -37,8 +37,8 @@ func toInterfaceMap(m map[string]interface{}) map[interface{}]interface{} {
 	return result
 }
 
-// Test PostDataHelper
-func TestPostDataHelper(t *testing.T) {
+// Test PostDataHelper KuberneteMetadata
+func TestPostDataHelperKuberneteMetadata(t *testing.T) {
 	var intermediateMap map[string]interface{}
     // Unmarshal JSON data into a map
     err := json.Unmarshal([]byte(kubernetesJSON), &intermediateMap)

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -10,7 +10,7 @@ import (
 var kubernetesJSON = `{
 	"pod_name":"test-publisher-ds-bssg6",
 	"namespace_name":"kube-system",
-	"pod_id":"93bf47d2-5c1a-42bc-9a22-481939a93a66",
+	"pod_id":"93bf47d2-5c1a-42bc-test-481939a93a66",
 	"labels":{
 		"app":"test",
 		"controller-revision-hash":"f48799794",
@@ -24,8 +24,8 @@ var kubernetesJSON = `{
 	},
 	"host":"test-agentpool-test-test000001",
 	"container_name":"test-publisher",
-	"docker_id":"1234567890123213213123213213213213",
-	"container_hash":publisher@sha256:1234567890123213213123213213213213",
+	"docker_id":"test1234567890123213213123213213213213",
+	"container_hash":publisher@sha256:test1234567890123213213123213213213213",
 	"container_image":"test-publisher:1.0.67"
 }`
 

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 var kubernetesJSON = `{
-	"pod_name":"defender-publisher-ds-bssg6",
+	"pod_name":"test-publisher-ds-bssg6",
 	"namespace_name":"kube-system",
 	"pod_id":"93bf47d2-5c1a-42bc-9a22-481939a93a66",
 	"labels":{
-		"app":"defender",
+		"app":"test",
 		"controller-revision-hash":"f48799794",
 		"dsName":"defender-publisher-ds",
 		"kubernetes.azure.com/managedby":"aks",
@@ -22,11 +22,11 @@ var kubernetesJSON = `{
 		"kubernetes.io/config.seen":"2023-10-02T08:21:49.954540360Z",
 		"kubernetes.io/config.source":"api"
 	},
-	"host":"aks-agentpool-15410898-vmss000001",
-	"container_name":"defender-publisher",
+	"host":"test-agentpool-test-test000001",
+	"container_name":"test-publisher",
 	"docker_id":"1234567890123213213123213213213213",
 	"container_hash":publisher@sha256:1234567890123213213123213213213213",
-	"container_image":"security-publisher:1.0.67"
+	"container_image":"test-publisher:1.0.67"
 }`
 
 func toInterfaceMap(m map[string]interface{}) map[interface{}]interface{} {

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 var kubernetesJSON = `{
-	"pod_name":"microsoft-defender-publisher-ds-bssg6",
+	"pod_name":"defender-publisher-ds-bssg6",
 	"namespace_name":"kube-system",
 	"pod_id":"93bf47d2-5c1a-42bc-9a22-481939a93a66",
 	"labels":{
 		"app":"defender",
 		"controller-revision-hash":"f48799794",
-		"dsName":"microsoft-defender-publisher-ds",
+		"dsName":"defender-publisher-ds",
 		"kubernetes.azure.com/managedby":"aks",
 		"pod-template-generation":"2"
 	},
@@ -23,10 +23,10 @@ var kubernetesJSON = `{
 		"kubernetes.io/config.source":"api"
 	},
 	"host":"aks-agentpool-15410898-vmss000001",
-	"container_name":"microsoft-defender-publisher",
-	"docker_id":"c695de72af6b3f5a6ed9770813f3235c20225ca344172335e030abc8431a1216",
-	"container_hash":"mcr.microsoft.com/azuredefender/stable/security-publisher@sha256:f64bbdbd552c18dcd6455508ba7282ee03cf86de5dbfbca665e9573f29218d69",
-	"container_image":"mcr.microsoft.com/azuredefender/stable/security-publisher:1.0.67"
+	"container_name":"defender-publisher",
+	"docker_id":"1234567890123213213123213213213213",
+	"container_hash":publisher@sha256:1234567890123213213123213213213213",
+	"container_image":"security-publisher:1.0.67"
 }`
 
 func toInterfaceMap(m map[string]interface{}) map[interface{}]interface{} {

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"testing"
-	"github.com/stretchr/testify/assert"
 	"fmt"
+	"reflect"
+	"github.com/stretchr/testify/assert"
 )
 
 var kubernetesJSON = `{
@@ -25,7 +26,7 @@ var kubernetesJSON = `{
 	"host":"test-agentpool-test-test000001",
 	"container_name":"test-publisher",
 	"docker_id":"test1234567890123213213123213213213213",
-	"container_hash":publisher@sha256:test1234567890123213213123213213213213",
+	"container_hash":"publisher@sha256:test1234567890123213213123213213213213",
 	"container_image":"test-publisher:1.0.67"
 }`
 
@@ -62,4 +63,159 @@ func TestPostDataHelperKuberneteMetadata(t *testing.T) {
 	output := PostDataHelper([]map[interface{}]interface{}{record})
 
 	assert.Greater(t, output, 0, "Expected output to be greater than 0 indicating processing occurred")
+}
+
+// Test PostDataHelper with empty tailPluginRecords
+func TestPostDataHelperEmpty(t *testing.T) {
+	tailPluginRecords := []map[interface{}]interface{}{}
+	expectedOutput := 1
+	output := PostDataHelper(tailPluginRecords)
+	if output != expectedOutput {
+		t.Errorf("Expected output to be %d, but got %d", expectedOutput, output)
+	}
+}
+
+// Test PostDataHelper with multiple tailPluginRecords
+func TestPostDataHelperMultiple(t *testing.T) {
+	tailPluginRecords := []map[interface{}]interface{}{
+		{
+			"filepath": "/var/log/containers/pod_xyz.log",
+			"stream":   "stdout",
+			"kubernetes": map[interface{}]interface{}{
+				"pod_name":        "test-publisher-ds-bssg6",
+				"namespace_name":  "kube-system",
+				"pod_id":          "93bf47d2-5c1a-42bc-test-481939a93a66",
+				"labels": map[interface{}]interface{}{
+					"app":                          "test",
+					"controller-revision-hash":     "f48799794",
+					"dsName":                       "defender-publisher-ds",
+					"kubernetes.azure.com/managedby": "aks",
+					"pod-template-generation":       "2",
+				},
+				"annotations": map[interface{}]interface{}{
+					"kubernetes.io/config.seen":   "2023-10-02T08:21:49.954540360Z",
+					"kubernetes.io/config.source": "api",
+				},
+				"host":             "test-agentpool-test-test000001",
+				"container_name":   "test-publisher",
+				"docker_id":        "test1234567890123213213123213213213213",
+				"container_hash":   "publisher@sha256:test1234567890123213213123213213213213",
+				"container_image":  "test-publisher:1.0.67",
+			},
+		},
+		{
+			"filepath": "/var/log/containers/pod_abc.log",
+			"stream":   "stderr",
+			"kubernetes": map[interface{}]interface{}{
+				"pod_name":        "test-consumer-ds-abcde",
+				"namespace_name":  "default",
+				"pod_id":          "a1b2c3d4e5f6",
+				"labels": map[interface{}]interface{}{
+					"app":                          "test",
+					"controller-revision-hash":     "f48799794",
+					"dsName":                       "defender-consumer-ds",
+					"kubernetes.azure.com/managedby": "aks",
+					"pod-template-generation":       "1",
+				},
+				"annotations": map[interface{}]interface{}{
+					"kubernetes.io/config.seen":   "2023-10-02T08:21:49.954540360Z",
+					"kubernetes.io/config.source": "api",
+				},
+				"host":             "test-agentpool-test-test000002",
+				"container_name":   "test-consumer",
+				"docker_id":        "abcde12345",
+				"container_hash":   "consumer@sha256:abcde12345",
+				"container_image":  "test-consumer:2.0.12",
+			},
+		},
+	}
+	expectedOutput := 2
+	output := PostDataHelper(tailPluginRecords)
+	if output != expectedOutput {
+		t.Errorf("Expected output to be %d, but got %d", expectedOutput, output)
+	}
+}
+
+func TestConvertKubernetesMetadata(t *testing.T) {
+	kubernetesMetadataJson := map[interface{}]interface{}{
+		"pod_name":       "test-pod",
+		"namespace_name": "test-namespace",
+		"labels": map[interface{}]interface{}{
+			"app": "test-app",
+		},
+		"annotations": map[interface{}]interface{}{
+			"annotation_key": "annotation_value",
+		},
+	}
+
+	expectedResult := map[string]interface{}{
+		"pod_name":       "test-pod",
+		"namespace_name": "test-namespace",
+		"labels": map[string]interface{}{
+			"app": "test-app",
+		},
+		"annotations": map[string]interface{}{
+			"annotation_key": "annotation_value",
+		},
+	}
+
+	result, err := convertKubernetesMetadata(kubernetesMetadataJson)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("Expected result to be %v, but got %v", expectedResult, result)
+	}
+}
+
+func TestProcessIncludes(t *testing.T) {
+	kubernetesMetadataMap := map[string]interface{}{
+		"pod_name":"test-publisher-ds-bssg6",
+		"namespace_name":"kube-system",
+		"pod_id":"93bf47d2-5c1a-42bc-test-481939a93a66",
+		"labels": map[string]interface{}{
+			"app":"test",
+			"controller-revision-hash":"f48799794",
+			"dsName":"defender-publisher-ds",
+			"kubernetes.azure.com/managedby":"aks",
+			"pod-template-generation":"2",
+		},
+		"annotations": map[string]interface{}{
+			"test":"2023-10-02T08:21:49.954540360Z",
+		},
+		"host":"test-agentpool-test-test000001",
+		"container_name":"test-publisher",
+		"docker_id":"test1234567890123213213123213213213213",
+		"container_hash":"publisher@sha256:test1234567890123213213123213213213213",
+		"container_image":"docker.io/test-publisher:1.0.67",
+	}
+
+	includesList := []string{
+		"poduid", "podlabels", "podannotations", "imageid", "imagerepo", //"imagetag", //"image",
+	}
+
+	expectedResult := map[string]interface{}{
+		//"image": "test-publisher",
+		"imageID": "sha256:test1234567890123213213123213213213213",
+		"imageRepo": "docker.io",
+		//"imageTag": "1.0.67",
+		"podAnnotations": map[string]interface{}{
+			"test": "2023-10-02T08:21:49.954540360Z",
+		},
+		"podLabels": map[string]interface{}{
+			"app": "test",
+			"controller-revision-hash": "f48799794",
+			"dsName": "defender-publisher-ds",
+			"kubernetes.azure.com/managedby": "aks",
+			"pod-template-generation": "2",
+		},
+		"podUid": "93bf47d2-5c1a-42bc-test-481939a93a66",
+	}
+
+	result := processIncludes(kubernetesMetadataMap, includesList)
+
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("Expected result to be %v, but got %v", expectedResult, result)
+	}
 }


### PR DESCRIPTION
This change majorly add unit tests for Kubernetes Metadata change.
It mocked the raw data from fluent-bit Kubernetes plugin and then then run the logic inside of functions in oms.go.
**TestPostDataHelperKuberneteMetadata**: mocked kubernetesJSON raw data and KubernetesMetadataIncludeList, and run the test in PostDataHelper section.
**TestPostDataHelperEmpty**: Test PostDataHelper with empty tailPluginRecords.
**TestPostDataHelperMultiple**: Test PostDataHelper with multiple tailPluginRecords.
**TestConvertKubernetesMetadata**: Test ConvertKubernetesMetadata which handle the kubernetes raw data.
**TestProcessIncludes**: Test ProcessIncludes for includes list via configmap.


