### PR TITLE
handle empty agent config in Go client and fix build failures

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -175,6 +175,7 @@ jobs:
 
         sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
         docker system prune --all -f
+        docker images -q --filter "dangling=true" | xargs docker rmi
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
         docker buildx create --name testbuilder
@@ -184,6 +185,11 @@ jobs:
         az account show
         az account set -s ${{ variables.subscription }}
         az acr login -n ${{ variables.containerRegistry }}
+
+        # NOTE: Using the prometheus-collector team's cached buildx image since moby/buildkit:buildx-stable-1 getting throttled
+        docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
+        docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
+        docker buildx inspect --bootstrap
 
         if [ "$(Build.Reason)" != "PullRequest" ]; then
           docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -280,23 +280,50 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-        export TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
-        export TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db"
+        PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
+        SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
+        PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
+        SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
+
+        # Set initial repositories to primary
+        export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY
+        export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
+
+        # Function to run Trivy scan and handle output
+        run_trivy_scan() {
+            trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+            return $?
+        }
+
+        # Attempt scan up to 5 times with repository fallback
         for i in {1..5}; do
-            trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM ${{ variables.repoImageName }}:$(linuxImagetag) > trivy_output.log 2>&1
+            echo "Running Trivy scan attempt $i..."
+
+            # Run the Trivy scan and capture exit code
+            run_trivy_scan
             TRIVY_EXIT_CODE=$?
+
+            # Check if scan was successful
             if [ $TRIVY_EXIT_CODE -eq 0 ]; then
-              cat trivy_output.log
-              break
+                echo "Trivy scan succeeded."
+                cat trivy_output.log
+                break
             fi
-            if grep -q "TOOMANYREQUESTS" trivy_output.log; then
-              echo "Error: Too many requests to the Trivy server. Retrying... ($i/5)"
-              sleep 5
-            else
-              cat trivy_output.log
-              exit 1
+
+            # If the first attempt fails, switch to secondary repositories
+            if [ $i -eq 1 ]; then
+                echo "Primary repositories failed with an error. Switching to secondary repositories."
+                export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY
+                export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY
             fi
+
+            # Log and wait before retrying if an error occurred
+            echo "Error: Trivy scan attempt $i failed. Retrying... ($i/5)"
+            cat trivy_output.log
+            sleep 5 # Wait 5 seconds before retrying
         done
+
+        # Final check: if still failing after 5 attempts, exit with error
         if [ $TRIVY_EXIT_CODE -ne 0 ]; then
             echo "Error: Trivy scan failed after 5 retries."
             exit 1

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -274,8 +274,27 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-
-        trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --exit-code 1 ${{ variables.repoImageName }}:$(linuxImagetag)
+        export TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
+        export TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db"
+        for i in {1..5}; do
+            trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM ${{ variables.repoImageName }}:$(linuxImagetag) > trivy_output.log 2>&1
+            TRIVY_EXIT_CODE=$?
+            if [ $TRIVY_EXIT_CODE -eq 0 ]; then
+              cat trivy_output.log
+              break
+            fi
+            if grep -q "TOOMANYREQUESTS" trivy_output.log; then
+              echo "Error: Too many requests to the Trivy server. Retrying... ($i/5)"
+              sleep 5
+            else
+              cat trivy_output.log
+              exit 1
+            fi
+        done
+        if [ $TRIVY_EXIT_CODE -ne 0 ]; then
+            echo "Error: Trivy scan failed after 5 retries."
+            exit 1
+        fi
 
     # Find in cache or download a specific version of Go and add it to the PATH.
   - task: GoTool@0

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -78,7 +78,7 @@ jobs:
 
       cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension/ServiceGroupRoot/Scripts
       tar -czvf ../artifacts.tar.gz ../../../../charts/azuremonitor-containers/ pushChartToAcr.sh
-    
+
       cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
       tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
 
@@ -95,7 +95,7 @@ jobs:
 
   - task: CredScan@3
     displayName: "SDL : Run credscan"
-  
+
   - task: CopyFiles@2
     displayName: "Copy ev2 deployment artifacts"
     inputs:
