### PR TITLE
Fix build pipeline where it is broken for ARM64 Build

### DIFF
--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -44,7 +44,6 @@ RUN mkdir /busybin && busybox --install /busybin
 COPY --from=golang-builder /src/kubernetes/linux/Linux_ULINUX_1.0_*_64_Release/docker-cimprov-*.*.*-*.*.sh $tmpdir/
 COPY kubernetes/linux/setup.sh kubernetes/linux/main.sh kubernetes/linux/defaultpromenvvariables kubernetes/linux/defaultpromenvvariables-rs kubernetes/linux/defaultpromenvvariables-sidecar kubernetes/linux/mdsd.xml kubernetes/linux/envmdsd kubernetes/linux/logrotate.conf $tmpdir/
 COPY kubernetes/linux/mariner-official-extras.repo /etc/yum.repos.d/
-RUN sed -i "s|/x86_64/|/${TARGETARCH}/|g" /etc/yum.repos.d/mariner-official-extras.repo
 
 WORKDIR ${tmpdir}
 

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -44,6 +44,7 @@ RUN mkdir /busybin && busybox --install /busybin
 COPY --from=golang-builder /src/kubernetes/linux/Linux_ULINUX_1.0_*_64_Release/docker-cimprov-*.*.*-*.*.sh $tmpdir/
 COPY kubernetes/linux/setup.sh kubernetes/linux/main.sh kubernetes/linux/defaultpromenvvariables kubernetes/linux/defaultpromenvvariables-rs kubernetes/linux/defaultpromenvvariables-sidecar kubernetes/linux/mdsd.xml kubernetes/linux/envmdsd kubernetes/linux/logrotate.conf $tmpdir/
 COPY kubernetes/linux/mariner-official-extras.repo /etc/yum.repos.d/
+RUN sed -i "s|/x86_64/|/${TARGETARCH}/|g" /etc/yum.repos.d/mariner-official-extras.repo
 
 WORKDIR ${tmpdir}
 

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -13,11 +13,15 @@ sudo tdnf install ca-certificates-microsoft -y
 sudo update-ca-trust
 
 # sudo tdnf install ruby-3.1.3 -y
-tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
-wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20230330.tar.gz -O ruby-build.tar.gz
-tar -xzf ruby-build.tar.gz
-PREFIX=/usr/local ./ruby-build-*/install.sh
-ruby-build 3.1.3 /usr
+if [ "$ARCH" == "arm64" ]; then
+    sudo tdnf install ruby-3.1.3-1.cm2.aarch64 -y
+else
+    tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
+    wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20230330.tar.gz -O ruby-build.tar.gz
+    tar -xzf ruby-build.tar.gz
+    PREFIX=/usr/local ./ruby-build-*/install.sh
+    ruby-build 3.1.3 /usr
+fi
 
 # clean up the ruby-build files
 rm ruby-build.tar.gz


### PR DESCRIPTION
Fix build pipeline where it is broken for ARM64 Build, the ARM64 build constantly hitting issue where the ruby install failed issue. The build can fail during compilation (incompatible flags, missing arm64 headers/libs). Error: Failed to synchronize cache for repo 'CBL-Mariner Official Extras'
#43 xxxx Plugin error: repogpgcheck plugin error: failed to verify signature