### PR TITLE
Fixed token refresh issue

### DIFF
--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -132,7 +132,7 @@ class KubernetesApiClient
 
     def getTokenStr
       begin
-        if (@@TokenStr.nil? || (@@TokenExpiry - DateTime.now.to_time.to_i).abs <= Constants::SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS) # refresh token from token file if its near expiry
+        if (@@TokenStr.nil? || @@TokenExpiry <= DateTime.now.to_time.to_i || (@@TokenExpiry - DateTime.now.to_time.to_i).abs <= Constants::SERVICE_ACCOUNT_TOKEN_REFRESH_INTERVAL_SECONDS) # refresh token from token file if its near expiry
           if File.exist?(@@TokenFileName) && File.readable?(@@TokenFileName)
             @@TokenStr = File.read(@@TokenFileName).strip
             begin


### PR DESCRIPTION
If the token refresh window is missed due to a load on the cluster (high CPU usage), the token will not get refreshed ever again until the pod restarted. The check ensures that the token is refreshed if it is expired or near expiry.