### PR TITLE
Longw/governed release yaml arc

### DIFF
--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -59,24 +59,17 @@ extends:
         approval:
           workflow: approvalService
       jobs:
-      - job: Job_1
-        displayName: Agentless job
-        condition: succeeded()
-        timeoutInMinutes: 7200
-        pool: server
-        steps:
-        - task: ReleasePipeline.approvalservice-ext.a81eb944-f6e7-40bb-acb3-6f68822bc5ab.ApprovalTask@1
-          displayName: Approval service
-          inputs:
-            servicetreeguid: $(ServiceTreeGuid)
-          timeoutInMinutes: 7200
-      - job: Job_2
+      - job: Ev2
         displayName: Agent job - Ev2
         condition: succeeded()
         timeoutInMinutes: 0
         templateContext:
           type: releaseJob
           workflow: ev2-classic
+          inputs:
+          - input: pipelineArtifact
+            pipeline: '_ci-arc-k8s-extension-canary-release'
+            artifactName: 'ev2Artifact'
           ev2:
             useServerMonitorTask: true
             serviceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot
@@ -91,24 +84,17 @@ extends:
         approval:
           workflow: approvalService
       jobs:
-      - job: Job_1
-        displayName: Agentless job
-        condition: succeeded()
-        timeoutInMinutes: 7200
-        pool: server
-        steps:
-        - task: ReleasePipeline.approvalservice-ext.a81eb944-f6e7-40bb-acb3-6f68822bc5ab.ApprovalTask@1
-          displayName: Approval service
-          inputs:
-            servicetreeguid: $(ServiceTreeGuid)
-          timeoutInMinutes: 7200
-      - job: Job_2
+      - job: Ev2
         displayName: Agent job - Ev2
         condition: succeeded()
         timeoutInMinutes: 0
         templateContext:
           type: releaseJob
           workflow: ev2-classic
+          inputs:
+          - input: pipelineArtifact
+            pipeline: '_ci-arc-k8s-extension-canary-release'
+            artifactName: 'ev2Artifact'
           ev2:
             useServerMonitorTask: true
             serviceRootPath: ServiceGroupRoot

--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -24,7 +24,7 @@ variables:
 - name: RESOURCE_AUDIENCE
   value: $[variables['RESOURCE_AUDIENCE']]
 - name: ServiceTreeGuid
-  value: $[variables['SERVICE_TREE_GUID']]
+  value: $(SERVICE_TREE_GUID)
 - name: SPN_CLIENT_ID
   value: $[variables['SPN_CLIENT_ID']]
 - name: SPN_SECRET
@@ -47,7 +47,7 @@ extends:
     pool:
       name: Azure-Pipelines-Windows-CI-Test-EO
       os: windows
-    serviceTreeId: $[variables['SERVICE_TREE_GUID']]
+    serviceTreeId: $(SERVICE_TREE_GUID)
     customBuildTags:
     - ES365AIMigrationTooling-Release
     stages:

--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -26,10 +26,11 @@ variables:
 - name: SPN_CLIENT_ID
   value: $(VAR_SPN_CLIENT_ID)
 - name: SPN_SECRET
-  value: 
+  value: ''
 - name: SPN_TENANT_ID
   value: $(VAR_SPN_TENANT_ID)
 resources:
+  containers: []
   pipelines:
   - pipeline: '_ci-arc-k8s-extension-canary-release'
     project: 'microsoft'
@@ -39,62 +40,573 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  parameters:
+stages:
+- stage: Stage_1
+  displayName: Canary MCR
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+    os: windows
+  jobs:
+  - job: releaseGating
+    displayName: Release Gating
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: runCodesignValidationInjection
+      value: false
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: skipNugetSecurityAnalysis
+      value: true
+    steps:
+    - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+      condition: false
+      inputs:
+        repository: none
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Branch Validation (1ES PT)
+      continueOnError: true
+      target:
+        container: host
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+        SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+        BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+        BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+        BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+        BUILD_REPOSITORYPROVIDER: $(Build.Repository.Provider)
+        BUILD_SOURCEVERSION: $(Build.SourceVersion)
+        TASK_MODE: audit
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: release_gating.py
+  - job: approval
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+    displayName: Approval
     pool:
