### PR TITLE
AKS Container Insights TroubleshootError.ps1 Verify DisableLocalAuth

### DIFF
--- a/scripts/troubleshoot/TroubleshootError.ps1
+++ b/scripts/troubleshoot/TroubleshootError.ps1
@@ -722,6 +722,12 @@ else {
     }
     else {
 
+        Write-Host('Verifying shared keys are allowed to used on the workspace') -ForegroundColor Green
+        if ($WorkspaceInformation.WorkspaceFeatures.DisableLocalAuth -eq $true) {
+            Write-Host("The Log Analytics Workspace does not allow the usage of shared keys. Set 'disableLocalAuth' to 'false' on the workspace or enable AADAuth on AKS monitoring addon.") -ForegroundColor Red
+        }
+	Write-Host("")
+
         try {
             $WorkspaceIPDetails = Get-AzOperationalInsightsIntelligencePacks -ResourceGroupName $workspaceResourceGroupName -WorkspaceName $workspaceName -ErrorAction Stop -WarningAction silentlyContinue
             Write-Host("Successfully fetched workspace IP details...") -ForegroundColor Green


### PR DESCRIPTION
When using AKS Container Insights with Azure Monitor and AAD authentication is not used to connect to Log Analytics, the specified workspace should not set `disableLocalAuth` to `true`. The value can be either `false` or `null`. This is because the workspace keys are used.

More info: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-troubleshoot