### PR TITLE
Longw/containerlogv2 fix telemetry bug

### DIFF
--- a/source/plugins/go/input/lib/cadvisor.go
+++ b/source/plugins/go/input/lib/cadvisor.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"Docker-Provider/source/plugins/go/src/extension"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -76,8 +74,6 @@ var (
 	winContainerPrevMetricRate              = make(map[string]float64)
 	Log                                     *logrus.Logger
 	osType                                  string
-	IsContainerLogV2DCR                     bool
-	ContainerType                           = os.Getenv("CONTAINER_TYPE")
 )
 
 func init() {
@@ -103,8 +99,6 @@ func init() {
 
 	Log.SetOutput(file)
 	Log.SetLevel(logrus.InfoLevel)
-
-	FLBLogger = CreateLogger(LogPath)
 }
 
 type metricDataItem map[string]interface{}
@@ -235,10 +229,6 @@ func getResponse(winNode map[string]string, relativeUri string) (*http.Response,
 }
 
 func GetMetrics(winNode map[string]string, namespaceFilteringMode string, namespaces []string, metricTime string) []metricDataItem {
-	if IsAADMSIAuthMode() {
-		IsContainerLogV2DCR = extension.GetInstance(FLBLogger, ContainerType).IsContainerLogV2(false)
-	}
-
 	cAdvisorStats, err := getSummaryStatsFromCAdvisor(winNode)
 
 	if err != nil {
@@ -1077,13 +1067,6 @@ func getContainerCpuMetricItems(metricInfo map[string]interface{}, hostName, met
 						}
 						if len(os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION")) > 0 {
 							telemetryProps["containerLogVer"] = os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION")
-							if IsAADMSIAuthMode() {
-								if IsContainerLogV2DCR {
-									telemetryProps["containerLogVerDCR"] = "v2"
-								} else {
-									telemetryProps["containerLogVerDCR"] = "v1"
-								}
-							}
 						}
 						if len(os.Getenv("AZMON_MULTILINE_ENABLED")) > 0 {
 							telemetryProps["multilineEnabled"] = os.Getenv("AZMON_MULTILINE_ENABLED")

--- a/source/plugins/go/input/lib/cadvisor.go
+++ b/source/plugins/go/input/lib/cadvisor.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"Docker-Provider/source/plugins/go/src/extension"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -74,6 +76,8 @@ var (
 	winContainerPrevMetricRate              = make(map[string]float64)
 	Log                                     *logrus.Logger
 	osType                                  string
+	IsContainerLogV2DCR                     bool
+	ContainerType                           = os.Getenv("CONTAINER_TYPE")
 )
 
 func init() {
@@ -99,6 +103,8 @@ func init() {
 
 	Log.SetOutput(file)
 	Log.SetLevel(logrus.InfoLevel)
+
+	FLBLogger = CreateLogger(LogPath)
 }
 
 type metricDataItem map[string]interface{}
@@ -229,6 +235,10 @@ func getResponse(winNode map[string]string, relativeUri string) (*http.Response,
 }
 
 func GetMetrics(winNode map[string]string, namespaceFilteringMode string, namespaces []string, metricTime string) []metricDataItem {
+	if IsAADMSIAuthMode() {
+		IsContainerLogV2DCR = extension.GetInstance(FLBLogger, ContainerType).IsContainerLogV2(false)
+	}
+
 	cAdvisorStats, err := getSummaryStatsFromCAdvisor(winNode)
 
 	if err != nil {
@@ -1067,6 +1077,13 @@ func getContainerCpuMetricItems(metricInfo map[string]interface{}, hostName, met
 						}
 						if len(os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION")) > 0 {
 							telemetryProps["containerLogVer"] = os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION")
+							if IsAADMSIAuthMode() {
+								if IsContainerLogV2DCR {
+									telemetryProps["containerLogVerDCR"] = "v2"
+								} else {
+									telemetryProps["containerLogVerDCR"] = "v1"
+								}
+							}
 						}
 						if len(os.Getenv("AZMON_MULTILINE_ENABLED")) > 0 {
 							telemetryProps["multilineEnabled"] = os.Getenv("AZMON_MULTILINE_ENABLED")

--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1613,6 +1613,10 @@ func PostDataHelper(tailPluginRecords []map[interface{}]interface{}) int {
 			}
 			useFromCache := checkIfUseFromCache(&MdsdContainerLogTagRefreshTracker)
 			ContainerLogSchemaV2 = extension.GetInstance(FLBLogger, ContainerType).IsContainerLogV2(useFromCache)
+			// Check if schema version is already set to v2 in environment, otherwise use DCR
+			if strings.Compare(strings.TrimSpace(strings.ToLower(os.Getenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION"))), ContainerLogV2SchemaVersion) != 0 {
+				os.Setenv("AZMON_CONTAINER_LOG_SCHEMA_VERSION", ContainerLogV2SchemaVersion)
+			}
 		}
 
 		//ADX Schema & LAv2 schema are almost the same (except resourceId)

--- a/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
+++ b/source/plugins/ruby/CAdvisorMetricsAPIClient.rb
@@ -303,10 +303,6 @@ class CAdvisorMetricsAPIClient
                     if (!@subnetIpUsageMetrics.nil? && !@subnetIpUsageMetrics.empty?)
                       telemetryProps["int-ipsubnetusage"] = "1"
                     end
-                    #telemetry for Container log schema version clusterContainerLogSchemaVersion
-                    if (!@clusterContainerLogSchemaVersion.nil? && !@clusterContainerLogSchemaVersion.empty?)
-                      telemetryProps["containerLogVer"] = @clusterContainerLogSchemaVersion
-                    end
                     if (!@clusterMultilineEnabled.nil? && !@clusterMultilineEnabled.empty?)
                       telemetryProps["multilineEnabled"] = @clusterMultilineEnabled
                       if (!@clusterMultilineLanguages.nil? && !@clusterMultilineLanguages.empty?)


### PR DESCRIPTION
Longw/containerlogv2 fix telemetry bug
When msi mode, the containerlogv2 telemetry will based on the extension fetch
https://msazure.visualstudio.com/InfrastructureInsights/_workitems/edit/33107568