-      name: Azure-Pipelines-Windows-CI-Test-EO
-      os: windows
-    serviceTreeId: $(VAR_SERVICE_TREE_GUID)
-    customBuildTags:
-    - ES365AIMigrationTooling-Release
-    stages:
-    - stage: Stage_1
-      displayName: Canary MCR
-      templateContext:
-        cloud: Public
-        isProduction: true
-        approval:
-          workflow: approvalService
-      jobs:
-      - job: Ev2
-        displayName: Agent job - Ev2
-        condition: succeeded()
-        timeoutInMinutes: 0
-        templateContext:
-          type: releaseJob
-          workflow: ev2-classic
-          inputs:
-          - input: pipelineArtifact
-            pipeline: '_ci-arc-k8s-extension-canary-release'
-            artifactName: 'ev2Artifact'
-          ev2:
-            useServerMonitorTask: true
-            serviceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot
-            rolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot/RolloutSpecs/Public.Canary.RolloutSpec.json
-            inlineScopeBindingOverrides: '{   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",   "contentVersion": "0.0.0.1",   "scopeBindings": [     {       "scopeTagName": "Canary",       "bindings": [         {           "find": "__ACR_NAME__",           "replaceWith": "$(ACRName)"         },         {           "find": "__REPO_TYPE__",           "replaceWith": "$(RepoType)"         },         {           "find": "__CHART_VERSION__",           "replaceWith": "$(CHART_VERSION)"         },                 {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }       ]     }   ] }'
-    - stage: Stage_2
-      displayName: Canary Regions Release
-      trigger: manual
-      templateContext:
-        cloud: Public
-        isProduction: true
-        approval:
-          workflow: approvalService
-      jobs:
-      - job: Ev2
-        displayName: Agent job - Ev2
-        condition: succeeded()
-        timeoutInMinutes: 0
-        templateContext:
-          type: releaseJob
-          workflow: ev2-classic
-          inputs:
-          - input: pipelineArtifact
-            pipeline: '_ci-arc-k8s-extension-canary-release'
-            artifactName: 'ev2Artifact'
-          ev2:
-            useServerMonitorTask: true
-            serviceRootPath: ServiceGroupRoot
-            rolloutSpecPath: Public.CanaryStable.RolloutSpec.json
-            inlineScopeBindingOverrides: '{     "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",     "contentVersion": "0.0.0.1",     "scopeBindings": [                {             "scopeTagName": "CanaryStable",             "bindings": [                 {                     "find": "__RELEASE_STAGE__",                     "replaceWith": "CanaryStable"                 },                 {                     "find": "__ADMIN_SUBSCRIPTION_ID__",                     "replaceWith": "$(ADMIN_SUBSCRIPTION_ID)"                 },                 {                     "find": "__CHART_VERSION__",                     "replaceWith": "$(CHART_VERSION)"                 },                 {                     "find": "__IS_CUSTOMER_HIDDEN__",                     "replaceWith": "$(IS_CUSTOMER_HIDDEN)"                 },                 {                     "find": "__REGISTER_REGIONS_CANARY__",                     "replaceWith": "$(REGISTER_REGIONS_CANARY)"                 },                 {                     "find": "__RELEASE_TRAINS_PREVIEW_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_PREVIEW_PATH)"                 },                 {                     "find": "__RELEASE_TRAINS_STABLE_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_STABLE_PATH)"                 },                 {                     "find": "__RESOURCE_AUDIENCE__",                     "replaceWith": "$(RESOURCE_AUDIENCE)"                 },                 {                     "find": "__SPN_CLIENT_ID__",                     "replaceWith": "$(SPN_CLIENT_ID)"                 },                 {                     "find": "__SPN_SECRET__",                     "replaceWith": "$(SPN_SECRET)"                 },                 {                     "find": "__SPN_TENANT_ID__",                     "replaceWith": "$(SPN_TENANT_ID)"                 },                  {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }             ]         }                ]         }                                                                                                                       '
+      name: server
+    timeoutInMinutes: 7200
+    dependsOn:
+    - releaseGating
+    steps:
+    - task: ApprovalTask@1
+      inputs:
+        environment: $(ev2Environment)
+        servicetreeguid: $(VAR_SERVICE_TREE_GUID)
+  - job: Ev2_ev2_rollout
+    displayName: Agent job - Ev2 Ev2 Rollout
+    timeoutInMinutes: '0'
+    condition: succeeded()
+    dependsOn:
+    - approval
+    variables:
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: https://azureservicedeploy.msft.net/api/monitorrollout
+    - name: OneESPT.JobType
+      value: releaseJob
+      readonly: true
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: OneESPT.Workflow
+      value: ev2-classic
+      readonly: true
+    - name: runCodesignValidationInjection
+      value: false
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: skipNugetSecurityAnalysis
+      value: true
+    - name: OneES_targetName
+      value: host
+    steps:
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Validate Hosted Pool Information (1ES PT)
+      continueOnError: false
+      target:
+        container: host
+      env:
+        HOST_ARCHITECTURE: amd64
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_DEFINITIONID: $(System.DefinitionId)
+        SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+        SYSTEM_TEAMPROJECT: $(System.TeamProject)
+        SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+        BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+        BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+        PIPELINEGOVERNANCESTATUS_AUDITED: variables['PipelineGovernanceStatus_Audited']
+        PIPELINECLASSIFICATION_AUDITED: variables['PipelineClassification_Audited']
+        BUILD_REASON: $(Build.Reason)
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: validateHostedPool.ps1
+        arguments: -TargetName '' -StepTargets '' -StepsLength 0 -SkipStatelessValidation True -OS windows -IgnoreProductionPoolCheck  -IsOfficialTemplate -IsProductionReleasePipeline
+    - task: DownloadPipelineArtifact@2
+      displayName: ⏬ Pipeline Artifact Download
+      inputs:
+        buildType: specific
+        project: $(resources.pipeline._ci-arc-k8s-extension-canary-release.projectID)
+        definition: $(resources.pipeline._ci-arc-k8s-extension-canary-release.pipelineID)
+        allowFailedBuilds: false
+        buildVersionToDownload: specific
+        pipelineId: $(resources.pipeline._ci-arc-k8s-extension-canary-release.runID)
+        pipeline: _ci-arc-k8s-extension-canary-release
+        targetPath: $(Pipeline.Workspace)/ev2Artifact
+      target:
+        container: host
+    - task: AzureArtifacts.drop-validator-task.drop-validator-task.DropValidatorTask@0
+      displayName: "\U0001F6E1 Validate SBoM Manifest (1ES PT)"
+      condition: succeeded()
+      continueOnError: False
+      timeoutInMinutes: 30
+      env:
+        SBOMVALIDATOR_TEMPIGNOREMISSING: true
+      inputs:
+        BuildDropPath: $(Pipeline.Workspace)/ev2Artifact/drop/linux
+        OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+        ValidateSignature: True
+        Verbosity: 'Verbose'
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Post-SBoM Validation (1ES PT)
+      continueOnError: true
+      target:
+        container: host
+      condition: succeeded()
+      env:
+        OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: post_sbom_validation.py
+    # - task: 1ESGPTRunTask@3.0.334
+    #   displayName: Validate Source Build (1ES PT)
+    #   continueOnError: false
+    #   target:
+    #     container: host
+    #   env:
+    #     BuildDropPath: $(Pipeline.Workspace)/ev2Artifact
+    #     IsProduction: True
+    #   inputs:
+    #     repoId: microsoft/Docker-Provider
+    #     path: validate_source_build.py
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+      displayName: "\U0001F6E1 Guardian: CodeSign Validation"
+      target:
+        container: host
+      condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+      continueOnError: true
+      timeoutInMinutes: 10
+      inputs:
+        Path: $(Pipeline.Workspace)/ev2Artifact
+        MaxThreads: $(OneES_UsableProcessorCount)
+        FailIfNoTargetsFound: false
+        ExcludePassesFromLog: False
+        Targets: f|**\*.dll;f|**\*.exe;f|**\*.sys;f|**\*.ps1;f|**\*.psm1;f|**\*.ps1xml;f|**\*.psc1;f|**\*.psd1;f|**\*.cdxml;f|**\*.vbs;f|**\*.js;f|**\*.wsf;-|.gdn\**;
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: "\U0001F6E1 Guardian: Check CodeSign Validation Results (1ES PT)"
+      continueOnError: true
+      target:
+        container: host
+      condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+      env:
+        OneES_PipelineWorkspace: $(Pipeline.Workspace)
+        OneES_DeleteCodeSignValidationResult: True
+        OneES_CustomPolicyFile: ''
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: check_csv_results.ps1
+    - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+      condition: false
+      inputs:
+        repository: none
+      target:
+        container: host
+    - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
+      inputs:
+        UseServerMonitorTask: true
+        EndpointProviderType: ApprovalService
+        ApprovalServiceEnvironment: $(ev2Environment)
+        ServiceRootLocation: LinkedArtifact
+        RolloutSpecType: RSPath
+        ServiceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension/ServiceGroupRoot
+        RolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension/ServiceGroupRoot/RolloutSpecs/Public.Canary.RolloutSpec.json
+        OutputRolloutId: RolloutId
+        OutputServiceGroupName: ServiceGroupName
+        OutputRolloutStatus: RolloutStatus
+        InlineDynamicBindingOverrides: '{   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",   "contentVersion": "0.0.0.1",   "scopeBindings": [     {       "scopeTagName": "Canary",       "bindings": [         {           "find": "__ACR_NAME__",           "replaceWith": "$(ACRName)"         },         {           "find": "__REPO_TYPE__",           "replaceWith": "$(RepoType)"         },         {           "find": "__CHART_VERSION__",           "replaceWith": "$(CHART_VERSION)"         },                 {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }       ]     }   ] }'
+      env:
+        ServiceTreeGuid: $(VAR_SERVICE_TREE_GUID)
+      target:
+        container: host
+      displayName: Ev2 Classic - Deploy
+  - job: Ev2_ev2_monitoring
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: OneESPT.Workflow
+      value: ev2-classic
+      readonly: true
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+    displayName: Agent job - Ev2 Ev2 Monitoring
+    pool:
+      name: server
+    dependsOn:
+    - Ev2_ev2_rollout
+    timeoutInMinutes: '0'
+    steps:
+    - task: vsrm-ev2.vss-server-ev2.1950188C-A844-4040-A014-A326BC8332D3.Ev2Agentless@1
+      displayName: Ev2 - Monitoring
+      inputs:
+        Ev2MonintoringUrl: $(Ev2MonintoringUrl)
+- stage: Stage_2
+  displayName: Canary Regions Release
+  trigger: manual
+  pool:
+    name: Azure-Pipelines-Windows-CI-Test-EO
+    os: windows
+  jobs:
+  - job: releaseGating
+    displayName: Release Gating
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: runCodesignValidationInjection
+      value: false
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: skipNugetSecurityAnalysis
+      value: true
+    steps:
+    - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+      condition: false
+      inputs:
+        repository: none
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Branch Validation (1ES PT)
+      continueOnError: true
+      target:
+        container: host
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+        SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+        BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+        BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+        BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+        BUILD_REPOSITORYPROVIDER: $(Build.Repository.Provider)
+        BUILD_SOURCEVERSION: $(Build.SourceVersion)
+        TASK_MODE: audit
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: release_gating.py
+  - job: approval
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+    displayName: Approval
+    pool:
+      name: server
+    timeoutInMinutes: 7200
+    dependsOn:
+    - releaseGating
+    steps:
+    - task: ApprovalTask@1
+      inputs:
+        environment: $(ev2Environment)
+        servicetreeguid: $(VAR_SERVICE_TREE_GUID)
+  - job: Ev2_ev2_rollout
+    displayName: Agent job - Ev2 Ev2 Rollout
+    timeoutInMinutes: '0'
+    condition: succeeded()
+    dependsOn:
+    - approval
+    variables:
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: https://azureservicedeploy.msft.net/api/monitorrollout
+    - name: OneESPT.JobType
+      value: releaseJob
+      readonly: true
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: OneESPT.Workflow
+      value: ev2-classic
+      readonly: true
+    - name: runCodesignValidationInjection
+      value: false
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: skipNugetSecurityAnalysis
+      value: true
+    - name: OneES_targetName
+      value: host
+    steps:
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Validate Hosted Pool Information (1ES PT)
+      continueOnError: false
+      target:
+        container: host
+      env:
+        HOST_ARCHITECTURE: amd64
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_DEFINITIONID: $(System.DefinitionId)
+        SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+        SYSTEM_TEAMPROJECT: $(System.TeamProject)
+        SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+        BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+        BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+        PIPELINEGOVERNANCESTATUS_AUDITED: variables['PipelineGovernanceStatus_Audited']
+        PIPELINECLASSIFICATION_AUDITED: variables['PipelineClassification_Audited']
+        BUILD_REASON: $(Build.Reason)
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: validateHostedPool.ps1
+        arguments: -TargetName '' -StepTargets '' -StepsLength 0 -SkipStatelessValidation True -OS windows -IgnoreProductionPoolCheck  -IsOfficialTemplate -IsProductionReleasePipeline
+    - task: DownloadPipelineArtifact@2
+      displayName: ⏬ Pipeline Artifact Download
+      inputs:
+        buildType: specific
+        project: $(resources.pipeline._ci-arc-k8s-extension-canary-release.projectID)
+        definition: $(resources.pipeline._ci-arc-k8s-extension-canary-release.pipelineID)
+        allowFailedBuilds: false
+        buildVersionToDownload: specific
+        pipelineId: $(resources.pipeline._ci-arc-k8s-extension-canary-release.runID)
+        pipeline: _ci-arc-k8s-extension-canary-release
+        targetPath: $(Pipeline.Workspace)/ev2Artifact
+      target:
+        container: host
+    - task: AzureArtifacts.drop-validator-task.drop-validator-task.DropValidatorTask@0
+      displayName: "\U0001F6E1 Validate SBoM Manifest (1ES PT)"
+      condition: succeeded()
+      continueOnError: False
+      timeoutInMinutes: 30
+      env:
+        SBOMVALIDATOR_TEMPIGNOREMISSING: true
+      inputs:
+        BuildDropPath: $(Pipeline.Workspace)/ev2Artifact/drop/linux
+        OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+        ValidateSignature: True
+        Verbosity: 'Verbose'
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Post-SBoM Validation (1ES PT)
+      continueOnError: true
+      target:
+        container: host
+      condition: succeeded()
+      env:
+        OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: post_sbom_validation.py
+    # - task: 1ESGPTRunTask@3.0.334
+    #   displayName: Validate Source Build (1ES PT)
+    #   continueOnError: false
+    #   target:
+    #     container: host
+    #   env:
+    #     BuildDropPath: $(Pipeline.Workspace)/ev2Artifact
+    #     IsProduction: True
+    #   inputs:
+    #     repoId: microsoft/Docker-Provider
+    #     path: validate_source_build.py
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+      displayName: "\U0001F6E1 Guardian: CodeSign Validation"
+      target:
+        container: host
+      condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+      continueOnError: true
+      timeoutInMinutes: 10
+      inputs:
+        Path: $(Pipeline.Workspace)/ev2Artifact
+        MaxThreads: $(OneES_UsableProcessorCount)
+        FailIfNoTargetsFound: false
+        ExcludePassesFromLog: False
+        Targets: f|**\*.dll;f|**\*.exe;f|**\*.sys;f|**\*.ps1;f|**\*.psm1;f|**\*.ps1xml;f|**\*.psc1;f|**\*.psd1;f|**\*.cdxml;f|**\*.vbs;f|**\*.js;f|**\*.wsf;-|.gdn\**;
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: "\U0001F6E1 Guardian: Check CodeSign Validation Results (1ES PT)"
+      continueOnError: true
+      target:
+        container: host
+      condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+      env:
+        OneES_PipelineWorkspace: $(Pipeline.Workspace)
+        OneES_DeleteCodeSignValidationResult: True
+        OneES_CustomPolicyFile: ''
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: check_csv_results.ps1
+    - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+      condition: false
+      inputs:
+        repository: none
+      target:
+        container: host
+    - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
+      inputs:
+        UseServerMonitorTask: true
+        EndpointProviderType: ApprovalService
+        ApprovalServiceEnvironment: $(ev2Environment)
+        ServiceRootLocation: LinkedArtifact
+        RolloutSpecType: RSPath
+        ServiceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2/ServiceGroupRoot
+        RolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2/ServiceGroupRoot/RolloutSpecs/Public.CanaryStable.RolloutSpec.json
+        OutputRolloutId: RolloutId
+        OutputServiceGroupName: ServiceGroupName
+        OutputRolloutStatus: RolloutStatus
+        InlineDynamicBindingOverrides: '{     "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",     "contentVersion": "0.0.0.1",     "scopeBindings": [                {             "scopeTagName": "CanaryStable",             "bindings": [                 {                     "find": "__RELEASE_STAGE__",                     "replaceWith": "CanaryStable"                 },                 {                     "find": "__ADMIN_SUBSCRIPTION_ID__",                     "replaceWith": "$(ADMIN_SUBSCRIPTION_ID)"                 },                 {                     "find": "__CHART_VERSION__",                     "replaceWith": "$(CHART_VERSION)"                 },                 {                     "find": "__IS_CUSTOMER_HIDDEN__",                     "replaceWith": "$(IS_CUSTOMER_HIDDEN)"                 },                 {                     "find": "__REGISTER_REGIONS_CANARY__",                     "replaceWith": "$(REGISTER_REGIONS_CANARY)"                 },                 {                     "find": "__RELEASE_TRAINS_PREVIEW_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_PREVIEW_PATH)"                 },                 {                     "find": "__RELEASE_TRAINS_STABLE_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_STABLE_PATH)"                 },                 {                     "find": "__RESOURCE_AUDIENCE__",                     "replaceWith": "$(RESOURCE_AUDIENCE)"                 },                 {                     "find": "__SPN_CLIENT_ID__",                     "replaceWith": "$(SPN_CLIENT_ID)"                 },                 {                     "find": "__SPN_SECRET__",                     "replaceWith": "$(SPN_SECRET)"                 },                 {                     "find": "__SPN_TENANT_ID__",                     "replaceWith": "$(SPN_TENANT_ID)"                 },                  {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }             ]         }                ]         }                                                                                                                       '
+      env:
+        ServiceTreeGuid: $(VAR_SERVICE_TREE_GUID)
+      target:
+        container: host
+      displayName: Ev2 Classic - Deploy
+  - job: Ev2_ev2_monitoring
+    variables:
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    - name: OneESPT.Workflow
+      value: ev2-classic
+      readonly: true
+    - name: ev2Environment
+      value: Production
+    - name: Ev2MonintoringUrl
+      value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+    displayName: Agent job - Ev2 Ev2 Monitoring
+    pool:
+      name: server
+    dependsOn:
+    - Ev2_ev2_rollout
+    timeoutInMinutes: '0'
+    steps:
+    - task: vsrm-ev2.vss-server-ev2.1950188C-A844-4040-A014-A326BC8332D3.Ev2Agentless@1
+      displayName: Ev2 - Monitoring
+      inputs:
+        Ev2MonintoringUrl: $(Ev2MonintoringUrl)
+- stage: Tag
+  displayName: "\U0001F512 1ES PT Tag"
+  isSkippable: false
+  dependsOn: []
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+  - job: Tag
+    displayName: "\U0001F512 Tag"
+    variables:
+    - name: runCodesignValidationInjection
+      value: false
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: skipNugetSecurityAnalysis
+      value: true
+    - name: OneESPT
+      value: true
+      readonly: true
+    - name: OneESPT.BuildType
+      value: Official
+      readonly: true
+    - name: OneESPT.OS
+      value: windows
+      readonly: true
+    steps:
+    - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+      condition: false
+      inputs:
+        repository: none
+    - task: 1ESGPTRunTask@3.0.334
+      displayName: Tag build and log custom issues (1ES PT)
+      continueOnError: false
+      target:
+        container: host
+      env:
+        BuildTags: >-
+          [
+            "ES365AIMigrationTooling-Release",
+            "1ES.PT.Official",
+            "1ES.PT.Release.Production"
+          ]
+        LogIssues: '[]'
+        SkipBuildTagsForGitHubPullRequests: ''
+      inputs:
+        repoId: microsoft/Docker-Provider
+        path: tagBuild.ps1
+

