### PR TITLE
update fluent-bit on windows to 3.0.6

### DIFF
--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -26,7 +26,7 @@ Write-Host ('Creating folder structure')
 Write-Host ('Installing Fluent Bit');
 
     try {
-        $fluentBitUri='https://fluentbit.io/releases/2.0/fluent-bit-2.0.14-win64.zip'
+        $fluentBitUri='https://fluentbit.io/releases/3.0/fluent-bit-3.0.6-win64.zip'
         Invoke-WebRequest -Uri $fluentBitUri -OutFile /installation/fluent-bit.zip
         Expand-Archive -Path /installation/fluent-bit.zip -Destination /installation/fluent-bit
         Move-Item -Path /installation/fluent-bit/*/* -Destination /opt/fluent-bit/ -ErrorAction SilentlyContinue


### PR DESCRIPTION
This pull request includes a change to the `setup.ps1` script in the `kubernetes/windows` directory. The change updates the version of Fluent Bit being downloaded and installed from version 2.0.14 to version 3.0.6. This is a significant update and should improve the functionality and performance of the Fluent Bit logging system within the Kubernetes environment.

* [`kubernetes/windows/setup.ps1`](diffhunk://#diff-5ec4ab2461b56d161a16acc7831e62fa863591ac9e6986aaf6833a9af73f881eL29-R29): Updated the Fluent Bit download URL to use the newer version 3.0.6 instead of the older version 2.0.14. This change should improve the functionality and performance of the Fluent Bit logging system.