@@ -140,7 +140,7 @@ jobs:
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
-  
+
   - task: Armory@2
     displayName: 'Run ARMory'
     inputs:
@@ -287,7 +287,7 @@ jobs:
         ls
         make
     displayName: 'Execute Makefile for Linux Build'
-  
+
   - task: CodeQL3000Finalize@0
     condition: eq(variables.IS_MAIN_BRANCH, true)
 
@@ -355,6 +355,7 @@ jobs:
       azureSubscription: ${{ variables.armServiceConnectionName }}
       scriptType: ps
       scriptLocation: inlineScript
+      retryCountOnTaskFailure: 2
       inlineScript: |
         mkdir -p $(Build.ArtifactStagingDirectory)/windows
         cd kubernetes/windows
@@ -398,7 +399,7 @@ jobs:
 
         echo "Extract fluent-bit"
         docker cp signingContainer:C:\opt\fluent-bit .
-        
+
         echo "Extract Ruby"
         docker cp signingContainer:C:\ruby31 .
 
@@ -525,7 +526,7 @@ jobs:
       targetType: 'inline'
       script: |
         docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
-        
+
         echo "Copy Signed binaries/folders back to docker image..."
         docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
         docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
@@ -588,6 +589,7 @@ jobs:
       azureSubscription: ${{ variables.armServiceConnectionName }}
       scriptType: ps
       scriptLocation: inlineScript
+      retryCountOnTaskFailure: 2
       inlineScript: |
         mkdir -p $(Build.ArtifactStagingDirectory)/windows
         cd kubernetes/windows
@@ -631,7 +633,7 @@ jobs:
 
         echo "Extract fluent-bit"
         docker cp signingContainer:C:\opt\fluent-bit .
-        
+
         echo "Extract Ruby"
         docker cp signingContainer:C:\ruby31 .
 
@@ -758,7 +760,7 @@ jobs:
       targetType: 'inline'
       script: |
         docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
-        
+
         echo "Copy Signed binaries/folders back to docker image..."
         docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
         docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
@@ -907,7 +909,7 @@ jobs:
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop
-  
+
   - task: AntiMalware@4
     displayName: 'Run MpCmdRun.exe'
     inputs:

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -140,10 +140,30 @@ RUN ln -s /lib/libnssckbi.so /lib/p11-kit-trust.so
 # Do vulnerability scan in a seperate stage to avoid adding layer
 FROM distroless_image AS vulnscan
 COPY .trivyignore .trivyignore
-# Use Backup DB repository since the default repository has throttle limits
-ENV TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
-ENV TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
 RUN ["/bin/bash", "-c", "curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.39.0"]
+
+# Set up primary and secondary repository URLs
+ENV PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
+ENV SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
+ENV PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
+ENV SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
+
+# Download Trivy main database with a fallback mechanism
+RUN export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY && \
+    trivy image --download-db-only || \
+    (echo "Primary TRIVY_DB_REPOSITORY failed, trying secondary." && \
+     export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY && \
+     trivy image --download-db-only) || \
+    (echo "Both TRIVY_DB_REPOSITORY sources failed." && exit 1)
+
+# Download Trivy Java database with a fallback mechanism
+RUN export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY && \
+    trivy fs --scanners vuln --vuln-type library --download-java-db-only || \
+    (echo "Primary TRIVY_JAVA_DB_REPOSITORY failed, trying secondary." && \
+     export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY && \
+     trivy fs --scanners vuln --vuln-type library --download-java-db-only) || \
+    (echo "Both TRIVY_JAVA_DB_REPOSITORY sources failed." && exit 1)
+
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --skip-files \"/usr/local/bin/trivy\" /"]
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM /usr/lib"]
 RUN ["/bin/bash", "-c", "trivy rootfs --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --skip-files \"/usr/local/bin/trivy\" / > /dev/null 2>&1 && trivy rootfs --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM /usr/lib > /dev/null 2>&1"]

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -140,6 +140,8 @@ RUN ln -s /lib/libnssckbi.so /lib/p11-kit-trust.so
 # Do vulnerability scan in a seperate stage to avoid adding layer
 FROM distroless_image AS vulnscan
 COPY .trivyignore .trivyignore
