### PR TITLE
Upgraded fluent-bit for windows with latest version

### DIFF
--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -26,7 +26,7 @@ Write-Host ('Creating folder structure')
 Write-Host ('Installing Fluent Bit');
 
     try {
-        $fluentBitUri='https://fluentbit.io/releases/3.0/fluent-bit-3.0.6-win64.zip'
+        $fluentBitUri='https://packages.fluentbit.io/windows/fluent-bit-4.0.3-win64.zip'
         Invoke-WebRequest -Uri $fluentBitUri -OutFile /installation/fluent-bit.zip
         Expand-Archive -Path /installation/fluent-bit.zip -Destination /installation/fluent-bit
         Move-Item -Path /installation/fluent-bit/*/* -Destination /opt/fluent-bit/ -ErrorAction SilentlyContinue


### PR DESCRIPTION
Memory usage (3.1.27 vs new image):
![image](https://github.com/user-attachments/assets/b2c04a47-3307-4d2c-bc96-c2e88dd3a6af)

I see some data increase in Prometheus metrics when I upgrade from current prod image but It's not related to the change - the metrics are coming differently for a linux node. When I downgrade from this change's image to current prod image, I see consistent numbers:
![image](https://github.com/user-attachments/assets/c85fed89-cf70-4ab3-9412-6e11c8bb1bb8)
![image](https://github.com/user-attachments/assets/db80b814-6d6b-47c9-ab3e-5e109102961a)