--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -1,0 +1,116 @@
+trigger: none
+name: $(Date:yyyyMMdd).$(Rev:r)
+variables:
+- name: ACRName
+  value: containerinsights.azurecr.io
+- name: ADMIN_SUBSCRIPTION_ID
+  value: $[variables['ADMIN_SUBSCRIPTION_ID']]
+- name: CHART_VERSION
+  value: ''
+- name: IS_CUSTOMER_HIDDEN
+  value: false
+- name: MANAGED_IDENTITY
+  value: $[variables['MANAGED_IDENTITY']]
+- name: ManagedIdentity
+  value: $[variables['MANAGED_IDENTITY']]
+- name: REGISTER_REGIONS_CANARY
+  value: eastus2euap
+- name: RELEASE_TRAINS_PREVIEW_PATH
+  value: preview
+- name: RELEASE_TRAINS_STABLE_PATH
+  value: stable
+- name: RepoType
+  value: stable
+- name: RESOURCE_AUDIENCE
+  value: $[variables['RESOURCE_AUDIENCE']]
+- name: ServiceTreeGuid
+  value: $[variables['SERVICE_TREE_GUID']]
+- name: SPN_CLIENT_ID
+  value: $[variables['SPN_CLIENT_ID']]
+- name: SPN_SECRET
+  value: 
+- name: SPN_TENANT_ID
+  value: $[variables['SPN_TENANT_ID']]
+resources:
+  pipelines:
+  - pipeline: '_ci-arc-k8s-extension-canary-release'
+    project: 'microsoft'
+    source: 'CDPX\docker-provider\ContainerInsights-MultiArch-MergedBranches'
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-Windows-CI-Test-EO
+      os: windows
+    serviceTreeId: $[variables['SERVICE_TREE_GUID']]
+    customBuildTags:
+    - ES365AIMigrationTooling-Release
+    stages:
+    - stage: Stage_1
+      displayName: Canary MCR
+      templateContext:
+        cloud: Public
+        isProduction: true
+        approval:
+          workflow: approvalService
+      jobs:
+      - job: Job_1
+        displayName: Agentless job
+        condition: succeeded()
+        timeoutInMinutes: 7200
+        pool: server
+        steps:
+        - task: ReleasePipeline.approvalservice-ext.a81eb944-f6e7-40bb-acb3-6f68822bc5ab.ApprovalTask@1
+          displayName: Approval service
+          inputs:
+            servicetreeguid: $(ServiceTreeGuid)
+          timeoutInMinutes: 7200
+      - job: Job_2
+        displayName: Agent job - Ev2
+        condition: succeeded()
+        timeoutInMinutes: 0
+        templateContext:
+          type: releaseJob
+          workflow: ev2-classic
+          ev2:
+            useServerMonitorTask: true
+            serviceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot
+            rolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot/RolloutSpecs/Public.Canary.RolloutSpec.json
+            inlineScopeBindingOverrides: '{   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",   "contentVersion": "0.0.0.1",   "scopeBindings": [     {       "scopeTagName": "Canary",       "bindings": [         {           "find": "__ACR_NAME__",           "replaceWith": "$(ACRName)"         },         {           "find": "__REPO_TYPE__",           "replaceWith": "$(RepoType)"         },         {           "find": "__CHART_VERSION__",           "replaceWith": "$(CHART_VERSION)"         },                 {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(ManagedIdentity)"                 }       ]     }   ] }'
+    - stage: Stage_2
+      displayName: Canary Regions Release
+      trigger: manual
+      templateContext:
+        cloud: Public
+        isProduction: true
+        approval:
+          workflow: approvalService
+      jobs:
+      - job: Job_1
+        displayName: Agentless job
+        condition: succeeded()
+        timeoutInMinutes: 7200
+        pool: server
+        steps:
+        - task: ReleasePipeline.approvalservice-ext.a81eb944-f6e7-40bb-acb3-6f68822bc5ab.ApprovalTask@1
+          displayName: Approval service
+          inputs:
+            servicetreeguid: $(ServiceTreeGuid)
+          timeoutInMinutes: 7200
+      - job: Job_2
+        displayName: Agent job - Ev2
+        condition: succeeded()
+        timeoutInMinutes: 0
+        templateContext:
+          type: releaseJob
+          workflow: ev2-classic
+          ev2:
+            useServerMonitorTask: true
+            serviceRootPath: ServiceGroupRoot
+            rolloutSpecPath: Public.CanaryStable.RolloutSpec.json
+            inlineScopeBindingOverrides: '{     "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",     "contentVersion": "0.0.0.1",     "scopeBindings": [                {             "scopeTagName": "CanaryStable",             "bindings": [                 {                     "find": "__RELEASE_STAGE__",                     "replaceWith": "CanaryStable"                 },                 {                     "find": "__ADMIN_SUBSCRIPTION_ID__",                     "replaceWith": "$(ADMIN_SUBSCRIPTION_ID)"                 },                 {                     "find": "__CHART_VERSION__",                     "replaceWith": "$(CHART_VERSION)"                 },                 {                     "find": "__IS_CUSTOMER_HIDDEN__",                     "replaceWith": "$(IS_CUSTOMER_HIDDEN)"                 },                 {                     "find": "__REGISTER_REGIONS_CANARY__",                     "replaceWith": "$(REGISTER_REGIONS_CANARY)"                 },                 {                     "find": "__RELEASE_TRAINS_PREVIEW_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_PREVIEW_PATH)"                 },                 {                     "find": "__RELEASE_TRAINS_STABLE_PATH__",                     "replaceWith": "$(RELEASE_TRAINS_STABLE_PATH)"                 },                 {                     "find": "__RESOURCE_AUDIENCE__",                     "replaceWith": "$(RESOURCE_AUDIENCE)"                 },                 {                     "find": "__SPN_CLIENT_ID__",                     "replaceWith": "$(SPN_CLIENT_ID)"                 },                 {                     "find": "__SPN_SECRET__",                     "replaceWith": "$(SPN_SECRET)"                 },                 {                     "find": "__SPN_TENANT_ID__",                     "replaceWith": "$(SPN_TENANT_ID)"                 },                  {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }             ]         }                ]         }                                                                                                                       '

