### PR TITLE
optimize agent telemetry

### DIFF
--- a/source/plugins/go/input/lib/cadvisor.go
+++ b/source/plugins/go/input/lib/cadvisor.go
@@ -606,7 +606,7 @@ func getContainerCpuMetricItemRate(metricInfo map[string]interface{}, hostName, 
 							telemetryProps["clusterenvvars"] = os.Getenv("AZMON_CLUSTER_COLLECT_ENV_VAR")
 							telemetryProps["clusterstderrlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDERR_LOGS")
 							telemetryProps["clusterstdoutlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDOUT_LOGS")
-							clusterlogtailexcludepath = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							clusterlogtailexcludepath := os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
 							// Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
 							if len(clusterlogtailexcludepath) <= 1024 {
 								telemetryProps["clusterlogtailexcludepath"] = clusterlogtailexcludepath
@@ -1034,7 +1034,7 @@ func getContainerCpuMetricItems(metricInfo map[string]interface{}, hostName, met
 							telemetryProps["clusterenvvars"] = os.Getenv("AZMON_CLUSTER_COLLECT_ENV_VAR")
 							telemetryProps["clusterstderrlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDERR_LOGS")
 							telemetryProps["clusterstdoutlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDOUT_LOGS")
-							clusterlogtailexcludepath = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							clusterlogtailexcludepath := os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
 							// Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
 							if len(clusterlogtailexcludepath) <= 1024 {
 								telemetryProps["clusterlogtailexcludepath"] = clusterlogtailexcludepath

--- a/source/plugins/go/input/lib/cadvisor.go
+++ b/source/plugins/go/input/lib/cadvisor.go
@@ -606,7 +606,11 @@ func getContainerCpuMetricItemRate(metricInfo map[string]interface{}, hostName, 
 							telemetryProps["clusterenvvars"] = os.Getenv("AZMON_CLUSTER_COLLECT_ENV_VAR")
 							telemetryProps["clusterstderrlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDERR_LOGS")
 							telemetryProps["clusterstdoutlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDOUT_LOGS")
-							telemetryProps["clusterlogtailexcludepath"] = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							clusterlogtailexcludepath = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							// Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
+							if len(clusterlogtailexcludepath) <= 1024 {
+								telemetryProps["clusterlogtailexcludepath"] = clusterlogtailexcludepath
+							}
 							telemetryProps["clusterLogTailPath"] = os.Getenv("AZMON_LOG_TAIL_PATH")
 							telemetryProps["clusterAgentSchemaVersion"] = os.Getenv("AZMON_AGENT_CFG_SCHEMA_VERSION")
 							telemetryProps["clusterCLEnrich"] = os.Getenv("AZMON_CLUSTER_CONTAINER_LOG_ENRICH")
@@ -1030,7 +1034,11 @@ func getContainerCpuMetricItems(metricInfo map[string]interface{}, hostName, met
 							telemetryProps["clusterenvvars"] = os.Getenv("AZMON_CLUSTER_COLLECT_ENV_VAR")
 							telemetryProps["clusterstderrlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDERR_LOGS")
 							telemetryProps["clusterstdoutlogs"] = os.Getenv("AZMON_CLUSTER_COLLECT_STDOUT_LOGS")
-							telemetryProps["clusterlogtailexcludepath"] = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							clusterlogtailexcludepath = os.Getenv("AZMON_CLUSTER_LOG_TAIL_EXCLUDE_PATH")
+							// Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
+							if len(clusterlogtailexcludepath) <= 1024 {
+								telemetryProps["clusterlogtailexcludepath"] = clusterlogtailexcludepath
+							}
 							telemetryProps["clusterLogTailPath"] = os.Getenv("AZMON_LOG_TAIL_PATH")
 							telemetryProps["clusterAgentSchemaVersion"] = os.Getenv("AZMON_AGENT_CFG_SCHEMA_VERSION")
 							telemetryProps["clusterCLEnrich"] = os.Getenv("AZMON_CLUSTER_CONTAINER_LOG_ENRICH")

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -276,7 +276,10 @@ class CAdvisorMetricsAPIClient
                       telemetryProps["clusterenvvars"] = @clusterEnvVarCollectionEnabled
                       telemetryProps["clusterstderrlogs"] = @clusterStdErrLogCollectionEnabled
                       telemetryProps["clusterstdoutlogs"] = @clusterStdOutLogCollectionEnabled
-                      telemetryProps["clusterlogtailexcludepath"] = @clusterLogTailExcludPath
+                      # Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
+                      if (!@clusterLogTailExcludPath.nil? && !@clusterLogTailExcludPath.empty? && @clusterLogTailExcludPath.size <= 1024)
+                        telemetryProps["clusterlogtailexcludepath"] = @clusterLogTailExcludPath
+                      end
                       telemetryProps["clusterLogTailPath"] = @clusterLogTailPath
                       telemetryProps["clusterAgentSchemaVersion"] = @clusterAgentSchemaVersion
                       telemetryProps["clusterCLEnrich"] = @clusterContainerLogEnrich
@@ -629,7 +632,10 @@ class CAdvisorMetricsAPIClient
                       telemetryProps["clusterenvvars"] = @clusterEnvVarCollectionEnabled
                       telemetryProps["clusterstderrlogs"] = @clusterStdErrLogCollectionEnabled
                       telemetryProps["clusterstdoutlogs"] = @clusterStdOutLogCollectionEnabled
-                      telemetryProps["clusterlogtailexcludepath"] = @clusterLogTailExcludPath
+                      # Limit the length of the clusterlogtailexcludepath to 1KB since it can impact telemetry ingestion
+                      if (!@clusterLogTailExcludPath.nil? && !@clusterLogTailExcludPath.empty? && @clusterLogTailExcludPath.size <= 1024)
+                        telemetryProps["clusterlogtailexcludepath"] = @clusterLogTailExcludPath
+                      end
                       telemetryProps["clusterLogTailPath"] = @clusterLogTailPath
                       telemetryProps["clusterAgentSchemaVersion"] = @clusterAgentSchemaVersion
                       telemetryProps["clusterCLEnrich"] = @clusterContainerLogEnrich


### PR DESCRIPTION
telemetry ingestion can fail to ingest if the message size is large and hence avoiding sending large field size.