+ENV TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
+ENV TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db"
 RUN ["/bin/bash", "-c", "curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.39.0"]
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --skip-files \"/usr/local/bin/trivy\" /"]
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM /usr/lib"]

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -140,8 +140,9 @@ RUN ln -s /lib/libnssckbi.so /lib/p11-kit-trust.so
 # Do vulnerability scan in a seperate stage to avoid adding layer
 FROM distroless_image AS vulnscan
 COPY .trivyignore .trivyignore
-ENV TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
-ENV TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db"
+# Use Backup DB repository since the default repository has throttle limits
+ENV TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
+ENV TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
 RUN ["/bin/bash", "-c", "curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.39.0"]
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --skip-files \"/usr/local/bin/trivy\" /"]
 RUN ["/bin/bash", "-c", "trivy rootfs --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM /usr/lib"]

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -37,27 +37,27 @@ RUN Write-Output "Configuring MSYS2 mirrors..." ; \
     Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait
 
 # Install required gems with retry logic for network stability
-RUN Write-Output "Installing Ruby gems with retry logic..." ; \
+RUN Write-Output 'Installing Ruby gems with retry logic...'; \
     function Install-GemWithRetry { \
-        param([string]$gemName, [string]$version, [int]$retries = 5) ; \
+        param([string]$gemName, [string]$version, [int]$retries = 5); \
         for ($i = 0; $i -lt $retries; $i++) { \
-            gem install $gemName -v $version --no-document --platform ruby && break || \
-            Write-Output "Failed to install $gemName. Retrying in 5 seconds... ($($i+1)/$retries)" ; \
-            Start-Sleep -Seconds 5 ; \
-        } ; \
-        if (-not (gem list -i $gemName -v $version)) { throw "Failed to install $gemName after $retries attempts." } ; \
-    } ; \
-    Install-GemWithRetry -gemName 'cool.io' -version '1.7.1' ; \
-    Install-GemWithRetry -gemName 'oj' -version '3.3.10' ; \
-    Install-GemWithRetry -gemName 'fluentd' -version '1.16.3' ; \
-    Install-GemWithRetry -gemName 'win32-service' -version '1.0.1' ; \
-    Install-GemWithRetry -gemName 'win32-ipc' -version '0.7.0' ; \
-    Install-GemWithRetry -gemName 'win32-event' -version '0.6.3' ; \
-    Install-GemWithRetry -gemName 'windows-pr' -version '1.2.6' ; \
-    Install-GemWithRetry -gemName 'tomlrb' -version '2.0.1' ; \
-    Install-GemWithRetry -gemName 'gyoku' -version '1.3.1' ; \
-    Install-GemWithRetry -gemName 'ipaddress' -version '0.8.3' ; \
-    Install-GemWithRetry -gemName 'jwt' -version '2.7.1' ; \
+            if (gem install $gemName -v $version --no-document --platform ruby) { break } else { \
+            Write-Output 'Failed to install $gemName. Retrying in 5 seconds... ($($i+1)/$retries)'; \
+            Start-Sleep -Seconds 5; } \
+        }; \
+        if (-not (gem list -i $gemName -v $version)) { throw 'Failed to install $gemName after $retries attempts.' }; \
+    }; \
+    Install-GemWithRetry -gemName 'cool.io' -version '1.7.1'; \
+    Install-GemWithRetry -gemName 'oj' -version '3.3.10'; \
+    Install-GemWithRetry -gemName 'fluentd' -version '1.16.3'; \
+    Install-GemWithRetry -gemName 'win32-service' -version '1.0.1'; \
+    Install-GemWithRetry -gemName 'win32-ipc' -version '0.7.0'; \
+    Install-GemWithRetry -gemName 'win32-event' -version '0.6.3'; \
+    Install-GemWithRetry -gemName 'windows-pr' -version '1.2.6'; \
+    Install-GemWithRetry -gemName 'tomlrb' -version '2.0.1'; \
+    Install-GemWithRetry -gemName 'gyoku' -version '1.3.1'; \
+    Install-GemWithRetry -gemName 'ipaddress' -version '0.8.3'; \
+    Install-GemWithRetry -gemName 'jwt' -version '2.7.1'; \
     gem sources --clear-all
 
 # Optional: Run `ridk install` to add MSYS2 dev tools (optional if MSYS2 update fails)

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -16,18 +16,6 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 && choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 
-# Set environment variables for paths
-RUN setx PATH "%PATH%;C:\ruby31\bin;C:\ruby31\msys64\usr\bin"
-
-RUN powershell -Command "Write-Output 'Configuring MSYS2 mirrors...'; \
-    $MirrorFileMsys = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.msys'; \
-    $MirrorFileMingw = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.mingw'; \
-    (Get-Content $MirrorFileMsys) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMsys; \
-    (Get-Content $MirrorFileMingw) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMingw; \
-    Add-Content -Path $MirrorFileMsys -Value 'Server = https://repo.msys2.org/msys/$arch'; \
-    Add-Content -Path $MirrorFileMingw -Value 'Server = https://repo.msys2.org/mingw/$arch'; \
-    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait;"
-
 # gangams - optional MSYS2 update via ridk failing in merged docker file so skipping that since we dont need optional update
 RUN refreshenv \
 && ridk install 3 \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -34,7 +34,8 @@ RUN Write-Output "Configuring MSYS2 mirrors..." ; \
     (Get-Content $MirrorFileMingw) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMingw ; \
     Add-Content -Path $MirrorFileMsys -Value 'Server = https://repo.msys2.org/msys/$arch' ; \
     Add-Content -Path $MirrorFileMingw -Value 'Server = https://repo.msys2.org/mingw/$arch' ; \
