### PR TITLE
Windows build fix

### DIFF
--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -18,7 +18,7 @@ RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 
 # gangams - optional MSYS2 update via ridk failing in merged docker file so skipping that since we dont need optional update
 RUN refreshenv \
-&& ridk install 3 \
+&& ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.7.1 --platform ruby \
 && gem install oj -v 3.3.10 \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -20,7 +20,7 @@ RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 RUN refreshenv \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
-# && gem install cool.io -v 1.7.1 --platform ruby \
+&& gem install cool.io -v 1.9.0 --platform ruby \
 && gem install oj -v 3.16.10 \
 && gem install fluentd -v 1.16.3 \
 && gem install win32-service -v 1.0.1 \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -20,8 +20,8 @@ RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 RUN refreshenv \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
-&& gem install cool.io -v 1.7.1 --platform ruby \
-&& gem install oj -v 3.3.10 \
+# && gem install cool.io -v 1.7.1 --platform ruby \
+&& gem install oj -v 3.16.10 \
 && gem install fluentd -v 1.16.3 \
 && gem install win32-service -v 1.0.1 \
 && gem install win32-ipc -v 0.7.0 \


### PR DESCRIPTION
This pull request addresses the windows build failure by modifying the installation of Ruby and several gems in the Dockerfile.

Key changes include:

* Updated the `ridk install` command to include both steps 2 and 3 instead of just step 3 as per the [ruby integration documentation](https://community.chocolatey.org/packages/msys2#psdsc).
* Upgraded the `cool.io` gem from version 1.7.1 to 1.9.0 to fix the build failure after the system update.
* Upgraded the `oj` gem from version 3.3.10 to 3.16.10 to fix the build failure after the system update.