### PR TITLE
update fluent-bit for security patches

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -78,7 +78,7 @@ docker_cimprov_version=$(sudo tdnf list installed | grep docker-cimprov | awk '{
 echo "DOCKER_CIMPROV_VERSION=$docker_cimprov_version" >> packages_version.txt
 
 #install fluent-bit
-sudo tdnf install fluent-bit-2.2.2 -y
+sudo tdnf install fluent-bit-2.2.3 -y
 echo "$(fluent-bit --version)" >> packages_version.txt
 
 # install fluentd using the mariner package


### PR DESCRIPTION
Fluent-bit version update to 2.2.3 for the security patches. This update gets the fixes for  CVE-2024-4323.