-    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait
+    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait ; \
+    refreshenv; ridk install 3; echo gem: --no-document >> C:\ProgramData\gemrc
 
 # Install required gems with retry logic for network stability
 RUN Write-Output 'Installing Ruby gems with retry logic...'; \
@@ -59,11 +60,6 @@ RUN Write-Output 'Installing Ruby gems with retry logic...'; \
     Install-GemWithRetry -gemName 'ipaddress' -version '0.8.3'; \
     Install-GemWithRetry -gemName 'jwt' -version '2.7.1'; \
     gem sources --clear-all
-
-# Optional: Run `ridk install` to add MSYS2 dev tools (optional if MSYS2 update fails)
-RUN refreshenv && \
-    ridk install 3 && \
-    echo gem: --no-document >> C:\ProgramData\gemrc
 
 # Remove gem cache and chocolatey
 RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'; Remove-Item -Recurse -Force 'C:\Users\ContainerAdministrator\AppData\Local\Temp'"

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -16,6 +16,9 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 && choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 
+# Set environment variables for paths
+RUN setx PATH "%PATH%;C:\ruby31\bin;C:\ruby31\msys64\usr\bin"
+
 RUN powershell -Command "Write-Output 'Configuring MSYS2 mirrors...'; \
     $MirrorFileMsys = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.msys'; \
     $MirrorFileMingw = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.mingw'; \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -10,28 +10,60 @@ RUN reg add "HKLM\Software\Wow6432Node\Microsoft\Cryptography\Wintrust\Config" /
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
+# Set the Chocolatey version
 ENV chocolateyVersion 1.4.0
-RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
-# Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
-RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
-&& choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 
-# gangams - optional MSYS2 update via ridk failing in merged docker file so skipping that since we dont need optional update
-RUN refreshenv \
-&& ridk install 3 \
-&& echo gem: --no-document >> C:\ProgramData\gemrc \
-&& gem install cool.io -v 1.7.1 --platform ruby \
-&& gem install oj -v 3.3.10 \
-&& gem install fluentd -v 1.16.3 \
-&& gem install win32-service -v 1.0.1 \
-&& gem install win32-ipc -v 0.7.0 \
-&& gem install win32-event -v 0.6.3 \
-&& gem install windows-pr -v 1.2.6 \
-&& gem install tomlrb -v 2.0.1 \
-&& gem install gyoku -v 1.3.1 \
-&& gem install ipaddress -v 0.8.3 \
-&& gem install jwt -v 2.7.1 \
-&& gem sources --clear-all
+# Install Chocolatey
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+
+# Install Ruby and MSYS2 using Chocolatey with specified install directories
+RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" && \
+    choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
+
+# Set environment variables for paths
+RUN setx PATH "%PATH%;C:\ruby31\bin;C:\ruby31\msys64\usr\bin"
+
+# Refresh environment and set up MSYS2 mirrors and retry logic for gem installs
+SHELL ["powershell", "-Command"]
+
+RUN Write-Output "Configuring MSYS2 mirrors..." ; \
+    $MirrorFileMsys = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.msys' ; \
+    $MirrorFileMingw = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.mingw' ; \
+    (Get-Content $MirrorFileMsys) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMsys ; \
+    (Get-Content $MirrorFileMingw) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMingw ; \
+    Add-Content -Path $MirrorFileMsys -Value 'Server = https://repo.msys2.org/msys/$arch' ; \
+    Add-Content -Path $MirrorFileMingw -Value 'Server = https://repo.msys2.org/mingw/$arch' ; \
+    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait
+
+# Install required gems with retry logic for network stability
+RUN Write-Output "Installing Ruby gems with retry logic..." ; \
+    function Install-GemWithRetry { \
+        param([string]$gemName, [string]$version, [int]$retries = 5) ; \
+        for ($i = 0; $i -lt $retries; $i++) { \
+            gem install $gemName -v $version --no-document --platform ruby && break || \
+            Write-Output "Failed to install $gemName. Retrying in 5 seconds... ($($i+1)/$retries)" ; \
+            Start-Sleep -Seconds 5 ; \
+        } ; \
+        if (-not (gem list -i $gemName -v $version)) { throw "Failed to install $gemName after $retries attempts." } ; \
+    } ; \
+    Install-GemWithRetry -gemName 'cool.io' -version '1.7.1' ; \
+    Install-GemWithRetry -gemName 'oj' -version '3.3.10' ; \
+    Install-GemWithRetry -gemName 'fluentd' -version '1.16.3' ; \
+    Install-GemWithRetry -gemName 'win32-service' -version '1.0.1' ; \
+    Install-GemWithRetry -gemName 'win32-ipc' -version '0.7.0' ; \
+    Install-GemWithRetry -gemName 'win32-event' -version '0.6.3' ; \
+    Install-GemWithRetry -gemName 'windows-pr' -version '1.2.6' ; \
+    Install-GemWithRetry -gemName 'tomlrb' -version '2.0.1' ; \
+    Install-GemWithRetry -gemName 'gyoku' -version '1.3.1' ; \
+    Install-GemWithRetry -gemName 'ipaddress' -version '0.8.3' ; \
+    Install-GemWithRetry -gemName 'jwt' -version '2.7.1' ; \
+    gem sources --clear-all
+
+# Optional: Run `ridk install` to add MSYS2 dev tools (optional if MSYS2 update fails)
+RUN refreshenv && \
+    ridk install 3 && \
+    echo gem: --no-document >> C:\ProgramData\gemrc
 
 # Remove gem cache and chocolatey
 RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'; Remove-Item -Recurse -Force 'C:\Users\ContainerAdministrator\AppData\Local\Temp'"

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -10,56 +10,37 @@ RUN reg add "HKLM\Software\Wow6432Node\Microsoft\Cryptography\Wintrust\Config" /
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
-# Set the Chocolatey version
 ENV chocolateyVersion 1.4.0
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+# Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
+RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
+&& choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 
-# Install Chocolatey
-RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; \
-    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+RUN powershell -Command "Write-Output 'Configuring MSYS2 mirrors...'; \
+    $MirrorFileMsys = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.msys'; \
+    $MirrorFileMingw = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.mingw'; \
+    (Get-Content $MirrorFileMsys) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMsys; \
+    (Get-Content $MirrorFileMingw) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMingw; \
+    Add-Content -Path $MirrorFileMsys -Value 'Server = https://repo.msys2.org/msys/$arch'; \
+    Add-Content -Path $MirrorFileMingw -Value 'Server = https://repo.msys2.org/mingw/$arch'; \
+    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait;"
 