--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -4,15 +4,15 @@ variables:
 - name: ACRName
   value: containerinsights.azurecr.io
 - name: ADMIN_SUBSCRIPTION_ID
-  value: $[variables['ADMIN_SUBSCRIPTION_ID']]
+  value: $(ADMIN_SUBSCRIPTION_ID)
 - name: CHART_VERSION
   value: ''
 - name: IS_CUSTOMER_HIDDEN
   value: false
 - name: MANAGED_IDENTITY
-  value: $[variables['MANAGED_IDENTITY']]
+  value: $(MANAGED_IDENTITY)
 - name: ManagedIdentity
-  value: $[variables['MANAGED_IDENTITY']]
+  value: $(MANAGED_IDENTITY)
 - name: REGISTER_REGIONS_CANARY
   value: eastus2euap
 - name: RELEASE_TRAINS_PREVIEW_PATH
@@ -22,15 +22,15 @@ variables:
 - name: RepoType
   value: stable
 - name: RESOURCE_AUDIENCE
-  value: $[variables['RESOURCE_AUDIENCE']]
+  value: $(RESOURCE_AUDIENCE)
 - name: ServiceTreeGuid
   value: $(SERVICE_TREE_GUID)
 - name: SPN_CLIENT_ID
-  value: $[variables['SPN_CLIENT_ID']]
+  value: $(SPN_CLIENT_ID)
 - name: SPN_SECRET
   value: 
 - name: SPN_TENANT_ID
