### PR TITLE
Workload cleanup job

### DIFF
--- a/appmonitoring/ts/src/DeploymentsCollection.ts
+++ b/appmonitoring/ts/src/DeploymentsCollection.ts
@@ -1,0 +1,29 @@
+﻿import { Deployment } from "./RequestDefinition.js"
+
+export class DeploymentsCollection {
+
+    private deployments: Deployment[] = [];
+
+    public ListDeployments(): Deployment[] {
+        return this.deployments;
+    }
+
+    public GetDeployment(namespace: string, name: string): Deployment {
+        return this.deployments.find(d => d.metadata.namespace === namespace && d.metadata.name === name, this);
+    }
+
+    public Upsert(deployment: Deployment): void {
+        this.Remove(deployment);
+
+        this.deployments.push(deployment);
+    }
+
+    public Remove(deployment: Deployment): void {
+        for (let i = 0; i < this.deployments.length; i++) {
+            if (this.deployments[i].metadata.name === deployment.metadata.name && this.deployments[i].metadata.namespace === deployment.metadata.namespace) {
+                this.deployments.splice(i, 1);
+                break;
+            }
+        }
+    }
+}

--- a/appmonitoring/ts/src/DeploymentsWatcher.ts
+++ b/appmonitoring/ts/src/DeploymentsWatcher.ts
@@ -1,0 +1,118 @@
+﻿import { HeartbeatLogs, HeartbeatMetrics, RequestMetadata, logger } from "./LoggerWrapper.js";
+import * as k8s from "@kubernetes/client-node";
+import { InstrumentationLabelName, DeploymentsListResponse, Deployment } from "./RequestDefinition.js"
+
+export class DeploymentsWatcher {
+
+    private static namePlural = "deployments";
+    private static apiGroup = "apps";
+    private static apiVersion = "v1";
+    
+    public static async StartWatching(onNew: (deployment: Deployment, isRemoved: boolean) => void): Promise<void> {
+        const kc = new k8s.KubeConfig();
+        kc.loadFromDefault();
+
+        const k8sApi = kc.makeApiClient(k8s.AppsV1Api);
+        const watch = new k8s.Watch(kc);
+
+        let latestResourceVersion = "0";
+        while (true) { // eslint-disable-line
+            try {
+                latestResourceVersion = await DeploymentsWatcher.Watch(k8sApi, watch, latestResourceVersion, onNew);
+            } catch (e) {
+                const ex = logger.sanitizeException(e);
+                
+                logger.addHeartbeatMetric(HeartbeatMetrics.ApiServerCallErrorCount, 1);
+
+                logger.appendHeartbeatLog(HeartbeatLogs.ApiServerTopExceptionsEncountered, JSON.stringify(ex));
+
+                const requestMetadata = new RequestMetadata("Deployment watcher", null);
+                logger.error(`K8s deployment watch failure: ${e}`, null, requestMetadata);
+
+                // pause for a bit to avoid generating too much load in case of cascading failures
+                await new Promise(r => setTimeout(r, 5000));
+            } finally {
+                // we ended up here because the watch above either finished gracefully or failed (its lifespan is limited no matter what), so we have to establish a new one
+                logger.addHeartbeatMetric(HeartbeatMetrics.ApiServerCallCount, 1);
+            }
+        }
+    }
+
+    private static async Watch(k8sApi: k8s.AppsV1Api, watch: k8s.Watch, latestResourceVersion: string, onNew: (deployment: Deployment, isRemoved: boolean) => void): Promise<string> {
+        let requestMetadata = new RequestMetadata("Deployment watcher", null);
+
+        logger.info(`Listing deployments, resourceVersion=${latestResourceVersion}...`, null, requestMetadata);
+
+        const labelSelector = `${InstrumentationLabelName}`;
+
+        const deploymentsResult: DeploymentsListResponse = <DeploymentsListResponse>await k8sApi.listDeploymentForAllNamespaces(
+            undefined,
+            undefined,
+            undefined, // fieldSelector: `metadata.name=name`
+            labelSelector, // labelSelector: `labelName=labelValue` or `labelName`
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined);
+
+        logger.info(`Deployments listed, resourceVersion=${deploymentsResult.body.metadata.resourceVersion}`, null, requestMetadata);
+
+        latestResourceVersion = deploymentsResult.body.metadata?.resourceVersion;
+
+        deploymentsResult.body.items.forEach((deployment: Deployment) => { 
+            onNew(deployment, false);
+        });
+
+        logger.info(`Starting a deployment watch, resourceVersion=${latestResourceVersion}...`, null, requestMetadata);
+        
+        // watch() doesn't block (it starts the loop and returns immediately), so we can't just return the promise it returns to our caller
+        // we must instead create our own promise and resolve it manually when the watch informs us that it stopped via a callback
+        const watchIsDonePromise: Promise<string> = new Promise(resolveWatchPromise => {
+            watch.watch(`/apis/${DeploymentsWatcher.apiGroup}/${DeploymentsWatcher.apiVersion}/${DeploymentsWatcher.namePlural}`,
+                {
+                    allowWatchBookmarks: true,
+                    resourceVersion: latestResourceVersion,
+                    //fieldSelector: 'metadata.name=my-namespace',
+                    labelSelector: labelSelector
+                },
+                (type, apiObj) => {
+                    requestMetadata = new RequestMetadata("Deployment watcher", null);
+
+                    try {
+                        if (type === "ADDED") {
+                            logger.info(`NEW deployment: ${apiObj.metadata?.name} (${apiObj.metadata?.namespace})`, null, requestMetadata);
+                            onNew(apiObj, false);
+                        } else if (type === "MODIFIED") {
+                            logger.info(`MODIFIED deployment: ${apiObj.metadata?.name} (${apiObj.metadata?.namespace})`, null, requestMetadata);
+                            onNew(apiObj, false);
+                        } else if (type === "DELETED") {
+                            logger.info(`DELETED deployment: ${apiObj.metadata?.name} (${apiObj.metadata?.namespace})`, null, requestMetadata);
+                            onNew(apiObj, true);
+                        } else if (type === "BOOKMARK") {
+                            latestResourceVersion = apiObj.metadata?.resourceVersion ?? latestResourceVersion;
+                        } else {
+                            logger.error(`Unknown object type: ${type}`, null, requestMetadata);
+                        }
+
+                        //logger.info(`apiObj: ${JSON.stringify(apiObj)}`, null, requestMetadata);
+                    } catch (e) {
+                        logger.error(`Failed to process a watched item: ${e}`, null, requestMetadata);
+                    }
+                },
+                err => { // watch is done callback
+                    logger.info("Deployments watch has completed", null, requestMetadata);
+                    if (err != null) {
+                        logger.error(err, null, requestMetadata);
+                    }
+
+                    resolveWatchPromise(latestResourceVersion);
+                });
+        });
+        
+        return watchIsDonePromise;
+    }
+}

