### PR TITLE
update golang version to fix CVEs related stdlib 

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -13,10 +13,10 @@ jobs:
   Golang-Tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go 1.22.5
+      - name: Setup Go 1.23.5
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.5'
+          go-version: '1.23.5'
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Run unit tests

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -332,7 +332,7 @@ jobs:
     # Find in cache or download a specific version of Go and add it to the PATH.
   - task: GoTool@0
     inputs:
-      version: '1.22.5'
+      version: '1.23.5'
 
   - bash: |
         cd $(System.DefaultWorkingDirectory)/build/linux/

--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -13,8 +13,8 @@ function Install-Go {
         exit 1
     }
 
-   $url = "https://go.dev/dl/go1.22.5.windows-amd64.msi"
-   $output = Join-Path -Path $tempGo -ChildPath "go1.22.5.windows-amd64.msi"
+   $url = "https://go.dev/dl/go1.23.5.windows-amd64.msi"
+   $output = Join-Path -Path $tempGo -ChildPath "go1.23.5.windows-amd64.msi"
    Write-Host("downloading go msi into directory path : " + $output + "  ...")
    Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop
    Write-Host("downloading of go msi into directory path : " + $output + "  completed")
@@ -146,7 +146,7 @@ function Install-cmetrics() {
 	git submodule sync
 	git -c protocol.version=2 submodule update --init --force --depth=1
 	git submodule foreach git config --local gc.auto 0
-	cmake --fresh -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX="$destinationPath" . 
+	cmake --fresh -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX="$destinationPath" .
 	make
 	make install
 }
@@ -155,7 +155,7 @@ function Install-cmetrics() {
 # https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download
 $ProgressPreference = 'SilentlyContinue'
 
-Write-Host "Install GO 1.22.5 version"
+Write-Host "Install GO 1.23.5 version"
 Install-Go
 Write-Host "Install Build dependencies"
 Build-Dependencies

--- a/source/plugins/go/input/go.mod
+++ b/source/plugins/go/input/go.mod
@@ -1,8 +1,6 @@
 module Docker-Provider/source/plugins/go/input
 
-go 1.21.0
-
-toolchain go1.22.5
+go 1.23.5
 
 require github.com/calyptia/plugin v1.0.2
 

--- a/source/plugins/go/src/go.mod
+++ b/source/plugins/go/src/go.mod
@@ -1,8 +1,6 @@
 module Docker-Provider/source/plugins/go/src
 
-go 1.21
-
-toolchain go1.22.5
+go 1.23.5
 
 require (
 	github.com/Microsoft/go-winio v0.6.1


### PR DESCRIPTION
This pull request includes updates to various files to upgrade the Go version from 1.22.5 to 1.23.5 across the project. The most important changes include modifications in configuration files, scripts, and module files to ensure compatibility with the new Go version.

### Go Version Upgrade:

* [`.github/workflows/run_unit_tests.yml`](diffhunk://#diff-394fcfd605d72aeb92748c54045208916c0dd638a4c1e09f2b15cc4ceffbcc48L16-R19): Updated the Go setup step to use version 1.23.5.
* [`.pipelines/azure_pipeline_mergedbranches.yaml`](diffhunk://#diff-2ee1d450a2b4018224d6c91140a21692f8e2fe7652f9c06359493a9fe8a2785dL335-R335): Updated the GoTool task to use version 1.23.5.
* [`scripts/build/windows/install-build-pre-requisites.ps1`](diffhunk://#diff-3b93f158c0288f1eaaea49c9f5d439061deee1ecf863a4a7bb3041ee97f313b8L16-R17): Updated the Go download URL and output file name to version 1.23.5. [[1]](diffhunk://#diff-3b93f158c0288f1eaaea49c9f5d439061deee1ecf863a4a7bb3041ee97f313b8L16-R17) [[2]](diffhunk://#diff-3b93f158c0288f1eaaea49c9f5d439061deee1ecf863a4a7bb3041ee97f313b8L158-R158)
* [`source/plugins/go/input/go.mod`](diffhunk://#diff-dec75be1d43c9293f45a8af5d251c23b4eb8a98dbfb850d68367738d09aa14cbL3-R3): Updated the Go version to 1.23.5 and removed the toolchain specification.
* [`source/plugins/go/src/go.mod`](diffhunk://#diff-4c8eb2bbf5d4a6f8f0d84217e96f7fb96f5d919c8f8e2519e5f99e86cd3f9262L3-R3): Updated the Go version to 1.23.5 and removed the toolchain specification.