### PR TITLE
Update to use red color for config parsing error messages

### DIFF
--- a/build/common/installer/scripts/ConfigParseErrorLogger.rb
+++ b/build/common/installer/scripts/ConfigParseErrorLogger.rb
@@ -12,7 +12,7 @@ class ConfigParseErrorLogger
       begin
         errorMessage = "config::error::" + message
         jsonMessage = errorMessage.to_json
-        STDERR.puts jsonMessage
+        STDERR.puts "\e[31m" + jsonMessage + "\e[0m" #Using red color for error messages
       rescue => errorStr
         puts "Error in ConfigParserErrorLogger::logError: #{errorStr}"
       end


### PR DESCRIPTION
This pull request includes a change to the `logError` method in the `ConfigParseErrorLogger.rb` file. The change modifies the way error messages are printed to the console, now using red color for better visibility. 

* [`build/common/installer/scripts/ConfigParseErrorLogger.rb`](diffhunk://#diff-0d5a2bc40415cd5f050af918040b4c7af83fb869480edee85b0fe725cca9cd14L15-R15): Updated the `logError` method to print error messages in red color, improving visibility and error detection.