### PR TITLE
wrap into string

### DIFF
--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -112,7 +112,6 @@ class KubernetesApiClient
               response = http.request(kubeApiRequest)
               responseCode = response.code
               @Log.info "KubernetesAPIClient::getKubeResourceInfoV2 : Got response of #{response.code} for #{uri.request_uri} @ #{Time.now.utc.iso8601}"
-              
               # Send telemetry for response code if not success
               if !response.nil? && !response.code.nil? && !response.code.start_with?("2")
                 @@K8sApiResponseTelemetryTimeTracker = ApplicationInsightsUtility.sendAPIResponseTelemetry(response.code, resource, "K8sAPIStatus", @@K8sApiResponseCodeHash, @@K8sApiResponseTelemetryTimeTracker)
@@ -213,6 +212,7 @@ class KubernetesApiClient
             end
           end
         end
+        @@ClusterName = "#{@@ClusterName}"
       rescue => error
         @Log.warn("getClusterName failed: #{error}")
       end
@@ -231,6 +231,7 @@ class KubernetesApiClient
         if cluster && !cluster.nil? && !cluster.empty?
           @@ClusterId = cluster
         end
+        @@ClusterId = "#{@@ClusterId}"
       rescue => error
         @Log.warn("getClusterId failed: #{error}")
       end

--- a/source/plugins/ruby/oms_common.rb
+++ b/source/plugins/ruby/oms_common.rb
@@ -10,7 +10,7 @@ module OMS
   end
 
   class Common
-    require 'socket'        
+    require 'socket'
     require_relative 'omslog'
 
     @@Hostname = nil
@@ -114,7 +114,7 @@ module OMS
         # we are otherwise instructed.
         rfcl = "RFCs 1123, 2181 with hostname range of {1,63} octets for non-root item."
         return if is_hostname_compliant?(hnBuffer)
-        return if is_like_ipv4_string?(hnBuffer) 
+        return if is_like_ipv4_string?(hnBuffer)
         return if is_like_ipv6_string?(hnBuffer)
         msg = "Hostname '#{hnBuffer}' not compliant (#{rfcl}).  Not IP Address Either."
         OMS::Log.warn_once(msg)
@@ -136,6 +136,7 @@ module OMS
         rescue => error
           OMS::Log.warn_once("Hostname '#{@@Hostname}' found, but did NOT validate as compliant.  #{error}.  Using anyway.")
         end
+        @@Hostname = "#{@@Hostname}"
         return @@Hostname
       end
     end # Class methods


### PR DESCRIPTION
AMA team updated their msgpack-c library which enforces the binary to binary before it was marshalling as string.  For weird reason, even though we are sending as string but msgpack library interpreting as binary. Explicitly making string type by wrapping into "" . This shouldnt have any side effects.

