### PR TITLE
Add update-ca-trust command

### DIFF
--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -22,7 +22,23 @@ ENV tmpdir /opt
 RUN tdnf clean all
 RUN tdnf repolist --refresh
 RUN tdnf -y update
-RUN tdnf install -y build-essential wget curl sudo net-tools cronie rsyslog dmidecode gnupg make logrotate busybox gawk tar && rm -rf /var/lib/apt/lists/*
+RUN tdnf install -y \
+         build-essential \
+        wget \
+        curl \
+        sudo \
+        net-tools \
+        cronie \
+        rsyslog \
+        dmidecode \
+        gnupg \
+        make \
+        logrotate \
+        busybox \
+        gawk \
+        tar \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 RUN mkdir /busybin && busybox --install /busybin
 
 COPY --from=golang-builder /src/kubernetes/linux/Linux_ULINUX_1.0_*_64_Release/docker-cimprov-*.*.*-*.*.sh $tmpdir/
@@ -81,6 +97,7 @@ COPY --from=builder /usr/bin/curl /usr/bin/curl
 COPY --from=builder /usr/bin/jq /usr/bin/jq
 COPY --from=builder /usr/bin/base64 /usr/bin/base64
 COPY --from=builder /usr/bin/fluentd /usr/bin/fluentd
+COPY --from=builder /usr/bin/update-ca-trust /usr/bin/update-ca-trust
 
 # bash dependencies
 COPY --from=builder /lib/libreadline.so.8 /lib/


### PR DESCRIPTION
Install the ca-certificates package to add the update-ca-trust command. update-ca-trust is referenced in main.sh for environments that need custom CA certificates installed. Because the command is missing, adding volume mounts for /anchors/mariner or /anchors/ubuntu has no effect.