--- a/appmonitoring/ts/src/Mutator.ts
+++ b/appmonitoring/ts/src/Mutator.ts
@@ -11,14 +11,16 @@ export class Mutator {
     private readonly clusterArmRegion: string;
     private readonly operationId: string;
     private readonly requestMetadata: RequestMetadata;
+    private readonly isCleanupMode: boolean;
 
-    public constructor(admissionReview: IAdmissionReview, crs: InstrumentationCRsCollection, clusterArmId: string, clusterArmRegion: string, operationId: string) {
+    public constructor(admissionReview: IAdmissionReview, crs: InstrumentationCRsCollection, cleanupMode: boolean, clusterArmId: string, clusterArmRegion: string, operationId: string) {
         this.admissionReview = admissionReview;
         this.crs = crs;
         this.clusterArmId = clusterArmId;
         this.clusterArmRegion = clusterArmRegion;
         this.operationId = operationId;
         this.requestMetadata = new RequestMetadata(this.admissionReview?.request?.uid, this.crs);
+        this.isCleanupMode = cleanupMode;
     }
 
     public async Mutate(): Promise<string> {
@@ -93,7 +95,7 @@ export class Mutator {
 
         const patchData: object[] = Patcher.PatchObject(
             this.admissionReview.request.object,
-            cr, // null to unpatch
+            this.isCleanupMode ? null : cr, // null to unpatch
             podInfo as PodInfo,
             platforms,
             this.clusterArmId,

--- a/appmonitoring/ts/src/Patcher.ts
+++ b/appmonitoring/ts/src/Patcher.ts
@@ -1,5 +1,5 @@
 ﻿import { Mutations } from "./Mutations.js";
-import { PodInfo, IContainer, ISpec, IVolume, IEnvironmentVariable, AutoInstrumentationPlatforms, IVolumeMount, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName, InstrumentationCR, IInstrumentationState, IMetadata, IAnnotations, IObjectType } from "./RequestDefinition.js";
+import { PodInfo, IContainer, ISpec, IVolume, IEnvironmentVariable, AutoInstrumentationPlatforms, IVolumeMount, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName, InstrumentationCR, IInstrumentationState, IMetadata, IAnnotations, IObjectType, ILabels, InstrumentationLabelName } from "./RequestDefinition.js";
 
 export class Patcher {
 
@@ -36,8 +36,12 @@ export class Patcher {
             const spec: ISpec = obj.spec;
             const podSpec: ISpec = spec.template.spec;
         
-            // add deployment-level annotation describing current mutation
+            // add deployment-level label and annotation describing current mutation
             obj.metadata = obj.metadata ?? <IMetadata>{};
+
+            obj.metadata.labels = obj.metadata.labels ?? <ILabels>{};
+            obj.metadata.labels[InstrumentationLabelName] = "";
+
             obj.metadata.annotations = obj.metadata.annotations ?? <IAnnotations>{};
             obj.metadata.annotations[InstrumentationAnnotationName] = JSON.stringify(<IInstrumentationState>{
                 crName: cr.metadata.name,
@@ -126,8 +130,13 @@ export class Patcher {
 
         const instrumentationState: IInstrumentationState = obj.metadata?.annotations?.[InstrumentationAnnotationName] ? JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) : null;
 
-        // remove deployment annotations
+        // remove deployment labels and annotations
         obj.metadata = obj.metadata ?? <IMetadata>{};
+
+        if(obj.metadata.labels) {
+            delete obj.metadata.labels[InstrumentationLabelName];
+        }
+
         if (obj.metadata.annotations) {
             delete obj.metadata.annotations[InstrumentationAnnotationName];
         }

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -17,8 +17,12 @@ export interface IUserInfo {
     groups: string[];
 }
 
+export const InstrumentationLabelName = "monitor.azure.com/instrumentation";
+
 export interface ILabels {
     app: string;
+
+    [key: string]: string;
 }
 
 export interface IInstrumentationState {

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -33,7 +33,7 @@ export interface IInstrumentationState {
 
 export const InstrumentationAnnotationName = "monitor.azure.com/instrumentation";
 export const EnableApplicationLogsAnnotationName = "monitor.azure.com/enable-application-logs";
-export const CleanupModeWebhoohEnvironmentVariableName = "CLEANUP_MODE";
+export const CleanupModeWebhookAnnotationName = "monitor.azure.com/cleanup-mode";
 export interface IAnnotations {
     "instrumentation.opentelemetry.io/inject-dotnet"?: string;
     "instrumentation.opentelemetry.io/inject-java"?: string;

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -33,6 +33,7 @@ export interface IInstrumentationState {
 
 export const InstrumentationAnnotationName = "monitor.azure.com/instrumentation";
 export const EnableApplicationLogsAnnotationName = "monitor.azure.com/enable-application-logs";
+export const CleanupModeWebhoohEnvironmentVariableName = "CLEANUP_MODE";
 export interface IAnnotations {
     "instrumentation.opentelemetry.io/inject-dotnet"?: string;
     "instrumentation.opentelemetry.io/inject-java"?: string;
@@ -203,12 +204,30 @@ export class InstrumentationCR {
     }
 }
 
-export class ListResponse {
+export class Deployment {
+    metadata: {
+        name: string,
+        namespace: string,
+        resourceVersion?: string
+    };
+}
+
+export class CRsListResponse {
     response: http.IncomingMessage;
     body: {
         metadata: {
             resourceVersion: string
         };
         items: InstrumentationCR[]
+    }
+}
+
+export class DeploymentsListResponse {
+    response: http.IncomingMessage;
+    body: {
+        metadata: {
+            resourceVersion: string
+        };
+        items: Deployment[]
     }
 }

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -209,7 +209,7 @@ export class Deployment {
         name: string,
         namespace: string,
         resourceVersion?: string
-    };
+    }
 }
 
 export class CRsListResponse {
@@ -217,7 +217,7 @@ export class CRsListResponse {
     body: {
         metadata: {
             resourceVersion: string
-        };
+        },
         items: InstrumentationCR[]
     }
 }
@@ -227,7 +227,7 @@ export class DeploymentsListResponse {
     body: {
         metadata: {
             resourceVersion: string
-        };
+        },
         items: Deployment[]
     }
 }

--- a/appmonitoring/ts/src/Utilities.ts
+++ b/appmonitoring/ts/src/Utilities.ts
@@ -4,7 +4,7 @@ import { logger, RequestMetadata } from './LoggerWrapper.js';
 
 export class Utilities {
     
-    public static async RestartWebhookDeployment(envVariableNameValue: string[], operationId: string, requestMetadata: RequestMetadata, kc: k8s.KubeConfig, clusterArmId: string, clusterArmRegion: string): Promise<void> {
+    public static async RestartWebhookDeployment(additionalAnnotationNameValue: string[], operationId: string, requestMetadata: RequestMetadata, kc: k8s.KubeConfig, clusterArmId: string, clusterArmRegion: string): Promise<void> {
         let name = null;
         if (!kc) {
             kc = new k8s.KubeConfig();
@@ -35,21 +35,10 @@ export class Utilities {
             const deployment: k8s.V1Deployment = matchingDeployments[0];
             const annotations = deployment.spec.template.metadata.annotations ?? {};
             annotations["kubectl.kubernetes.io/restartedAt"] = new Date().toISOString();
-            deployment.spec.template.metadata.annotations = annotations;
-
-            if (envVariableNameValue) {
-                const envVars = deployment.spec.template.spec.containers[0].env ?? [];
-
-                // remove it if present
-                const evIndex = envVars.findIndex(ev => ev.name === envVariableNameValue[0]);
-                if(evIndex !== -1) {
-                    envVars.splice(evIndex, 1);
-                }
-
-                envVars.push(<k8s.V1EnvVar>{ name: envVariableNameValue[0], value: envVariableNameValue[1] });
-
-                deployment.spec.template.spec.containers[0].env = envVars;
+            if (additionalAnnotationNameValue) {
+                annotations[additionalAnnotationNameValue[0]] = additionalAnnotationNameValue[1];
             }
+            deployment.spec.template.metadata.annotations = annotations;
 
             name = deployment.metadata.name;
 

--- a/appmonitoring/ts/src/Utilities.ts
+++ b/appmonitoring/ts/src/Utilities.ts
@@ -1,0 +1,59 @@
+import * as k8s from '@kubernetes/client-node';
+import { KubeSystemNamespaceName, WebhookName } from './Constants.js'
+import { logger, RequestMetadata } from './LoggerWrapper.js';
+
+export class Utilities {
+    
+    public static async RestartWebhookDeployment(additionalAnnotationNameValue: string[], operationId: string, requestMetadata: RequestMetadata, kc: k8s.KubeConfig, clusterArmId: string, clusterArmRegion: string): Promise<void> {
+        let name = null;
+        if (!kc) {
+            kc = new k8s.KubeConfig();
+            kc.loadFromDefault();
+        }
+
+        /**
+         * The try block contains the logic to restart the webhook deployment. It first gets the webhook deployment by
+         * its selector. If there is no deployment or more than one deployment with the selector, it throws an error. If
+         * there is exactly one deployment with the selector, it restarts the deployment by updating the annotations with
+         * the current time.
+         */
+        try {
+            const k8sApi = kc.makeApiClient(k8s.AppsV1Api);
+            const selector = WebhookName;
+            const deployments: k8s.V1DeploymentList = (await k8sApi.listNamespacedDeployment(KubeSystemNamespaceName)).body;
+
+            if (!deployments)
+            {
+                throw new Error(`No Deployments found in ${KubeSystemNamespaceName} namespace!`);
+            }
+            const matchingDeployments: k8s.V1Deployment[] = deployments.items.filter(deployment => selector.localeCompare(deployment.spec.selector?.matchLabels?.app) === 0);
+
+            if (matchingDeployments.length != 1) {
+                throw new Error(`Expected 1 Deployment with selector ${selector}, but found ${matchingDeployments.length}`);
+            }
+
+            const deployment: k8s.V1Deployment = matchingDeployments[0];
+            const annotations = deployment.spec.template.metadata.annotations ?? {};
+            annotations["kubectl.kubernetes.io/restartedAt"] = new Date().toISOString();
+            deployment.spec.template.metadata.annotations = annotations;
+
+            if (additionalAnnotationNameValue) {
+                const annotations = deployment.metadata.annotations ?? {};
+                annotations[additionalAnnotationNameValue[0]] = additionalAnnotationNameValue[1];
+                deployment.metadata.annotations = annotations;
+            }
+
+            name = deployment.metadata.name;
+
+            logger.info(`Restarting deployment ${name}...`, operationId, requestMetadata);
+            logger.SendEvent("DeploymentRestarting", operationId, null, clusterArmId, clusterArmRegion);
+            await k8sApi.replaceNamespacedDeployment(name, KubeSystemNamespaceName, deployment);
+            console.log(`Successfully restarted Deployment ${name}`);
+            logger.SendEvent("DeploymentRestarted", operationId, null, clusterArmId, clusterArmRegion);
+        } catch (err) {
+            logger.error(`Failed to restart Deployment ${name}: ${err}`, operationId, requestMetadata);
+            logger.SendEvent("DeploymentRestartFailed", operationId, null, clusterArmId, clusterArmRegion, true, err);
+            throw err;
+        }
+    }
+}

--- a/appmonitoring/ts/src/server.ts
+++ b/appmonitoring/ts/src/server.ts
@@ -1,16 +1,20 @@
 ﻿import * as https from "https";
 import { Mutator } from "./Mutator.js";
 import { HeartbeatMetrics, HeartbeatLogs, logger, RequestMetadata } from "./LoggerWrapper.js";
-import { InstrumentationCR, IAdmissionReview } from "./RequestDefinition.js";
-import { K8sWatcher } from "./K8sWatcher.js";
+import { InstrumentationCR, IAdmissionReview, Deployment, CleanupModeWebhoohEnvironmentVariableName } from "./RequestDefinition.js";
+import { InstrumentationCRsWatcher } from "./InstrumentationCRsWatcher.js";
 import { InstrumentationCRsCollection } from "./InstrumentationCRsCollection.js"
 import fs from "fs";
 import { CertificateManager } from "./CertificateManager.js";
 import { randomUUID } from 'crypto';
+import { DeploymentsWatcher } from "./DeploymentsWatcher.js";
+import { DeploymentsCollection } from "./DeploymentsCollection.js";
+import { Utilities } from "./Utilities.js";
 
 const containerMode = process.env.CONTAINER_MODE;
 const clusterArmId = process.env.ARM_ID;
 const clusterArmRegion = process.env.ARM_REGION;
+const isServerModeInCleanupMode: boolean = "1".localeCompare(process.env.CLEANUP_MODE) === 0;
 
 let operationId = randomUUID();
 
@@ -39,6 +43,45 @@ if ("secrets-manager".localeCompare(containerMode) === 0) {
         throw error;
     }
     process.exit();
+} else if ("cleanup".localeCompare(containerMode) === 0) {
+    /* 
+      This is the Cleanup mode, we are running as a job in the Helm chart's pre-delete hook, and must do the following:
+        - mark the webhook with an annotation that indicates we are in cleanup mode. The webhook will only unmutate once that happens
+            - restart the webhook to make it aware of the annotation change
+        - get a list of mutated workloads in all namespaces, and keep watching that list until none are left
+        - once none are left, successfully return, which will finish the job successfully and unblock Helm chart deletion
+        - if we encounter an error during these operations, we must return an error that restarts the job from scratch
+    */
+    try {
+        logger.info("Running in cleanup mode...", operationId, null);
+
+        // mark the webhook deployment with an annotation and restart it
+        await Utilities.RestartWebhookDeployment([CleanupModeWebhoohEnvironmentVariableName, "1"], operationId, null, null, clusterArmId, clusterArmRegion);
+
+        const mutatedDeployments: DeploymentsCollection = new DeploymentsCollection();
+        await DeploymentsWatcher.StartWatching((deployment: Deployment, isRemoved: boolean) => {
+            logger.info(`Deployment: ${deployment.metadata.namespace}/${deployment.metadata.name} was ${isRemoved ? "removed" : "created or modified"}`, operationId, null);
+
+            if(isRemoved) {
+                mutatedDeployments.Remove(deployment);
+
+                // if nothing left - our work is done
+                if(mutatedDeployments.ListDeployments().length === 0) {
+                    logger.info(`Mutated deployment list empty, our work is done`, operationId, null);
+                    logger.SendEvent("CleanupSucceeded", operationId, null, clusterArmId, clusterArmRegion, true);
+
+                    process.exit();
+                }
+            } else {
+                mutatedDeployments.Upsert(deployment);
+            }
+        });
+    } catch (error) {
+        logger.error(`Failed to perform a cleanup, terminating...\n${JSON.stringify(error)}`, operationId, null);
+        logger.SendEvent("CleanupFailed", operationId, null, clusterArmId, clusterArmRegion, true, error);
+        throw error;
+    }
+    process.exit();
 }
 
 const crs: InstrumentationCRsCollection = new InstrumentationCRsCollection();
@@ -57,7 +100,7 @@ if (!armIdMatches || armIdMatches.length != 6) {
 logger.startHeartbeats(operationId);
 
 // don't await, this runs an infinite loop
-K8sWatcher.StartWatchingCRs(crs, (cr: InstrumentationCR, isRemoved: boolean) => {
+InstrumentationCRsWatcher.StartWatchingCRs(crs, (cr: InstrumentationCR, isRemoved: boolean) => {
     if (isRemoved) {
         crs.Remove(cr);
     } else {
@@ -126,7 +169,7 @@ https.createServer(options, (req, res) => {
                     throw `Unable to get request.uid from the incoming admission review`;
                 }
 
-                const mutator: Mutator = new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, operationId);
+                const mutator: Mutator = new Mutator(admissionReview, crs, isServerModeInCleanupMode, clusterArmId, clusterArmRegion, operationId);
                 const mutatedObject: string = await mutator.Mutate();
 
                 const end = Date.now();

--- a/appmonitoring/ts/src/server.ts
+++ b/appmonitoring/ts/src/server.ts
@@ -53,6 +53,7 @@ if ("secrets-manager".localeCompare(containerMode) === 0) {
     */
     try {
         logger.info("Running in cleanup mode...", operationId, null);
+        logger.SendEvent("CleanupModeRun", operationId, null, clusterArmId, clusterArmRegion, true);
 
         // mark the webhook deployment with an annotation and restart it
         await Utilities.RestartWebhookDeployment([CleanupModeWebhookAnnotationName, "1"], operationId, null, null, clusterArmId, clusterArmRegion);

--- a/appmonitoring/ts/src/tests/CertificateManager.spec.ts
+++ b/appmonitoring/ts/src/tests/CertificateManager.spec.ts
@@ -1,17 +1,15 @@
 import { CertificateManager, WebhookCertData } from '../CertificateManager.js';
+import { RequestMetadata } from "../LoggerWrapper.js";
 import * as k8s from '@kubernetes/client-node';
 import forge from 'node-forge';
+import { Utilities } from '../Utilities.js';
 
 describe('CertificateManager', () => {
-    let kubeConfig: k8s.KubeConfig;
     let certManager: CertificateManager;
-
+    
     beforeEach(() => {
-        kubeConfig = new k8s.KubeConfig();
-        jest.clearAllMocks();
-        jest.resetAllMocks();
-        // Set up kubeConfig with necessary configurations
-
+        jest.restoreAllMocks();
+        
         certManager = new CertificateManager();
     });
 
@@ -59,16 +57,12 @@ describe('CertificateManager', () => {
             certManager = new CertificateManager();
         });
 
-        afterEach(() => {
-            jest.resetAllMocks();
-        });
-
         it('should not do anything if it cant find the installer job', async () => {
             const checkCertificateJobStatus = jest.spyOn(certManager as any, 'HasCertificateInstallerJobFinished').mockRejectedValue(new Error('Job not found'));
             const getMutatingWebhookCABundle = jest.spyOn(certManager as any, 'GetMutatingWebhookCABundle').mockResolvedValue(null);
             const getSecretDetails = jest.spyOn(certManager as any, 'GetSecretDetails').mockResolvedValue(null);
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
             expect(checkCertificateJobStatus).toHaveBeenCalled();
@@ -84,7 +78,7 @@ describe('CertificateManager', () => {
             const getMutatingWebhookCABundle = jest.spyOn(certManager as any, 'GetMutatingWebhookCABundle').mockResolvedValue(null);
             const getSecretDetails = jest.spyOn(certManager as any, 'GetSecretDetails').mockResolvedValue(null);
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
             expect(checkCertificateJobStatus).toHaveBeenCalled();
@@ -100,7 +94,7 @@ describe('CertificateManager', () => {
             const getSecretDetails = jest.spyOn(certManager as any, 'GetSecretDetails').mockRejectedValue(new Error('Secret not found'));
             const getMutatingWebhookCABundle = jest.spyOn(certManager as any, 'GetMutatingWebhookCABundle').mockResolvedValue(null);
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
             expect(checkCertificateJobStatus).toHaveBeenCalled();
@@ -117,7 +111,7 @@ describe('CertificateManager', () => {
             const getSecretDetails = jest.spyOn(certManager as any, 'GetSecretDetails').mockReturnValue(null);
             const getMutatingWebhookCABundle = jest.spyOn(certManager as any, 'GetMutatingWebhookCABundle').mockRejectedValue(new Error('Mutating webhook not found'));
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
             expect(checkCertificateJobStatus).toHaveBeenCalled();
@@ -138,7 +132,7 @@ describe('CertificateManager', () => {
             const checkCertificateJobStatus = jest.spyOn(certManager as any, 'HasCertificateInstallerJobFinished').mockReturnValue(true);
             const IsValidCertificate = jest.spyOn(certManager as any, 'IsValidCertificate').mockReturnValue(true);
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
             expect(checkCertificateJobStatus).toHaveBeenCalled();
@@ -161,7 +155,7 @@ describe('CertificateManager', () => {
             const checkCertificateJobStatus = jest.spyOn(certManager as any, 'HasCertificateInstallerJobFinished').mockReturnValue(true);
             const IsValidCertificate = jest.spyOn(certManager as any, 'IsValidCertificate').mockReturnValue(false);
             const patchWebhookAndCertificates = jest.spyOn(certManager as any, 'PatchWebhookAndSecretStore').mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
             const certGenCaller = jest.spyOn(certManager as any, 'CreateOrUpdateCertificates');
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
             const generatedCertificate: WebhookCertData = certGenCaller.mock.results[0].value;
@@ -174,7 +168,7 @@ describe('CertificateManager', () => {
             expect(patchWebhookAndCertificates).toHaveBeenCalledTimes(1);
             expect(patchWebhookAndCertificates).toHaveBeenCalledWith(operationId, mockKubeConfig, generatedCertificate, mockClusterArmId, mockClusterArmRegion);
             expect(restartWebhookDeployment).toHaveBeenCalledTimes(1);
-            expect(restartWebhookDeployment).toHaveBeenCalledWith(operationId, mockKubeConfig, mockClusterArmId, mockClusterArmRegion);
+            expect(restartWebhookDeployment).toHaveBeenCalledWith(null, operationId, new RequestMetadata(null, null), mockKubeConfig, mockClusterArmId, mockClusterArmRegion);
         });
 
         it('should generate all new certs for host and CA if certs are corrupted or mismatched', async () => {
@@ -210,7 +204,7 @@ describe('CertificateManager', () => {
                 }
                 return null;
             });
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockImplementation((_1: string, kc: k8s.KubeConfig, _2: string, _3: string) => {
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockImplementation((additionalAnnotationName: string[], operationId: string, requestMetadata: RequestMetadata, kc: k8s.KubeConfig, _2: string, _3: string) => {
                 if (!kc) {
                     throw new Error('Invalid KubeConfig');
                 }
@@ -230,7 +224,7 @@ describe('CertificateManager', () => {
             expect(patchWebhookAndCertificates).toHaveBeenCalledTimes(1);
             expect(patchWebhookAndCertificates).toHaveBeenCalledWith(operationId, mockKubeConfig, mockCertData, mockClusterArmId, mockClusterArmRegion);
             expect(restartWebhookDeployment).toHaveBeenCalledTimes(1);
-            expect(restartWebhookDeployment).toHaveBeenCalledWith(operationId, mockKubeConfig, mockClusterArmId, mockClusterArmRegion);
+            expect(restartWebhookDeployment).toHaveBeenCalledWith(null, operationId, new RequestMetadata(null, null), mockKubeConfig, mockClusterArmId, mockClusterArmRegion);
         });
 
         it('should handle only CA cert expiration', async () => {
@@ -270,7 +264,7 @@ describe('CertificateManager', () => {
                 }
                 return null;
             });
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
 
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
@@ -314,7 +308,7 @@ describe('CertificateManager', () => {
                 }
                 return null;
             }).mockResolvedValue(null);
-            const restartWebhookDeployment = jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            const restartWebhookDeployment = jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
 
             await certManager.ReconcileWebhookAndCertificates(operationId, mockClusterArmId, mockClusterArmRegion);
 
@@ -389,7 +383,7 @@ describe('CertificateManager', () => {
             const clusterArmRegion = 'clusterArmRegion';
             const patchMutatingWebhook = jest.spyOn(certManager, 'PatchMutatingWebhook').mockResolvedValue(null);
             const patchSecretStore = jest.spyOn(certManager, 'PatchSecretStore').mockResolvedValue(null);
-            jest.spyOn(certManager as any, 'RestartWebhookDeployment').mockResolvedValue(null);
+            jest.spyOn(Utilities, 'RestartWebhookDeployment').mockResolvedValue(null);
 
             // Act
             await (certManager as any).PatchWebhookAndSecretStore(operationId, mockKubeConfig, mockCertificate, clusterArmId, clusterArmRegion);
@@ -493,7 +487,62 @@ describe('CertificateManager', () => {
             jest.spyOn(k8s.KubeConfig.prototype, 'makeApiClient').mockReturnValue(new k8s.AppsV1Api());
             
             // Act
-            await (certManager as any).RestartWebhookDeployment(operationId, mockKubeConfig, clusterArmId, clusterArmRegion);
+            await Utilities.RestartWebhookDeployment(null, operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
+
+            // Assert
+            expect(listNamespacedDeployment).toHaveBeenCalledWith('kube-system');
+            expect(replaceNamespacedDeployment).toHaveBeenCalledWith('app-monitoring-webhook', 'kube-system', updatedDeployment);
+        });
+
+        it('should set additional annotation if required', async () => {
+            // Arrange
+            const operationId = 'operationId';
+            const clusterArmId = 'clusterArmId';
+            const clusterArmRegion = 'clusterArmRegion';
+            const mockKubeConfig = new k8s.KubeConfig();
+            const deploymentList = {
+                body: {
+                    items: [{
+                            metadata: {
+                                name: 'app-monitoring-webhook',
+                                namespace: 'kube-system',
+                                annotations: {}
+                            },
+                            spec: {
+                                selector: {
+                                    matchLabels: {
+                                        app: 'app-monitoring-webhook'
+                                    }
+                                },
+                                template: {
+                                    metadata: {
+                                        name: 'app-monitoring-webhook',
+                                        annotations: {
+                                            'anno1': 'anno1'
+                                        }
+                                    }
+                                }
+                            }
+                        } as k8s.V1Deployment
+                    ]} as k8s.V1DeploymentList
+            } as any;
+            const updatedDeployment: k8s.V1ReplicaSet = JSON.parse(JSON.stringify(deploymentList.body.items[0]));
+            jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('GivenDate');
+            updatedDeployment.spec.template.metadata = {
+                name: 'app-monitoring-webhook',
+                annotations: {
+                    'anno1': 'anno1',
+                    'kubectl.kubernetes.io/restartedAt': 'GivenDate'
+                }
+            };
+            updatedDeployment.metadata.annotations["test-annotation"] = "test-annotation-value";
+            
+            const listNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'listNamespacedDeployment').mockResolvedValue(deploymentList);
+            const replaceNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'replaceNamespacedDeployment').mockResolvedValue(null);
+            jest.spyOn(k8s.KubeConfig.prototype, 'makeApiClient').mockReturnValue(new k8s.AppsV1Api());
+            
+            // Act
+            await Utilities.RestartWebhookDeployment(["test-annotation", "test-annotation-value"], operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
 
             // Assert
             expect(listNamespacedDeployment).toHaveBeenCalledWith('kube-system');

--- a/appmonitoring/ts/src/tests/CertificateManager.spec.ts
+++ b/appmonitoring/ts/src/tests/CertificateManager.spec.ts
@@ -494,7 +494,7 @@ describe('CertificateManager', () => {
             expect(replaceNamespacedDeployment).toHaveBeenCalledWith('app-monitoring-webhook', 'kube-system', updatedDeployment);
         });
 
-        it('should set additional environment variable if required', async () => {
+        it('should set additional annotation if required', async () => {
             // Arrange
             const operationId = 'operationId';
             const clusterArmId = 'clusterArmId';
@@ -545,17 +545,17 @@ describe('CertificateManager', () => {
                 name: 'app-monitoring-webhook',
                 annotations: {
                     'anno1': 'anno1',
-                    'kubectl.kubernetes.io/restartedAt': 'GivenDate'
+                    'kubectl.kubernetes.io/restartedAt': 'GivenDate',
+                    'test-annotation-name': 'test-annotation-value'
                 }
             };
-            updatedDeployment.spec.template.spec.containers[0].env.push({ name: "TEST_ENVVAR", value: "test-env-var-value" });
-
+            
             const listNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'listNamespacedDeployment').mockResolvedValue(deploymentList);
             const replaceNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'replaceNamespacedDeployment').mockResolvedValue(null);
             jest.spyOn(k8s.KubeConfig.prototype, 'makeApiClient').mockReturnValue(new k8s.AppsV1Api());
             
             // Act
-            await Utilities.RestartWebhookDeployment(["TEST_ENVVAR", "test-env-var-value"], operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
+            await Utilities.RestartWebhookDeployment(["test-annotation-name", "test-annotation-value"], operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
 
             // Assert
             expect(listNamespacedDeployment).toHaveBeenCalledWith('kube-system');

--- a/appmonitoring/ts/src/tests/CertificateManager.spec.ts
+++ b/appmonitoring/ts/src/tests/CertificateManager.spec.ts
@@ -494,7 +494,7 @@ describe('CertificateManager', () => {
             expect(replaceNamespacedDeployment).toHaveBeenCalledWith('app-monitoring-webhook', 'kube-system', updatedDeployment);
         });
 
-        it('should set additional annotation if required', async () => {
+        it('should set additional environment variable if required', async () => {
             // Arrange
             const operationId = 'operationId';
             const clusterArmId = 'clusterArmId';
@@ -520,6 +520,19 @@ describe('CertificateManager', () => {
                                         annotations: {
                                             'anno1': 'anno1'
                                         }
+                                    },
+                                    spec: {
+                                        containers: [
+                                            {
+                                                name: "container1",
+                                                env: [
+                                                    {
+                                                        name: "env1",
+                                                        value: "val1"
+                                                    }
+                                                ]
+                                            }
+                                        ]
                                     }
                                 }
                             }
@@ -535,14 +548,14 @@ describe('CertificateManager', () => {
                     'kubectl.kubernetes.io/restartedAt': 'GivenDate'
                 }
             };
-            updatedDeployment.metadata.annotations["test-annotation"] = "test-annotation-value";
-            
+            updatedDeployment.spec.template.spec.containers[0].env.push({ name: "TEST_ENVVAR", value: "test-env-var-value" });
+
             const listNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'listNamespacedDeployment').mockResolvedValue(deploymentList);
             const replaceNamespacedDeployment = jest.spyOn(k8s.AppsV1Api.prototype, 'replaceNamespacedDeployment').mockResolvedValue(null);
             jest.spyOn(k8s.KubeConfig.prototype, 'makeApiClient').mockReturnValue(new k8s.AppsV1Api());
             
             // Act
-            await Utilities.RestartWebhookDeployment(["test-annotation", "test-annotation-value"], operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
+            await Utilities.RestartWebhookDeployment(["TEST_ENVVAR", "test-env-var-value"], operationId, null, mockKubeConfig, clusterArmId, clusterArmRegion);
 
             // Assert
             expect(listNamespacedDeployment).toHaveBeenCalledWith('kube-system');

--- a/appmonitoring/ts/src/tests/Mutator.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutator.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { expect, describe, it } from "@jest/globals";
 import { Mutator } from "../Mutator.js";
-import { IAdmissionReview, IAnnotations, IMetadata, InstrumentationCR, AutoInstrumentationPlatforms, DefaultInstrumentationCRName, IInstrumentationState, IObjectType, InstrumentationAnnotationName } from "../RequestDefinition.js";
+import { IAdmissionReview, IAnnotations, IMetadata, InstrumentationCR, AutoInstrumentationPlatforms, DefaultInstrumentationCRName, IInstrumentationState, IObjectType, InstrumentationAnnotationName, InstrumentationLabelName } from "../RequestDefinition.js";
 import { TestObject2, TestObject4, crs, clusterArmId, clusterArmRegion } from "./testConsts.js";
 import { logger } from "../LoggerWrapper.js"
 import { InstrumentationCRsCollection } from "../InstrumentationCRsCollection.js";
@@ -114,8 +114,10 @@ describe("Mutator", () => {
         expect((<[]>patches).length).toBe(1);
 
         const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const labelValue: string = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
-
+        
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(DefaultInstrumentationCRName);
         expect(annotationValue.crResourceVersion).toBe("1");
         expect(annotationValue.platforms).toStrictEqual([AutoInstrumentationPlatforms.DotNet, AutoInstrumentationPlatforms.Java, AutoInstrumentationPlatforms.NodeJs]);
@@ -168,6 +170,7 @@ describe("Mutator", () => {
         expect((<[]>patches).length).toBe(1);
 
         const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        expect(obj.metadata?.labels?.[InstrumentationLabelName]).toBeUndefined();
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();        
     });
 
@@ -300,8 +303,10 @@ describe("Mutator", () => {
         expect((<[]>patches).length).toBe(1);
 
         const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const labelValue: string = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
         
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(DefaultInstrumentationCRName);
         expect(annotationValue.crResourceVersion).toBe("1");
         expect(annotationValue.platforms).toStrictEqual([AutoInstrumentationPlatforms.Java, AutoInstrumentationPlatforms.NodeJs]);
@@ -377,8 +382,10 @@ describe("Mutator", () => {
         expect((<[]>patches).length).toBe(1);
         
         const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const labelValue: string = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
         
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(cr1.metadata.name);
         expect(annotationValue.crResourceVersion).toBe("1");
         expect(annotationValue.platforms).toStrictEqual([AutoInstrumentationPlatforms.DotNet, AutoInstrumentationPlatforms.NodeJs]);
@@ -435,8 +442,10 @@ describe("Mutator", () => {
         expect((<[]>patches).length).toBe(1);
 
         const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const labelValue: string = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
 
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(crDefault.metadata.name);
         expect(annotationValue.crResourceVersion).toBe("12");
         expect(annotationValue.platforms).toStrictEqual([]);

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { expect, describe, it } from "@jest/globals";
 import { Mutations } from "../Mutations.js";
-import { IAdmissionReview, PodInfo, IContainer, IVolume, AutoInstrumentationPlatforms, IEnvironmentVariable, InstrumentationCR, IInstrumentationState, IObjectType, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName } from "../RequestDefinition.js";
+import { IAdmissionReview, PodInfo, IContainer, IVolume, AutoInstrumentationPlatforms, IEnvironmentVariable, InstrumentationCR, IInstrumentationState, IObjectType, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName, InstrumentationLabelName } from "../RequestDefinition.js";
 import { Patcher } from "../Patcher.js";
 import { cr, clusterArmId, clusterArmRegion, clusterName, TestDeployment2 } from "./testConsts.js";
 import { logger } from "../LoggerWrapper.js"
@@ -40,7 +40,10 @@ describe("Patcher", () => {
         expect((<[]>result).length).toBe(1);
         
         const obj: IObjectType = (<any>result[0]).value as IObjectType;
+        const labelValue = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
+        
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(cr1.metadata.name);
         expect(annotationValue.crResourceVersion).toBe("1");
         expect(annotationValue.platforms).toStrictEqual([AutoInstrumentationPlatforms.DotNet, AutoInstrumentationPlatforms.Java, AutoInstrumentationPlatforms.NodeJs]);        
@@ -101,8 +104,10 @@ describe("Patcher", () => {
         expect((<[]>result).length).toBe(1);
 
         const obj: IObjectType = (<any>result[0]).value as IObjectType;
+        const labelValue = obj.metadata.labels[InstrumentationLabelName];
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
 
+        expect(labelValue).toBe("");
         expect(annotationValue.crName).toBe(cr1.metadata.name);
         expect(annotationValue.crResourceVersion).toBe("1");
         expect(annotationValue.platforms).toStrictEqual([]);        
@@ -167,6 +172,7 @@ describe("Patcher", () => {
         expect(unpatchResult.length).toBe(1);
 
         const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        expect(obj.metadata?.labels?.[InstrumentationLabelName]).toBeUndefined();
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -203,6 +209,7 @@ describe("Patcher", () => {
         expect(unpatchResult.length).toBe(1);
 
         const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        expect(obj.metadata?.labels?.[InstrumentationLabelName]).toBeUndefined();
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -237,6 +244,7 @@ describe("Patcher", () => {
         expect(unpatchResult.length).toBe(1);
 
         const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        expect(obj.metadata?.labels?.[InstrumentationLabelName]).toBeUndefined();
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -272,6 +280,7 @@ describe("Patcher", () => {
         expect(patchResult.length).toBe(1);
 
         const obj: IObjectType = (<any>patchResult[0]).value as IObjectType;
+        expect(obj.metadata?.labels?.[InstrumentationLabelName]).toBeUndefined();
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
         
         expect((<any>patchResult[0]).op).toBe("replace");


### PR DESCRIPTION
Once Helm chart is being removed, we must block its removal with a pre-delete job until the last instrumented workload is deleted or uninstrumented. To query for such workloads efficiently, we are introducing a label that marks them during instrumentation (we previously had only an annotation), and also introducing a job that tracks instrumented workloads once the Helm chart is being uninstalled.