### PR TITLE
Filter out loopback metrics

### DIFF
--- a/build/linux/installer/conf/fluent-bit-common.conf
+++ b/build/linux/installer/conf/fluent-bit-common.conf
@@ -97,6 +97,11 @@
     Match oms.container.log.flbplugin.amaca.*
     Exclude log Information
 
+[FILTER]
+    Name    grep
+    Match   oms.container.perf.telegraf.*
+    Exclude interface lo
+
 [OUTPUT]
     Name                            oms
     Alias                           oms_output

--- a/build/linux/installer/conf/fluent-bit-common.conf
+++ b/build/linux/installer/conf/fluent-bit-common.conf
@@ -97,11 +97,6 @@
     Match oms.container.log.flbplugin.amaca.*
     Exclude log Information
 
-[FILTER]
-    Name    grep
-    Match   oms.container.perf.telegraf.*
-    Exclude interface lo
-
 [OUTPUT]
     Name                            oms
     Alias                           oms_output

--- a/build/linux/installer/conf/telegraf.conf
+++ b/build/linux/installer/conf/telegraf.conf
@@ -509,6 +509,14 @@
   fieldpass = ["bytes_recv", "bytes_sent", "err_in", "err_out"]
   taginclude = ["interface","hostName"]
 
+# net plugin is collecting loopback interface metrics by default from telegraf 1.34.3
+# Filter out loopback metrics to keep it aligned with previous versions
+[[processors.filter]]
+ namepass = ["container.azm.ms/net"]
+
+ [[processors.filter.rule]]
+   tags = {"interface" = ["lo"]}
+
 # Read metrics from the kubernetes kubelet api
 #[[inputs.kubernetes]]
   ## URL for the kubelet


### PR DESCRIPTION
Telegraf net plugin collects loopback interface metrics by default from 1.34.3 dalec version. Though, the local image with the only Telegraf running in it doesn't collect the loopback metrics as mentioned in Telegraf documnetation. We need to dig deeper into this to understand why the loopback metrics are being collected only for container insights. Meanwhile, filter out loopback metrics to keep it aligned with previous versions

**Test notes:** Tested the changes on a local cluster and the loopback metrics are getting filtered out.