### PR TITLE
Windows build fix for gcc issue

### DIFF
--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -19,6 +19,13 @@ RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 # gangams - optional MSYS2 update via ridk failing in merged docker file so skipping that since we dont need optional update
 RUN refreshenv \
 && ridk install 2 3 \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc "pacman -Rns --noconfirm mingw-w64-ucrt-x86_64-gcc" \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc "curl -O https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-gcc-libs-14.2.0-3-any.pkg.tar.zst" \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc 'pacman -U --noconfirm mingw-w64-ucrt-x86_64-gcc-libs-14.2.0-3-any.pkg.tar.zst' \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc "rm mingw-w64-ucrt-x86_64-gcc-libs-14.2.0-3-any.pkg.tar.zst" \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc "curl -O https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-gcc-14.2.0-3-any.pkg.tar.zst" \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc 'pacman -U --noconfirm mingw-w64-ucrt-x86_64-gcc-14.2.0-3-any.pkg.tar.zst' \
+&& C:\ruby31\msys64\usr\bin\bash.exe -lc "rm mingw-w64-ucrt-x86_64-gcc-14.2.0-3-any.pkg.tar.zst" \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.9.0 --platform ruby \
 && gem install oj -v 3.16.10 \


### PR DESCRIPTION
GCC had a [major upgrade](https://gcc.gnu.org/releases.html) because of which gem installation is failing.