### PR TITLE
Upgrade Telegraf version to latest dalec build

### DIFF
--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -43,7 +43,14 @@ RUN mkdir /busybin && busybox --install /busybin
 
 COPY --from=golang-builder /src/kubernetes/linux/Linux_ULINUX_1.0_*_64_Release/docker-cimprov-*.*.*-*.*.sh $tmpdir/
 COPY kubernetes/linux/setup.sh kubernetes/linux/main.sh kubernetes/linux/defaultpromenvvariables kubernetes/linux/defaultpromenvvariables-rs kubernetes/linux/defaultpromenvvariables-sidecar kubernetes/linux/mdsd.xml kubernetes/linux/envmdsd kubernetes/linux/logrotate.conf $tmpdir/
-COPY kubernetes/linux/mariner-official-extras.repo /etc/yum.repos.d/
+
+COPY kubernetes/linux/mariner-official-cloud-native-arm64.repo /tmp/mariner-official-cloud-native-arm64.repo
+COPY kubernetes/linux/mariner-official-cloud-native-amd64.repo /tmp/mariner-official-cloud-native-amd64.repo
+RUN if [ "${TARGETARCH}" == "arm64" ]; then \
+    cp /tmp/mariner-official-cloud-native-arm64.repo /etc/yum.repos.d/; \
+else \
+    cp /tmp/mariner-official-cloud-native-amd64.repo /etc/yum.repos.d/; \
+fi
 
 WORKDIR ${tmpdir}
 

--- a/kubernetes/linux/mariner-official-cloud-native-amd64.repo
+++ b/kubernetes/linux/mariner-official-cloud-native-amd64.repo
@@ -1,0 +1,9 @@
+[mariner-official-cloud-native-amd64]
+name=CBL-Mariner Official Cloud Native Amd64
+baseurl=https://packages.microsoft.com/cbl-mariner/2.0/prod/cloud-native/x86_64
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+skip_if_unavailable=True
+sslverify=1

--- a/kubernetes/linux/mariner-official-cloud-native-arm64.repo
+++ b/kubernetes/linux/mariner-official-cloud-native-arm64.repo
@@ -1,6 +1,6 @@
-[mariner-official-extras]
-name=CBL-Mariner Official Extras
-baseurl=https://packages.microsoft.com/cbl-mariner/2.0/prod/extras/x86_64/
+[mariner-official-cloud-native-arm64]
+name=CBL-Mariner Official Cloud Native Arm64
+baseurl=https://packages.microsoft.com/cbl-mariner/2.0/prod/cloud-native/aarch64
 gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
 gpgcheck=1
 repo_gpgcheck=1

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -79,10 +79,10 @@ sudo tdnf install jq-1.6-1.cm2 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install telegraf-1.29.4 -y
+sudo tdnf install telegraf-agent-1.34.2 -y
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
-mv /usr/bin/telegraf /opt/telegraf
+mv /usr/bin/telegraf-agent /opt/telegraf
 
 # Use wildcard version so that it doesnt require to touch this file
 /$TMPDIR/docker-cimprov-*.*.*-*.*.sh --install


### PR DESCRIPTION
Upgraded Telegraf version to latest dalec build.
Validated following scenarios:

1. ### CPU and Memory usage before (current prod 3.1.26) and after:
    **Default settings:**
![image](https://github.com/user-attachments/assets/759ceebf-fafd-478c-b0fb-24ba50150c1f)
![image](https://github.com/user-attachments/assets/bb4bfabe-e43d-4234-8657-2d45e3b31ba8)


    **With custom agent config:**
    
![image](https://github.com/user-attachments/assets/0d205a08-f91c-4f06-a8d0-c931f2d86ceb)

![image](https://github.com/user-attachments/assets/088c5576-6e36-4a95-97c9-5cf79d3db691)


2. ### Data validation:
    **Default settings:** Network input plugin has an extra record for lo (loopback) network interface. This record is emitted once per node per minute. This is an issue on the Telegraf side. [As per documentation](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/README.md), loopback interface shouldn't be part of the emitted records.

    **With custom agent config:** All looks good.

3. ### Errors in Telegraf logs: 
   No issues observed.