### PR TITLE
fluent-bit-upgrade-3.0.6 for linux

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -81,7 +81,7 @@ docker_cimprov_version=$(sudo tdnf list installed | grep docker-cimprov | awk '{
 echo "DOCKER_CIMPROV_VERSION=$docker_cimprov_version" >> packages_version.txt
 
 #install fluent-bit
-sudo tdnf install fluent-bit-2.2.3 -y
+sudo tdnf install fluent-bit-3.0.6 -y
 echo "$(fluent-bit --version)" >> packages_version.txt
 
 # install fluentd using the mariner package


### PR DESCRIPTION
This pull request includes an update to the `setup.sh` script for Kubernetes on Linux. The most important change is the upgrade of the `fluent-bit` package to 3.0.6 version which latest available version in package repo.

Package version update:

* [`kubernetes/linux/setup.sh`](diffhunk://#diff-41e13b2078423187d4de7802d178ff603e09a6aec1c0c653dbe02834cfd15315L84-R84): Updated `fluent-bit` installation from version 2.2.3 to version 3.0.6 to ensure the latest features and security fixes are included.

Following scenarios being validated
1. Both legacy and MSI mode for all the data flows
2. All the multiline features

Plan to validate across all the CI/CD clusters.
