### PR TITLE
Fix windows fluent-bit feature to use resource optimization flag

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -132,7 +132,6 @@ def substituteFluentBitPlaceHolders
     stacktraceLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
     resourceOptimizationEnabled = ENV["AZMON_RESOURCE_OPTIMIZATION_ENABLED"]
     enableCustomMetrics = ENV["ENABLE_CUSTOM_METRICS"]
-    # windowsFluentBitDisabled = ENV["AZMON_WINDOWS_FLUENT_BIT_DISABLED"]
     windowsFluentBitDisabled = !resourceOptimizationEnabled
     kubernetesMetadataCollection = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
     annotationBasedLogFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]

--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -132,7 +132,8 @@ def substituteFluentBitPlaceHolders
     stacktraceLanguages = ENV["AZMON_MULTILINE_LANGUAGES"]
     resourceOptimizationEnabled = ENV["AZMON_RESOURCE_OPTIMIZATION_ENABLED"]
     enableCustomMetrics = ENV["ENABLE_CUSTOM_METRICS"]
-    windowsFluentBitDisabled = ENV["AZMON_WINDOWS_FLUENT_BIT_DISABLED"]
+    # windowsFluentBitDisabled = ENV["AZMON_WINDOWS_FLUENT_BIT_DISABLED"]
+    windowsFluentBitDisabled = !resourceOptimizationEnabled
     kubernetesMetadataCollection = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
     annotationBasedLogFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]
     storageMaxChunksUp = ENV["FBIT_STORAGE_MAX_CHUNKS_UP"]

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1060,9 +1060,10 @@ if [ ! -f /etc/cron.d/ci-agent ]; then
       echo "*/5 * * * * root /usr/sbin/logrotate -s /var/lib/logrotate/ci-agent-status /etc/logrotate.d/ci-agent >/dev/null 2>&1" >/etc/cron.d/ci-agent
 fi
 
-setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}"
+# setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}"
+setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "$( [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" == "true" ] && echo "false" || echo "true" )"
 if [ "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" == "true" ] || [ -z "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" ] || [ "${USING_AAD_MSI_AUTH}" != "true" ] || [ "${RS_GENEVA_LOGS_INTEGRATION}" == "true" ]; then
-      if [ -e "/etc/config/kube.conf" ]; then
+      if [ -e "/etc/fluent/kube.conf" ]; then
            # Replace a string in the configmap file
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube.conf
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube-cm.conf

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1060,10 +1060,9 @@ if [ ! -f /etc/cron.d/ci-agent ]; then
       echo "*/5 * * * * root /usr/sbin/logrotate -s /var/lib/logrotate/ci-agent-status /etc/logrotate.d/ci-agent >/dev/null 2>&1" >/etc/cron.d/ci-agent
 fi
 
-# setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}"
 setGlobalEnvVar AZMON_WINDOWS_FLUENT_BIT_DISABLED "$( [ "${AZMON_RESOURCE_OPTIMIZATION_ENABLED}" == "true" ] && echo "false" || echo "true" )"
 if [ "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" == "true" ] || [ -z "${AZMON_WINDOWS_FLUENT_BIT_DISABLED}" ] || [ "${USING_AAD_MSI_AUTH}" != "true" ] || [ "${RS_GENEVA_LOGS_INTEGRATION}" == "true" ]; then
-      if [ -e "/etc/fluent/kube.conf" ]; then
+      if [ -e "/etc/config/kube.conf" ]; then
            # Replace a string in the configmap file
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube.conf
             sed -i "s/#@include windows_rs/@include windows_rs/g" /etc/fluent/kube-cm.conf


### PR DESCRIPTION
Fix windows fluent-bit feature to use resource optimization flag

issue 1: chart values for AZMON_WINDOWS_FLUENT_BIT_DISABLED was removed from rs pod
 
issue 2: as the AZMON_WINDOWS_FLUENT_BIT_DISABLED was set for windows, this value is always trues in win
 
 