-  value: $[variables['SPN_TENANT_ID']]
+  value: $(SPN_TENANT_ID)
 resources:
   pipelines:
   - pipeline: '_ci-arc-k8s-extension-canary-release'

--- a/.pipelines/ci-arc-k8s-extension-canary-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-canary-release.yaml
@@ -4,33 +4,31 @@ variables:
 - name: ACRName
   value: containerinsights.azurecr.io
 - name: ADMIN_SUBSCRIPTION_ID
-  value: $(ADMIN_SUBSCRIPTION_ID)
+  value: $(VAR_ADMIN_SUBSCRIPTION_ID)
 - name: CHART_VERSION
-  value: ''
+  value: $(VAR_CHART_VERSION)
 - name: IS_CUSTOMER_HIDDEN
-  value: false
+  value: $(VAR_IS_CUSTOMER_HIDDEN)
 - name: MANAGED_IDENTITY
-  value: $(MANAGED_IDENTITY)
-- name: ManagedIdentity
-  value: $(MANAGED_IDENTITY)
+  value: $(VAR_MANAGED_IDENTITY)
 - name: REGISTER_REGIONS_CANARY
-  value: eastus2euap
+  value: $(VAR_REGISTER_REGIONS_CANARY)
 - name: RELEASE_TRAINS_PREVIEW_PATH
