### PR TITLE
ai_prod logging cleanup

### DIFF
--- a/appmonitoring/ts/src/AdmissionReviewValidator.ts
+++ b/appmonitoring/ts/src/AdmissionReviewValidator.ts
@@ -2,44 +2,83 @@
 import { logger, RequestMetadata } from "./LoggerWrapper.js";
 import { IAdmissionReview } from "./RequestDefinition.js";
 
+export interface IValidationResult {
+    isValid: boolean;
+    message?: string;
+}
+
 export class AdmissionReviewValidator {
-    public static Validate(content: IAdmissionReview, operationId: string, requestMetadata: RequestMetadata) {
-        let returnValue = true;
-        logger.info(`Validating content ${this.uid(content)}, ${JSON.stringify(content)}`, operationId, requestMetadata);
+    public static Validate(content: IAdmissionReview): IValidationResult { 
 
         if (isNullOrUndefined(content)) {
-            logger.error(`Null content ${this.uid(content)}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if (isNullOrUndefined(content.request)
+            return {
+                message: `Empty request`,
+                isValid: false
+            };
+        }
+
+        if (isNullOrUndefined(content.kind)) {
+            return {
+                message: `Invalid empty request kind ${content.request?.uid}`,
+                isValid: false
+            };
+        } 
+
+        if(content.kind !== "AdmissionReview" && content.kind !== "Testing") {
+            return {
+                message: `Invalid kind of the incoming document, the webhook only supports AdmissionReview: ${content.kind} ${content.request?.uid}`,
+                isValid: false
+            };
+        }
+        
+        if (isNullOrUndefined(content.request)
             || isNullOrUndefined(content.request.operation)) {
-            logger.error(`Invalid incoming operation ${this.uid(content)}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if (isNullOrUndefined(content.kind)) {
-            logger.error(`Invalid empty kind ${this.uid(content)}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if (isNullOrUndefined(content.request.object)
-            || isNullOrUndefined(content.request.object.spec)
-            || isNullOrUndefined(content.request.object.spec.template.spec)) {
-            logger.error(`Missing object or object.spec in template, DELETE operations are not supported ${this.uid(content)}, ${content}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if(content.request.resource?.resource?.toLowerCase() !== "deployments") {
-            logger.error(`Invalid incoming resource type: ${content.request.resource.resource}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if(content.request.operation.toUpperCase() !== "CREATE" && content.request.operation.toUpperCase() !== "UPDATE") {
-            logger.error(`Invalid operation, the webhook only supports CREATE and UPDATE: ${content.request}`, operationId, requestMetadata);
-            returnValue = false;
-        } else if(content.kind !== "AdmissionReview" && content.kind !== "Testing") {
-            logger.error(`Invalid kind of the incoming document, the webhook only supports AdmissionReview: ${content.kind}`, operationId, requestMetadata);
-            returnValue = false;
-        }
+            return {
+                message: `Invalid incoming operation ${content.request.uid}`,
+                isValid: false
+            };
+        } 
 
-        return returnValue;
-    }
+        if (content.request.operation.toUpperCase() !== "CREATE" 
+            && content.request.operation.toUpperCase() !== "UPDATE") {
+            return {
+                message: `Invalid operation, the webhook only supports CREATE and UPDATE: ${content.request.operation} ${content.request.uid}`,
+                isValid: false
+            };
+        } 
 
-    private static uid(content: IAdmissionReview): string {
-        if (content && content.request && content.request.uid) {
-            return content.request.uid;
+        if (isNullOrUndefined(content.request.object)) {           
+            return {
+                message: `Missing config object in request, DELETE operations are not supported ${content.request.uid}, ${content}`,
+                isValid: false
+            };
+        } 
+
+        if (isNullOrUndefined(content.request.object.spec)
+            || isNullOrUndefined(content.request.object.spec.template.spec)) {           
+            return {
+                message: `Missing object.spec or template.spec, DELETE operations are not supported ${content.request.uid}, ${content}`,
+                isValid: false
+            };
+        } 
+
+        if (isNullOrUndefined(content.request.object.metadata.namespace)){
+            return {
+                message: `Missing object.metadata.namespace ${content.request.uid}`,
+                isValid: false
+            };
         }
-        return "";
+ 
+        if (content.request.resource?.resource?.toLowerCase() === "deployments") {
+            return { 
+                message: "deployments",
+                isValid: true
+            };
+        } else {
+            return {
+                message: `Unsupported incoming resource type: ${content.request.resource.resource}`,
+                isValid: false
+            };
+        }
     }
 }

--- a/appmonitoring/ts/src/K8sWatcher.ts
+++ b/appmonitoring/ts/src/K8sWatcher.ts
@@ -25,7 +25,7 @@ export class K8sWatcher {
                 
                 logger.addHeartbeatMetric(HeartbeatMetrics.ApiServerCallErrorCount, 1);
 
-                logger.appendHeartbeatLog(HeartbeatLogs.ApiServerTopExceptionsEncountered, JSON.stringify(ex));
+                logger.appendHeartbeatLog(HeartbeatLogs.ApiServerTopExceptionsEncountered, 'K8S watch error: ' + JSON.stringify(ex));
 
                 const requestMetadata = new RequestMetadata("CR watcher", crs);
                 logger.error(`K8s watch failure: ${e}`, operationId, requestMetadata);
@@ -92,8 +92,10 @@ export class K8sWatcher {
                             onNewCR(apiObj, true);
                         } else if (type === "BOOKMARK") {
                             latestResourceVersion = apiObj.metadata?.resourceVersion ?? latestResourceVersion;
+                        } else if (type === "ERROR") {
+                            logger.error(`Error object received: ${type}=${JSON.stringify(apiObj)}`, operationId, requestMetadata);
                         } else {
-                            logger.error(`Unknown object type: ${type}`, operationId, requestMetadata);
+                            logger.error(`Unknown object type: ${type}=${JSON.stringify(apiObj)}`, operationId, requestMetadata);
                         }
 
                         //logger.info(`apiObj: ${JSON.stringify(apiObj)}`);

--- a/appmonitoring/ts/src/LoggerWrapper.ts
+++ b/appmonitoring/ts/src/LoggerWrapper.ts
@@ -274,7 +274,9 @@ class LocalLogger {
                     message: logArray[j].message,
                     time: new Date(),
                     properties: {
-                        clusterMetadata: this.clusterMetadata
+                        clusterMetadata: this.clusterMetadata,
+                        count: logArray[j].count,
+                        logName: HeartbeatLogs[logName],
                     }
                 };
 

--- a/appmonitoring/ts/src/Mutator.ts
+++ b/appmonitoring/ts/src/Mutator.ts
@@ -1,7 +1,7 @@
 ﻿import { Patcher } from "./Patcher.js";
-import { logger, RequestMetadata, HeartbeatMetrics } from "./LoggerWrapper.js";
+import { logger, RequestMetadata, HeartbeatMetrics, HeartbeatLogs } from "./LoggerWrapper.js";
 import { PodInfo, IAdmissionReview, InstrumentationCR, AutoInstrumentationPlatforms, DefaultInstrumentationCRName } from "./RequestDefinition.js";
-import { AdmissionReviewValidator } from "./AdmissionReviewValidator.js";
+import { AdmissionReviewValidator, IValidationResult } from "./AdmissionReviewValidator.js";
 import { InstrumentationCRsCollection } from "./InstrumentationCRsCollection.js";
 
 export class Mutator {
@@ -21,38 +21,47 @@ export class Mutator {
         this.requestMetadata = new RequestMetadata(this.admissionReview?.request?.uid, this.crs);
     }
 
-    public async Mutate(): Promise<string> {
-        const response = this.newResponse();
+    public async Mutate(): Promise<IAdmissionReview> {
+        let response: IAdmissionReview;
 
         try {
             if (!this.admissionReview) {
-                throw `Admission review can't be null`;
+                // this shouldn't happen but helps with testing
+                throw `admissionReview can't be null`;
             }
+    
+            logger.info(`Validating content ${this.admissionReview.request?.uid}, ${JSON.stringify(this.admissionReview)}`, this.operationId, this.requestMetadata);
 
-            if (!AdmissionReviewValidator.Validate(this.admissionReview, this.operationId, this.requestMetadata)) {
-                logger.error(`Validation failed on original AdmissionReview: ${JSON.stringify(this.admissionReview)}`, this.operationId, this.requestMetadata);
-                throw `Validation of the incoming AdmissionReview failed: ${JSON.stringify(this.admissionReview?.request?.uid)}`;
+            const validationResult: IValidationResult = AdmissionReviewValidator.Validate(this.admissionReview);
+            if (!validationResult.isValid) {
+                logger.error(`Validation failed with ${validationResult.message} on original AdmissionReview: ${JSON.stringify(this.admissionReview)}`, this.operationId, this.requestMetadata);
+
+                response = this.createErrorResponse(this.admissionReview, 400, validationResult.message);
             } else {
                 logger.info(`Validation passed on original AdmissionReview: ${JSON.stringify(this.admissionReview)}`, this.operationId, this.requestMetadata);
+                
+                const patch: string = await this.mutateDeployment();                
+                response = this.createPatchResponse(this.admissionReview, patch);
             }
-
-            const patch: string = await this.mutateDeployment();
-            response.response.patch = patch;
-
-            return JSON.stringify(response);
         } catch (e) {
-            const exceptionMessage = `Exception encountered: ${e}${e?.stack ?? ""}`;
-
+            const exceptionMessage = `Mutate error: ${e}${e?.stack ?? ""}`;
             logger.addHeartbeatMetric(HeartbeatMetrics.AdmissionReviewActionableFailedCount, 1);
-        
+            logger.appendHeartbeatLog(HeartbeatLogs.AdmissionReviewTopExceptionsEncountered, exceptionMessage);        
             logger.error(exceptionMessage, this.operationId, this.requestMetadata);
             
-            response.response.patch = undefined;
-            response.response.status.code = 400;
-            response.response.status.message = exceptionMessage;
-
-            return JSON.stringify(response);
+            response = this.createErrorResponse(this.admissionReview, 500, exceptionMessage);
+        } finally{
+            if (response === undefined || response === null) {
+                const unexpectedError = `Unexpected null response in Mutator.Mutate`;
+                logger.error(unexpectedError + ' uid: '+ this.admissionReview.request?.uid, this.operationId, this.requestMetadata);
+                logger.addHeartbeatMetric(HeartbeatMetrics.AdmissionReviewActionableFailedCount, 1);
+                // not appending uid to the log because different uid values would make each error count 1 and it would be easily swamped by other errors
+                logger.appendHeartbeatLog(HeartbeatLogs.AdmissionReviewTopExceptionsEncountered, unexpectedError);
+                response = this.createErrorResponse(this.admissionReview, 500, unexpectedError);
+            }           
         }
+        
+        return response;
     }
 
     /**
@@ -62,10 +71,7 @@ export class Mutator {
     private async mutateDeployment(): Promise<string> {
         const podInfo: PodInfo = this.getPodInfo();
         
-        const namespace: string = this.admissionReview.request.object.metadata.namespace;
-        if (!namespace) {
-            throw `Could not determine the namespace of the incoming object`;
-        }
+        const namespace: string = this.admissionReview.request.object.metadata.namespace;   
 
          // find an appropriate CR that dictates whether and how we should mutate
         const crNameToUse: string = this.pickCR();
@@ -101,32 +107,44 @@ export class Mutator {
             clusterName);
 
         const patchDataString: string = JSON.stringify(patchData);
-        logger.info(`Mutated a deployment, returning: ${patchDataString}`, this.operationId, this.requestMetadata);
+
+        logger.info(`Mutation of requested: ${JSON.stringify(this.admissionReview.request.object)}`, this.operationId, this.requestMetadata);
+        logger.info(`Mutation is returning: ${patchDataString}`, this.operationId, this.requestMetadata);        
 
         return Buffer.from(patchDataString).toString("base64");
     }           
 
-    private newResponse() {
-        const response = {
-            apiVersion: "admission.k8s.io/v1",
-            kind: "AdmissionReview",
+
+    private createPatchResponse(admissionReview: IAdmissionReview, patch: string): IAdmissionReview {
+        return <IAdmissionReview>{
+            apiVersion: admissionReview?.apiVersion ?? "admission.k8s.io/v1",
+            kind: admissionReview?.kind ?? "AdmissionReview",
             response: {
-                allowed: true, // we only mutate, not admit, so this should always be true as we never want to block any of the customer's API calls
-                patch: undefined, // JsonPatch document describing the mutation
+                allowed: true, 
+                patch: patch, // JsonPatch document describing the mutation
                 patchType: "JSONPatch",
-                uid: "", // must match the uid of the incoming AdmissionReview,
+                uid: admissionReview?.request?.uid,
                 status: {
                     code: 200, // indicate the type of success/error to k8s
                     message: "OK"
                 }
             },
+        }; 
+    }
+
+    private createErrorResponse(admissionReview: IAdmissionReview, statusCode?: number, errorMessage?: string): IAdmissionReview {
+        return <IAdmissionReview>{
+            apiVersion: admissionReview?.apiVersion ?? "admission.k8s.io/v1",
+            kind: admissionReview?.kind ?? "AdmissionReview",
+            response: {
+                allowed: false,
+                uid: admissionReview?.request?.uid,
+                status: {
+                    code: statusCode ?? 400, // indicate the type of success/error to k8s
+                    message: errorMessage ?? "Error"
+                }
+            },
         };
-
-        response.apiVersion = this.admissionReview?.apiVersion;
-        response.response.uid = this.admissionReview?.request?.uid;
-        response.kind = this.admissionReview?.kind;
-
-        return response;
     }
 
     private getPodInfo(): PodInfo {

--- a/appmonitoring/ts/src/Patcher.ts
+++ b/appmonitoring/ts/src/Patcher.ts
@@ -1,5 +1,5 @@
 ﻿import { Mutations } from "./Mutations.js";
-import { PodInfo, IContainer, ISpec, IVolume, IEnvironmentVariable, AutoInstrumentationPlatforms, IVolumeMount, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName, InstrumentationCR, IInstrumentationState, IMetadata, IAnnotations, IObjectType } from "./RequestDefinition.js";
+import { PodInfo, IContainer, ISpec, IVolume, IEnvironmentVariable, AutoInstrumentationPlatforms, IVolumeMount, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName, InstrumentationCR, IInstrumentationState, IMetadata, IAnnotations, IKubeObjectType } from "./RequestDefinition.js";
 
 export class Patcher {
 
@@ -9,7 +9,7 @@ export class Patcher {
      * Calculates a JsonPatch string describing the difference between the old (incoming) and new (outgoing) spec
      * The spec is also patched in-place
     */
-    public static PatchObject(obj: IObjectType, cr: InstrumentationCR, podInfo: PodInfo, platforms: AutoInstrumentationPlatforms[], armId: string, armRegion: string, clusterName: string): object[] {
+    public static PatchObject(obj: IKubeObjectType, cr: InstrumentationCR, podInfo: PodInfo, platforms: AutoInstrumentationPlatforms[], armId: string, armRegion: string, clusterName: string): object[] {
         if (!obj?.spec) {
             throw `Unable to parse request.object.spec in AdmissionReview: ${obj}`;
         }
@@ -17,7 +17,7 @@ export class Patcher {
         // remove all mutation (in case it is already mutated)
         this.unpatch(obj);
 
-        // mutate
+        // mutate, cr is null to remove the mutations
         this.patch(cr, platforms, obj, podInfo, armId, armRegion, clusterName);
 
         const jsonPatch: object[] = [
@@ -31,15 +31,15 @@ export class Patcher {
         return jsonPatch;
     }
 
-    private static patch(cr: InstrumentationCR, platforms: AutoInstrumentationPlatforms[], obj: IObjectType, podInfo: PodInfo, armId: string, armRegion: string, clusterName: string) {
-        if (cr) {
-            const spec: ISpec = obj.spec;
+    private static patch(cr: InstrumentationCR, platforms: AutoInstrumentationPlatforms[], kubeObj: IKubeObjectType, podInfo: PodInfo, armId: string, armRegion: string, clusterName: string) {
+        if (cr) { // only apply mutations if cr is not null, otherwise the mutations will be removed
+            const spec: ISpec = kubeObj.spec;
             const podSpec: ISpec = spec.template.spec;
         
             // add deployment-level annotation describing current mutation
-            obj.metadata = obj.metadata ?? <IMetadata>{};
-            obj.metadata.annotations = obj.metadata.annotations ?? <IAnnotations>{};
-            obj.metadata.annotations[InstrumentationAnnotationName] = JSON.stringify(<IInstrumentationState>{
+            kubeObj.metadata = kubeObj.metadata ?? <IMetadata>{};
+            kubeObj.metadata.annotations = kubeObj.metadata.annotations ?? <IAnnotations>{};
+            kubeObj.metadata.annotations[InstrumentationAnnotationName] = JSON.stringify(<IInstrumentationState>{
                 crName: cr.metadata.name,
                 crResourceVersion: cr.metadata.resourceVersion,
                 platforms: <string[]>platforms
@@ -116,7 +116,7 @@ export class Patcher {
     /**
      * Removes all mutations from a spec in-place
      */
-    private static unpatch(obj: IObjectType): void {
+    private static unpatch(obj: IKubeObjectType): void {
         const spec: ISpec = obj?.spec;
         const podSpec: ISpec = spec?.template?.spec;
         

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -131,7 +131,7 @@ export interface ISpec {
     containers?: IContainer[];
 }
 
-export interface IObjectType {
+export interface IKubeObjectType {
     kind: string;
     apiVersion: string;
     metadata: IMetadata;
@@ -154,16 +154,29 @@ export interface IRequest {
     namespace: string;
     operation: string;
     userInfo: IUserInfo;
-    object: IObjectType;
+    object: IKubeObjectType;
     oldObject: string;
     dryRun: string;
+}
+
+export interface IResponseStatus{
+    code: number;
+    message: string;
+}
+
+export interface IAdmissionReviewResponse {
+    uid: string;
+    allowed: boolean;
+    status?: IResponseStatus;
+    patch?: string;
+    patchType?: string;
 }
 
 export interface IAdmissionReview {
     kind: string;
     apiVersion: string;
     request: IRequest;
-    response?: object;
+    response?: IAdmissionReviewResponse;
 }
 
 export class PodInfo {

--- a/appmonitoring/ts/src/server.ts
+++ b/appmonitoring/ts/src/server.ts
@@ -127,13 +127,14 @@ https.createServer(options, (req, res) => {
                 }
 
                 const mutator: Mutator = new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, operationId);
-                const mutatedObject: string = await mutator.Mutate();
+                const mutateResponse: IAdmissionReview = await mutator.Mutate();
+                const mutatedObject = JSON.stringify(mutateResponse);
 
                 const end = Date.now();
                 
-                logger.info(`Done processing request in ${end - begin} ms for ${uid}. ${JSON.stringify(mutatedObject)}`, operationId, requestMetadata);
+                logger.info(`Done processing request in ${end - begin} ms for ${uid}. ${mutatedObject}`, operationId, requestMetadata);
                 
-                res.writeHead(200, { "Content-Type": "application/json" });
+                res.writeHead(mutateResponse.response?.status?.code ?? 200, { "Content-Type": "application/json" });
                 res.end(mutatedObject);
             } catch (e) {
                 const ex = logger.sanitizeException(e);

--- a/appmonitoring/ts/src/server.ts
+++ b/appmonitoring/ts/src/server.ts
@@ -139,7 +139,7 @@ https.createServer(options, (req, res) => {
                 const ex = logger.sanitizeException(e);
 
                 // e must not contain any customer content for privacy reasons, this exception is logged to a Microsoft-owned resource
-                logger.appendHeartbeatLog(HeartbeatLogs.AdmissionReviewTopExceptionsEncountered, JSON.stringify(ex));
+                logger.appendHeartbeatLog(HeartbeatLogs.AdmissionReviewTopExceptionsEncountered, 'AdmissionReview error:' + JSON.stringify(ex));
 
                 logger.error(`Error while processing request: ${JSON.stringify(e)}. Incoming payload: ${body}`, operationId, requestMetadata);
             }

--- a/appmonitoring/ts/src/tests/AdmissionReviewValidator.spec.ts
+++ b/appmonitoring/ts/src/tests/AdmissionReviewValidator.spec.ts
@@ -16,47 +16,47 @@ afterEach(() => {
 
 describe("AdmissionReviewValidator", () => {
     it("ValidateNull", () => {
-        expect(AdmissionReviewValidator.Validate(null, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(null, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.request = null
 
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields2", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.request.operation = null;
 
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields3", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.request.operation = "nope";
 
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields4", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.kind = null;
 
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields6", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.request.object = null;
 
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 
     it("ValidateMissingFields7", () => {
         const testSubject: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         testSubject.request.object.spec = null;
-        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata)).toBe(false);
+        expect(AdmissionReviewValidator.Validate(testSubject, null, requestMetadata).isValid).toBe(false);
     })
 });

--- a/appmonitoring/ts/src/tests/LoggerWrapper.spec.ts
+++ b/appmonitoring/ts/src/tests/LoggerWrapper.spec.ts
@@ -1,7 +1,6 @@
 ﻿import { expect, describe, it } from "@jest/globals";
 import { logger, HeartbeatMetrics, HeartbeatLogs } from "../LoggerWrapper.js";
 import { TelemetryClient } from "applicationinsights";
-import { MetricTelemetry, TraceTelemetry } from "applicationinsights/out/Declarations/Contracts/index.js";
 
 beforeEach(() => {
     logger.setUnitTestMode(true);

--- a/appmonitoring/ts/src/tests/Mutator.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutator.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { expect, describe, it } from "@jest/globals";
 import { Mutator } from "../Mutator.js";
-import { IAdmissionReview, IAnnotations, IMetadata, InstrumentationCR, AutoInstrumentationPlatforms, DefaultInstrumentationCRName, IInstrumentationState, IObjectType, InstrumentationAnnotationName } from "../RequestDefinition.js";
+import { IAdmissionReview, IAnnotations, IMetadata, InstrumentationCR, AutoInstrumentationPlatforms, DefaultInstrumentationCRName, IInstrumentationState, IKubeObjectType, InstrumentationAnnotationName } from "../RequestDefinition.js";
 import { TestObject2, TestObject4, crs, clusterArmId, clusterArmRegion } from "./testConsts.js";
 import { logger } from "../LoggerWrapper.js"
 import { InstrumentationCRsCollection } from "../InstrumentationCRsCollection.js";
@@ -15,7 +15,7 @@ afterEach(() => {
 
 describe("Mutator", () => {
     it("Null admission review", async () => {
-        const result = JSON.parse(await new Mutator(null, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(null, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         expect(result.response.allowed).toBe(true);
         expect(result.response.patchType).toBe("JSONPatch");
@@ -28,7 +28,7 @@ describe("Mutator", () => {
         const admissionReview: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         admissionReview.request.resource.resource = "Not a pod!";
 
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         expect(result.response.allowed).toBe(true);
         expect(result.response.patchType).toBe("JSONPatch");
@@ -41,7 +41,7 @@ describe("Mutator", () => {
         const admissionReview: IAdmissionReview = JSON.parse(JSON.stringify(TestObject2));
         admissionReview.request.operation = "DELETE";
 
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         expect(result.response.allowed).toBe(true);
         expect(result.response.patchType).toBe("JSONPatch");
@@ -98,7 +98,7 @@ describe("Mutator", () => {
         crs.Upsert(crDefault);
 
         // ACT
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         // ASSERT
         expect(result.response.allowed).toBe(true);
@@ -113,7 +113,7 @@ describe("Mutator", () => {
 
         expect((<[]>patches).length).toBe(1);
 
-        const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patches[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
 
         expect(annotationValue.crName).toBe(DefaultInstrumentationCRName);
@@ -152,7 +152,7 @@ describe("Mutator", () => {
         crs.Upsert(cr1);
 
         // ACT
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         // ASSERT
         expect(result.response.allowed).toBe(true);
@@ -167,7 +167,7 @@ describe("Mutator", () => {
 
         expect((<[]>patches).length).toBe(1);
 
-        const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patches[0]).value as IKubeObjectType;
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();        
     });
 
@@ -191,7 +191,7 @@ describe("Mutator", () => {
             admissionReview.request.object.spec.template.metadata = metadata;
 
              // ACT
-            const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+            const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
             
             // ASSERT
             expect(result.response.allowed).toBe(true);
@@ -255,7 +255,7 @@ describe("Mutator", () => {
         admissionReview.request.object.spec.template.metadata = metadata;
 
         // ACT
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         // ASSERT
         expect(result.response.allowed).toBe(true);
@@ -270,7 +270,7 @@ describe("Mutator", () => {
 
         expect((<[]>patches).length).toBe(1);
 
-        const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patches[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
         
         expect(annotationValue.crName).toBe(DefaultInstrumentationCRName);
@@ -331,7 +331,7 @@ describe("Mutator", () => {
         admissionReview.request.object.spec.template.metadata = metadata;
 
         // ACT
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         // ASSERT
         expect(result.response.allowed).toBe(true);
@@ -346,7 +346,7 @@ describe("Mutator", () => {
 
         expect((<[]>patches).length).toBe(1);
         
-        const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patches[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
         
         expect(annotationValue.crName).toBe(cr1.metadata.name);
@@ -389,7 +389,7 @@ describe("Mutator", () => {
         admissionReview.request.object.spec.template.metadata = metadata;
 
         // ACT
-        const result = JSON.parse(await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate());
+        const result = await new Mutator(admissionReview, crs, clusterArmId, clusterArmRegion, null).Mutate();
 
         // ASSERT
         expect(result.response.allowed).toBe(true);
@@ -404,7 +404,7 @@ describe("Mutator", () => {
 
         expect((<[]>patches).length).toBe(1);
 
-        const obj: IObjectType = (<any>patches[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patches[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
 
         expect(annotationValue.crName).toBe(crDefault.metadata.name);

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { expect, describe, it } from "@jest/globals";
 import { Mutations } from "../Mutations.js";
-import { IAdmissionReview, PodInfo, IContainer, IVolume, AutoInstrumentationPlatforms, IEnvironmentVariable, InstrumentationCR, IInstrumentationState, IObjectType, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName } from "../RequestDefinition.js";
+import { IAdmissionReview, PodInfo, IContainer, IVolume, AutoInstrumentationPlatforms, IEnvironmentVariable, InstrumentationCR, IInstrumentationState, IKubeObjectType, InstrumentationAnnotationName, EnableApplicationLogsAnnotationName } from "../RequestDefinition.js";
 import { Patcher } from "../Patcher.js";
 import { cr, clusterArmId, clusterArmRegion, clusterName, TestDeployment2 } from "./testConsts.js";
 import { logger } from "../LoggerWrapper.js"
@@ -39,7 +39,7 @@ describe("Patcher", () => {
 
         expect((<[]>result).length).toBe(1);
         
-        const obj: IObjectType = (<any>result[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>result[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
         expect(annotationValue.crName).toBe(cr1.metadata.name);
         expect(annotationValue.crResourceVersion).toBe("1");
@@ -100,7 +100,7 @@ describe("Patcher", () => {
 
         expect((<[]>result).length).toBe(1);
 
-        const obj: IObjectType = (<any>result[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>result[0]).value as IKubeObjectType;
         const annotationValue: IInstrumentationState = JSON.parse(obj.metadata.annotations[InstrumentationAnnotationName]) as IInstrumentationState;
 
         expect(annotationValue.crName).toBe(cr1.metadata.name);
@@ -166,7 +166,7 @@ describe("Patcher", () => {
 
         expect(unpatchResult.length).toBe(1);
 
-        const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>unpatchResult[0]).value as IKubeObjectType;
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -202,7 +202,7 @@ describe("Patcher", () => {
 
         expect(unpatchResult.length).toBe(1);
 
-        const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>unpatchResult[0]).value as IKubeObjectType;
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -236,7 +236,7 @@ describe("Patcher", () => {
 
         expect(unpatchResult.length).toBe(1);
 
-        const obj: IObjectType = (<any>unpatchResult[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>unpatchResult[0]).value as IKubeObjectType;
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
 
         expect((<any>unpatchResult[0]).op).toBe("replace");
@@ -271,7 +271,7 @@ describe("Patcher", () => {
 
         expect(patchResult.length).toBe(1);
 
-        const obj: IObjectType = (<any>patchResult[0]).value as IObjectType;
+        const obj: IKubeObjectType = (<any>patchResult[0]).value as IKubeObjectType;
         expect(obj.metadata?.annotations?.[InstrumentationAnnotationName]).toBeUndefined();
         
         expect((<any>patchResult[0]).op).toBe("replace");


### PR DESCRIPTION
Refactoring for readability and logging
- moved logs from validator to returned message, now logged by mutator and returned to K8S as a status message
- added static prefixes to error logs so it's clear where the error is being recorded
- added count to logged exception aggregations
- added a few type definitions in place of `object`
- moved some serializations around, `Mutate()` returns a strong type. The status in AdmissionReview.response is now used in the http response, unit tests don't need to deserialize