### PR TITLE
Update managed cluster api versions

### DIFF
--- a/scripts/onboarding/aks/onboarding-msi-azure-policy/azure-policy.rules.json
+++ b/scripts/onboarding/aks/onboarding-msi-azure-policy/azure-policy.rules.json
@@ -266,7 +266,7 @@
 								"type": "Microsoft.ContainerService/managedClusters",
 								"location": "[parameters('aksResourceLocation')]",
 								"tags": "[parameters('resourceTagValues')]",
-								"apiVersion": "2019-04-01",
+								"apiVersion": "2023-04-01",
 								"properties": {
 								  "mode": "Incremental",
 								  "id": "[parameters('aksResourceId')]",

--- a/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterOnboarding.bicep
+++ b/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterOnboarding.bicep
@@ -108,7 +108,7 @@ resource aks_monitoring_msi_dcr 'Microsoft.Insights/dataCollectionRules@2022-06-
   }
 }
 
-resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2019-04-01' = {
+resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2023-04-01' = {
   name: clusterName
   location: aksResourceLocation
   tags: resourceTagValues

--- a/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterOnboarding.bicep
+++ b/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterOnboarding.bicep
@@ -84,7 +84,7 @@ resource aks_monitoring_msi_dcr 'Microsoft.Insights/dataCollectionRules@2022-06-
   }
 }
 
-resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2019-04-01' = {
+resource aks_monitoring_msi_addon 'Microsoft.ContainerService/managedClusters@2023-04-01' = {
   name: clusterName
   location: aksResourceLocation
   tags: resourceTagValues

--- a/scripts/onboarding/aks/onboarding-using-azure-policy/azure-policy.json
+++ b/scripts/onboarding/aks/onboarding-using-azure-policy/azure-policy.json
@@ -59,7 +59,7 @@
 													"type": "Microsoft.ContainerService/managedClusters",
 													"location": "[parameters('clusterLocation')]",
 													"tags": "[parameters('clusterTags')]",
-													"apiVersion": "2019-04-01",
+													"apiVersion": "2023-04-01",
 													"properties": {
 														"mode": "Incremental",
 														"id": "[resourceId(parameters('clusterResourceGroupName'), 'Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",

--- a/scripts/onboarding/aks/onboarding-using-azure-policy/azurepolicy.rules.json
+++ b/scripts/onboarding/aks/onboarding-using-azure-policy/azurepolicy.rules.json
@@ -57,7 +57,7 @@
 												"type": "Microsoft.ContainerService/managedClusters",
 												"location": "[parameters('clusterLocation')]",
 												"tags": "[parameters('clusterTags')]",
-												"apiVersion": "2019-04-01",
+												"apiVersion": "2023-04-01",
 												"properties": {
 													"mode": "Incremental",
 													"id": "[resourceId(parameters('clusterResourceGroupName'), 'Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json
@@ -465,7 +465,7 @@
                             "type": "Microsoft.ContainerService/managedClusters",
                             "location": "[parameters('aksResourceLocation')]",
                             "tags": "[parameters('resourceTagValues')]",
-                            "apiVersion": "2019-04-01",
+                            "apiVersion": "2023-04-01",
                             "properties": {
                                 "mode": "Incremental",
                                 "id": "[parameters('aksResourceId')]",

--- a/test/onboarding-templates-legacy-auth/existingClusterOnboarding.json
+++ b/test/onboarding-templates-legacy-auth/existingClusterOnboarding.json
@@ -26,7 +26,7 @@
             "name": "[split(parameters('aksResourceId'),'/')[8]]",
             "type": "Microsoft.ContainerService/managedClusters",
             "location": "[parameters('aksResourceLocation')]",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2023-04-01",
             "properties": {
                 "mode": "Incremental",
                 "id": "[parameters('aksResourceId')]",


### PR DESCRIPTION
Update managed cluster api versions from 2019-04-01 to 2023-04-01 as AKS 1.32+ needs newer version.