-  value: preview
+  value: $(VAR_RELEASE_TRAINS_PREVIEW_PATH)
 - name: RELEASE_TRAINS_STABLE_PATH
-  value: stable
+  value: $(VAR_RELEASE_TRAINS_STABLE_PATH)
 - name: RepoType
-  value: stable
+  value: $(VAR_REPO_TYPE)
 - name: RESOURCE_AUDIENCE
-  value: $(RESOURCE_AUDIENCE)
+  value: $(VAR_RESOURCE_AUDIENCE)
 - name: ServiceTreeGuid
-  value: $(SERVICE_TREE_GUID)
+  value: $(VAR_SERVICE_TREE_GUID)
 - name: SPN_CLIENT_ID
-  value: $(SPN_CLIENT_ID)
+  value: $(VAR_SPN_CLIENT_ID)
 - name: SPN_SECRET
   value: 
 - name: SPN_TENANT_ID
-  value: $(SPN_TENANT_ID)
+  value: $(VAR_SPN_TENANT_ID)
 resources:
   pipelines:
   - pipeline: '_ci-arc-k8s-extension-canary-release'
@@ -47,7 +45,7 @@ extends:
     pool:
       name: Azure-Pipelines-Windows-CI-Test-EO
       os: windows
-    serviceTreeId: $(SERVICE_TREE_GUID)
+    serviceTreeId: $(VAR_SERVICE_TREE_GUID)
     customBuildTags:
     - ES365AIMigrationTooling-Release
     stages:
