### PR TITLE
Gangams/windows telegraf update

### DIFF
--- a/build/common/installer/scripts/tomlparser-prom-customconfig.rb
+++ b/build/common/installer/scripts/tomlparser-prom-customconfig.rb
@@ -114,11 +114,6 @@ def createPrometheusPluginsWithNamespaceSetting(monitorKubernetesPods, monitorKu
     new_contents = new_contents.gsub("$AZMON_TELEGRAF_CUSTOM_PROM_SCRAPE_SCOPE", "# Commenting this out since new plugins will be created per namespace\n  # $AZMON_TELEGRAF_CUSTOM_PROM_SCRAPE_SCOPE")
 
     timeout_config_key = "timeout"
-    if is_windows?
-      # For windows, the timeout config key is different because of old version of telegraf
-      timeout_config_key = "response_timeout"
-    end
-
     pluginConfigsWithNamespaces = ""
     monitorKubernetesPodsNamespaces.each do |namespace|
       if !namespace.nil?

--- a/build/windows/installer/conf/telegraf.conf
+++ b/build/windows/installer/conf/telegraf.conf
@@ -124,7 +124,7 @@
 #Prometheus Custom Metrics
 [[inputs.prometheus]]
   interval = "$AZMON_TELEGRAF_CUSTOM_PROM_INTERVAL"
-  
+
   ## Scrape Kubernetes pods for the following prometheus annotations:
   ## - prometheus.io/scrape: Enable scraping for this pod
   ## - prometheus.io/scheme: If the metrics endpoint is secured then you will need to
@@ -150,7 +150,7 @@
   # bearer_token_string = "abc_123"
 
   ## Specify timeout duration for slower prometheus clients (default is 3s)
-  response_timeout = "15s"
+  timeout = "15s"
 
   ## Optional TLS Config
   tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -102,6 +102,7 @@ ENV APPLICATIONINSIGHTS_AUTH "NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi"
 ENV AZMON_COLLECT_ENV False
 ENV CI_CERT_LOCATION "C://oms.crt"
 ENV CI_KEY_LOCATION "C://oms.key"
+ENV TELEGRAF_CONFIG_PATH "C://etc//telegraf//telegraf.conf"
 
 # Delete unnecessary files
 RUN powershell -Command "Remove-Item -Recurse -Force 'C:\ruby31\share\doc\ruby\html\js'; \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -102,7 +102,7 @@ ENV APPLICATIONINSIGHTS_AUTH "NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi"
 ENV AZMON_COLLECT_ENV False
 ENV CI_CERT_LOCATION "C://oms.crt"
 ENV CI_KEY_LOCATION "C://oms.key"
-ENV TELEGRAF_CONFIG_PATH "C://etc//telegraf//telegraf.conf"
+ENV TELEGRAF_CONFIG_PATH "/etc/telegraf/telegraf.conf"
 
 # Delete unnecessary files
 RUN powershell -Command "Remove-Item -Recurse -Force 'C:\ruby31\share\doc\ruby\html\js'; \

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -812,6 +812,15 @@ function Start-Telegraf {
             Write-Host "Failed to set environment variable NODE_IP for target 'machine' since it is either null or empty"
         }
 
+        $telegrafConfigPath = [System.Environment]::GetEnvironmentVariable("TELEGRAF_CONFIG_PATH", "process")
+        if (![string]::IsNullOrEmpty($telegrafConfigPath)) {
+            [System.Environment]::SetEnvironmentVariable("TELEGRAF_CONFIG_PATH", $telegrafConfigPath, "machine")
+            Write-Host "Successfully set environment variable TELEGRAF_CONFIG_PATH - $($telegrafConfigPath) for target 'machine'..."
+        }
+        else {
+            Write-Host "Failed to set environment variable TELEGRAF_CONFIG_PATH for target 'machine' since it is either null or empty"
+        }
+
         $hostName = [System.Environment]::GetEnvironmentVariable("HOSTNAME", "process")
         Write-Host "nodename: $($hostName)"
         Write-Host "replacing nodename in telegraf config"
@@ -843,8 +852,8 @@ function Start-Telegraf {
             }
             Write-Host "Running telegraf service in test mode"
             C:\opt\telegraf\telegraf.exe --config "C:\etc\telegraf\telegraf.conf" --test
-            Write-Host "Starting telegraf service"
-            C:\opt\telegraf\telegraf.exe --service start
+            Write-Host "Starting telegraf service with auto restart"
+            C:\opt\telegraf\telegraf.exe --service-auto-restart
 
             # Trying to start telegraf again if it did not start due to fluent bit not being ready at startup
             Get-Service telegraf | findstr Running

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -42,7 +42,7 @@ Write-Host ('Finished Installing Fluentbit')
 Write-Host ('Installing Telegraf');
 try {
     # For next telegraf update, make sure to update config changes in telegraf.conf, tomlparser-prom-customconfig.rb and tomlparser-osm-config.rb
-    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.30.0_windows_amd64.zip'
+    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.25.0_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -42,7 +42,7 @@ Write-Host ('Finished Installing Fluentbit')
 Write-Host ('Installing Telegraf');
 try {
     # For next telegraf update, make sure to update config changes in telegraf.conf, tomlparser-prom-customconfig.rb and tomlparser-osm-config.rb
-    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.25.0_windows_amd64.zip'
+    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.26.0_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -42,7 +42,7 @@ Write-Host ('Finished Installing Fluentbit')
 Write-Host ('Installing Telegraf');
 try {
     # For next telegraf update, make sure to update config changes in telegraf.conf, tomlparser-prom-customconfig.rb and tomlparser-osm-config.rb
-    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.26.0_windows_amd64.zip'
+    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.33.1_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -42,7 +42,7 @@ Write-Host ('Finished Installing Fluentbit')
 Write-Host ('Installing Telegraf');
 try {
     # For next telegraf update, make sure to update config changes in telegraf.conf, tomlparser-prom-customconfig.rb and tomlparser-osm-config.rb
-    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.24.2_windows_amd64.zip'
+    $telegrafUri='https://dl.influxdata.com/telegraf/releases/telegraf-1.30.0_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue


### PR DESCRIPTION
This PR upgrade to latest available telegraf version for windows and update the telegraf configuration file to support the latest version.

Telegraf started with --service-auto-restart instead of start since start doesnt work after telegraf version 1.25.1. 

This should also eliminate need of enabling the liveness probe on telegraf since telegraf will be restarted on failures.

Following scenarios verified ..

1. Both Windows Server 2019 and Windows Server 2022
2. Prometheus scraping on both SKUs
3. Resource usage between current vs new

