### PR TITLE
bump aks arm api version for addon enablement

### DIFF
--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -457,8 +457,6 @@ spec:
               value: "false"
             - name: APPMONITORING_OPENTELEMETRYLOGS_PORT
               value: "28331"
-            - name: AZMON_TELEGRAF_LIVENESSPROBE_ENABLED
-              value: "false"
           securityContext:
             privileged: true
             capabilities:
@@ -857,6 +855,8 @@ spec:
               value: "false"
             - name: APPMONITORING_OPENTELEMETRYLOGS_PORT
               value: "28331"
+            - name: AZMON_TELEGRAF_LIVENESSPROBE_ENABLED
+              value: "false"
           securityContext:
             privileged: true
             capabilities:

--- a/scripts/onboarding/aks/onboarding-msi-azure-policy/azure-policy.rules.json
+++ b/scripts/onboarding/aks/onboarding-msi-azure-policy/azure-policy.rules.json
@@ -266,7 +266,7 @@
 								"type": "Microsoft.ContainerService/managedClusters",
 								"location": "[parameters('aksResourceLocation')]",
 								"tags": "[parameters('resourceTagValues')]",
-								"apiVersion": "2018-03-31",
+								"apiVersion": "2019-04-01",
 								"properties": {
 								  "mode": "Incremental",
 								  "id": "[parameters('aksResourceId')]",

--- a/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterOnboarding.bicep
+++ b/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterOnboarding.bicep
@@ -108,7 +108,7 @@ resource aks_monitoring_msi_dcr 'Microsoft.Insights/dataCollectionRules@2022-06-
   }
 }
 
-resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2018-03-31' = {
+resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2019-04-01' = {
   name: clusterName
   location: aksResourceLocation
   tags: resourceTagValues

--- a/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterOnboarding.bicep
+++ b/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterOnboarding.bicep
@@ -84,7 +84,7 @@ resource aks_monitoring_msi_dcr 'Microsoft.Insights/dataCollectionRules@2022-06-
   }
 }
 
-resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2018-03-31' = {
+resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2019-04-01' = {
   name: clusterName
   location: aksResourceLocation
   tags: resourceTagValues

--- a/scripts/onboarding/aks/onboarding-using-azure-policy/azure-policy.json
+++ b/scripts/onboarding/aks/onboarding-using-azure-policy/azure-policy.json
@@ -59,7 +59,7 @@
 													"type": "Microsoft.ContainerService/managedClusters",
 													"location": "[parameters('clusterLocation')]",
 													"tags": "[parameters('clusterTags')]",
-													"apiVersion": "2018-03-31",
+													"apiVersion": "2019-04-01",
 													"properties": {
 														"mode": "Incremental",
 														"id": "[resourceId(parameters('clusterResourceGroupName'), 'Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",

--- a/scripts/onboarding/aks/onboarding-using-azure-policy/azurepolicy.rules.json
+++ b/scripts/onboarding/aks/onboarding-using-azure-policy/azurepolicy.rules.json
@@ -57,7 +57,7 @@
 												"type": "Microsoft.ContainerService/managedClusters",
 												"location": "[parameters('clusterLocation')]",
 												"tags": "[parameters('clusterTags')]",
-												"apiVersion": "2018-03-31",
+												"apiVersion": "2019-04-01",
 												"properties": {
 													"mode": "Incremental",
 													"id": "[resourceId(parameters('clusterResourceGroupName'), 'Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
@@ -465,7 +465,7 @@
                             "type": "Microsoft.ContainerService/managedClusters",
                             "location": "[parameters('aksResourceLocation')]",
                             "tags": "[parameters('resourceTagValues')]",
-                            "apiVersion": "2018-03-31",
+                            "apiVersion": "2019-04-01",
                             "properties": {
                                 "mode": "Incremental",
                                 "id": "[parameters('aksResourceId')]",

--- a/test/onboarding-templates-legacy-auth/existingClusterOnboarding.json
+++ b/test/onboarding-templates-legacy-auth/existingClusterOnboarding.json
@@ -26,7 +26,7 @@
             "name": "[split(parameters('aksResourceId'),'/')[8]]",
             "type": "Microsoft.ContainerService/managedClusters",
             "location": "[parameters('aksResourceLocation')]",
-            "apiVersion": "2018-03-31",
+            "apiVersion": "2019-04-01",
             "properties": {
                 "mode": "Incremental",
                 "id": "[parameters('aksResourceId')]",


### PR DESCRIPTION
updating the arm api version from 2018-03-31 to 2019-04-01 since the arm api version:2018-03-31 doesnt work on managed identity enabled clusters.