-# Install Ruby and MSYS2 using Chocolatey with specified install directories
-RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" && \
-    choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
-
-# Set environment variables for paths
-RUN setx PATH "%PATH%;C:\ruby31\bin;C:\ruby31\msys64\usr\bin"
-
-# Refresh environment and set up MSYS2 mirrors and retry logic for gem installs
-SHELL ["powershell", "-Command"]
-
-RUN Write-Output "Configuring MSYS2 mirrors..." ; \
-    $MirrorFileMsys = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.msys' ; \
-    $MirrorFileMingw = 'C:\ruby31\msys64\etc\pacman.d\mirrorlist.mingw' ; \
-    (Get-Content $MirrorFileMsys) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMsys ; \
-    (Get-Content $MirrorFileMingw) -replace '^(Server = .*)$', '#$1' | Set-Content $MirrorFileMingw ; \
-    Add-Content -Path $MirrorFileMsys -Value 'Server = https://repo.msys2.org/msys/$arch' ; \
-    Add-Content -Path $MirrorFileMingw -Value 'Server = https://repo.msys2.org/mingw/$arch' ; \
-    Start-Process 'C:\ruby31\msys64\usr\bin\bash.exe' -ArgumentList '-c', 'pacman -Syuu --noconfirm' -NoNewWindow -Wait ; \
-    refreshenv; ridk install 3; echo gem: --no-document >> C:\ProgramData\gemrc
-
-# Install required gems with retry logic for network stability
-RUN Write-Output 'Installing Ruby gems with retry logic...'; \
-    function Install-GemWithRetry { \
-        param([string]$gemName, [string]$version, [int]$retries = 5); \
-        for ($i = 0; $i -lt $retries; $i++) { \
-            if (gem install $gemName -v $version --no-document --platform ruby) { break } else { \
-            Write-Output 'Failed to install $gemName. Retrying in 5 seconds... ($($i+1)/$retries)'; \
-            Start-Sleep -Seconds 5; } \
-        }; \
-        if (-not (gem list -i $gemName -v $version)) { throw 'Failed to install $gemName after $retries attempts.' }; \
-    }; \
-    Install-GemWithRetry -gemName 'cool.io' -version '1.7.1'; \
-    Install-GemWithRetry -gemName 'oj' -version '3.3.10'; \
-    Install-GemWithRetry -gemName 'fluentd' -version '1.16.3'; \
-    Install-GemWithRetry -gemName 'win32-service' -version '1.0.1'; \
-    Install-GemWithRetry -gemName 'win32-ipc' -version '0.7.0'; \
-    Install-GemWithRetry -gemName 'win32-event' -version '0.6.3'; \
-    Install-GemWithRetry -gemName 'windows-pr' -version '1.2.6'; \
-    Install-GemWithRetry -gemName 'tomlrb' -version '2.0.1'; \
-    Install-GemWithRetry -gemName 'gyoku' -version '1.3.1'; \
-    Install-GemWithRetry -gemName 'ipaddress' -version '0.8.3'; \
-    Install-GemWithRetry -gemName 'jwt' -version '2.7.1'; \
-    gem sources --clear-all
+# gangams - optional MSYS2 update via ridk failing in merged docker file so skipping that since we dont need optional update
+RUN refreshenv \
+&& ridk install 3 \
+&& echo gem: --no-document >> C:\ProgramData\gemrc \
+&& gem install cool.io -v 1.7.1 --platform ruby \
+&& gem install oj -v 3.3.10 \
+&& gem install fluentd -v 1.16.3 \
+&& gem install win32-service -v 1.0.1 \
+&& gem install win32-ipc -v 0.7.0 \
+&& gem install win32-event -v 0.6.3 \
+&& gem install windows-pr -v 1.2.6 \
+&& gem install tomlrb -v 2.0.1 \
+&& gem install gyoku -v 1.3.1 \
+&& gem install ipaddress -v 0.8.3 \
+&& gem install jwt -v 2.7.1 \
+&& gem sources --clear-all
 
 # Remove gem cache and chocolatey
 RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'; Remove-Item -Recurse -Force 'C:\Users\ContainerAdministrator\AppData\Local\Temp'"