@@ -74,7 +72,7 @@ extends:
             useServerMonitorTask: true
             serviceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot
             rolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/deploy/ServiceGroupRoot/RolloutSpecs/Public.Canary.RolloutSpec.json
-            inlineScopeBindingOverrides: '{   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",   "contentVersion": "0.0.0.1",   "scopeBindings": [     {       "scopeTagName": "Canary",       "bindings": [         {           "find": "__ACR_NAME__",           "replaceWith": "$(ACRName)"         },         {           "find": "__REPO_TYPE__",           "replaceWith": "$(RepoType)"         },         {           "find": "__CHART_VERSION__",           "replaceWith": "$(CHART_VERSION)"         },                 {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(ManagedIdentity)"                 }       ]     }   ] }'
+            inlineScopeBindingOverrides: '{   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",   "contentVersion": "0.0.0.1",   "scopeBindings": [     {       "scopeTagName": "Canary",       "bindings": [         {           "find": "__ACR_NAME__",           "replaceWith": "$(ACRName)"         },         {           "find": "__REPO_TYPE__",           "replaceWith": "$(RepoType)"         },         {           "find": "__CHART_VERSION__",           "replaceWith": "$(CHART_VERSION)"         },                 {                     "find": "__MANAGED_IDENTITY__",                     "replaceWith": "$(MANAGED_IDENTITY)"                 }       ]     }   ] }'
     - stage: Stage_2
       displayName: Canary Regions Release
       trigger: manual


### PR DESCRIPTION
This is the migration of existing ADO release pipeline for ARC canary stable release to 1ES governed release yaml pipeline per https://dev.azure.com/msazure/InfrastructureInsights/_wiki/wikis/InfrastructureInsights.wiki/761472/1ESReleasePipeline. The pipeline reference to arc-k8s-extension/ServiceGroupRoot for pushing chart to MCR and arc-k8s-extension-release-v2 for rollout. Test Run: https://github-private.visualstudio.com/microsoft/_build?definitionId=1021&_a=summary  The commented out section is due to pending migration of build pipeline.