### PR TITLE
Zane/guardian check ignore

### DIFF
--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -1,0 +1,25 @@
+{
+  "tool": "credscan",
+  "suppressions": [
+    {
+      "file": "scripts/troubleshoot/TroubleshootError.ps1",
+      "line": 935,
+      "justification": "xx"
+    },
+    {
+      "file": "scripts/troubleshoot/TroubleshootError_nonAzureK8s.ps1", 
+      "line": 452,
+      "justification": "xx"
+    },
+    {
+      "file": "test/testkube/helm-testkube-values.yaml",
+      "line": 506,
+      "justification": "xx"
+    },
+    {
+      "file": "test/testkube/helm-testkube-values.yaml",
+      "line": 687,
+      "justification": "xx"
+    }
+  ]
+}

--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -4,22 +4,22 @@
     {
       "file": "scripts/troubleshoot/TroubleshootError.ps1",
       "line": 935,
-      "justification": "xx"
+      "justification": "general kubectl command to get cres for troubleshooting"
     },
     {
       "file": "scripts/troubleshoot/TroubleshootError_nonAzureK8s.ps1", 
       "line": 452,
-      "justification": "xx"
+      "justification": "general kubectl command to get cres for troubleshooting"
     },
     {
       "file": "test/testkube/helm-testkube-values.yaml",
       "line": 506,
-      "justification": "xx"
+      "justification": "a configuration key name, not a secret"
     },
     {
       "file": "test/testkube/helm-testkube-values.yaml",
       "line": 687,
-      "justification": "xx"
+      "justification": "used for ci testing clusters, not public accessible"
     }
   ]
 }

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -57,7 +57,7 @@ extends:
           - output: pipelineArtifact
             targetPath: '$(Build.ArtifactStagingDirectory)'
             artifactName: drop
-        steps:
+        steps:        
         - bash: |
             echo "Current directory: $(pwd)"
             echo "Contents of .gdn directory:"
@@ -65,7 +65,12 @@ extends:
             ls -la .gdn/ || echo ".gdn directory not found"
             echo "Build.SourcesDirectory: $(Build.SourcesDirectory)"
             echo "System.DefaultWorkingDirectory: $(System.DefaultWorkingDirectory)"
-          displayName: 'Debug Guardian suppression file location'
+            echo "Copying Guardian suppression file to workspace root..."
+            mkdir -p /mnt/vss/_work/1/.gdn
+            cp .gdn/.gdnsuppress /mnt/vss/_work/1/.gdn/.gdnsuppress
+            echo "Verification - suppression file copied:"
+            ls -la /mnt/vss/_work/1/.gdn/
+          displayName: 'Debug and fix Guardian suppression file location'
         - task: ComponentGovernanceComponentDetection@0
         - bash: |
             commit=$(git describe)

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -70,7 +70,7 @@ extends:
             cp .gdn/.gdnsuppress /mnt/vss/_work/1/.gdn/.gdnsuppress
             echo "Verification - suppression file copied:"
             ls -la /mnt/vss/_work/1/.gdn/
-          displayName: 'Debug and fix Guardian suppression file location'
+          displayName: 'copy over Guardian suppression file'
         - task: ComponentGovernanceComponentDetection@0
         - bash: |
             commit=$(git describe)

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -58,6 +58,14 @@ extends:
             targetPath: '$(Build.ArtifactStagingDirectory)'
             artifactName: drop
         steps:
+        - bash: |
+            echo "Current directory: $(pwd)"
+            echo "Contents of .gdn directory:"
+            find . -name ".gdnsuppress" -type f
+            ls -la .gdn/ || echo ".gdn directory not found"
+            echo "Build.SourcesDirectory: $(Build.SourcesDirectory)"
+            echo "System.DefaultWorkingDirectory: $(System.DefaultWorkingDirectory)"
+          displayName: 'Debug Guardian suppression file location'
         - task: ComponentGovernanceComponentDetection@0
         - bash: |
             commit=$(git describe)


### PR DESCRIPTION
build pipeline is failing due to ms guardian security scanning tool, and following 4 files have security risk

![image (2)](https://github.com/user-attachments/assets/05381627-df26-4b74-8e52-1a7969bc6b1e)