--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -444,17 +444,40 @@ func getAgentConfiguration(imdsAccessToken string) (configurationId string, chan
 		return configurationId, channelId, err
 	}
 
-	if len(agentConfiguration.Configurations[0].Content.Channels) == 0 {
-		message := "getAgentConfiguration: Received empty agentConfiguration.Configurations[0].Content.Channels"
-		Log(message)
-		SendException(message)
-		return configurationId, channelId, err
+	for _, config := range agentConfiguration.Configurations {
+		if len(config.Content.Channels) == 0 {
+			// this is expected because AMCS will return agent config based on OS Type. For example, syslog is not supported on windows hence config will not have channels and data sources
+			message := "getAgentConfiguration: Received empty config.Content.Channels"
+			Log(message)
+			continue
+		}
+
+		configurationId = config.Configurationid
+		for _, channel := range config.Content.Channels {
+			if channel.ID != "" {
+				channelId = channel.ID
+				break
+			}
+		}
+
+		if !ContainerLogV2ConfigMap && len(config.Content.Extensionconfigurations.Containerinsights) > 0 {
+			for _, ciExtensionInstance := range config.Content.Extensionconfigurations.Containerinsights {
+				if ciExtensionInstance.Extensionsettings != nil && ciExtensionInstance.Extensionsettings.DataCollectionSettings != nil {
+					ContainerLogSchemaV2 = ciExtensionInstance.Extensionsettings.DataCollectionSettings.EnableContainerLogV2
+					break
+				} else {
+					Log("getAgentConfiguration: Extensionsettings or DataCollectionSettings is nil")
+				}
+			}
+		}
+		break
 	}
 
-	configurationId = agentConfiguration.Configurations[0].Configurationid
-	channelId = agentConfiguration.Configurations[0].Content.Channels[0].ID
-	if !ContainerLogV2ConfigMap && len(agentConfiguration.Configurations[0].Content.Extensionconfigurations.Containerinsights) > 0 {
-		ContainerLogSchemaV2 = agentConfiguration.Configurations[0].Content.Extensionconfigurations.Containerinsights[0].Extensionsettings.DataCollectionSettings.EnableContainerLogV2
+	if configurationId == "" || channelId == "" {
+		message := "getAgentConfiguration: Failed to obtain configurationId or channelId"
+		Log(message)
+		SendException(message)
+		return configurationId, channelId, errors.New(message)
 	}
 	Log("getAgentConfiguration: obtained configurationId: %s, channelId: %s", configurationId, channelId)
 	Log("Info getAgentConfiguration: end")

--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -462,12 +462,7 @@ func getAgentConfiguration(imdsAccessToken string) (configurationId string, chan
 
 		if !ContainerLogV2ConfigMap && len(config.Content.Extensionconfigurations.Containerinsights) > 0 {
 			for _, ciExtensionInstance := range config.Content.Extensionconfigurations.Containerinsights {
-				if ciExtensionInstance.Extensionsettings != nil && ciExtensionInstance.Extensionsettings.DataCollectionSettings != nil {
-					ContainerLogSchemaV2 = ciExtensionInstance.Extensionsettings.DataCollectionSettings.EnableContainerLogV2
-					break
-				} else {
-					Log("getAgentConfiguration: Extensionsettings or DataCollectionSettings is nil")
-				}
+				ContainerLogSchemaV2 = ciExtensionInstance.Extensionsettings.DataCollectionSettings.EnableContainerLogV2
 			}
 		}
 		break


### PR DESCRIPTION
This PR has following changes

1. Fix build failures related to buildx image pull and trivy db throttling
2.  Handle empty agent/dcr config in Go http client -
      AMCS returns the DCR config with config with no data sources/channels for the /agentConfig call if the AKS/Arc K8s cluster has Prom DCR. Because Go client expecting non-empty config, its keep retrying.
      
      This fix handles the empty agent configuration returned by AMCS.