### PR TITLE
CVE 202543857: uninstall net-imap gem

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -34,9 +34,8 @@ rm -rf /usr/lib/ruby/gems/3.3.0/gems/find-0.2.0
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/rdoc-6.6.3.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
 
-# remove net-imap gem and strscan as it has a known CVE (CVE-2025-43857) and is not used by the agent
+# remove net-imap gem as it has a known CVE (CVE-2025-43857) and is not used by the agent
 gem uninstall net-imap --force
-gem uninstall strscan --force
 
 sudo tdnf install -y azure-mdsd-1.35.1
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -33,8 +33,8 @@ rm /usr/lib/ruby/gems/3.3.0/specifications/default/find-0.2.0.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/find-0.2.0
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/rdoc-6.6.3.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
-rm /usr/lib/ruby/gems/3.3.0/specifications/default/net-imap-0.4.19.gemspec
-rm -rf /usr/lib/ruby/gems/3.3.0/gems/net-imap-0.4.19
+
+gem uninstall net-imap -v "0.4.19"
 
 sudo tdnf install -y azure-mdsd-1.35.1
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -34,8 +34,9 @@ rm -rf /usr/lib/ruby/gems/3.3.0/gems/find-0.2.0
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/rdoc-6.6.3.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
 
-# remove net-imap gem as it has a known CVE (CVE-2025-43857) and is not used by the agent
-gem uninstall net-imap -v "0.4.19"
+# remove net-imap gem and strscan as it has a known CVE (CVE-2025-43857) and is not used by the agent
+gem uninstall net-imap --force
+gem uninstall strscan --force
 
 sudo tdnf install -y azure-mdsd-1.35.1
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -33,6 +33,8 @@ rm /usr/lib/ruby/gems/3.3.0/specifications/default/find-0.2.0.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/find-0.2.0
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/rdoc-6.6.3.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
+rm /usr/lib/ruby/gems/3.3.0/specifications/default/net-imap-0.4.19.gemspec
+rm -rf /usr/lib/ruby/gems/3.3.0/gems/net-imap-0.4.19
 
 sudo tdnf install -y azure-mdsd-1.35.1
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d
@@ -87,7 +89,7 @@ gem install jwt -v "2.7.1" --no-document
 gem install racc --no-document
 
 # Fix CVE-2025-43857: Update net-imap to a non-vulnerable version
-gem install net-imap -v 0.5.7 --no-document
+gem install net-imap -v 0.5.8 --no-document
 
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -88,9 +88,6 @@ gem install ipaddress --no-document
 gem install jwt -v "2.7.1" --no-document
 gem install racc --no-document
 
-# Fix CVE-2025-43857: Update net-imap to a non-vulnerable version
-gem install net-imap -v 0.5.8 --no-document
-
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml
 rm -f $TMPDIR/envmdsd

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -34,6 +34,7 @@ rm -rf /usr/lib/ruby/gems/3.3.0/gems/find-0.2.0
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/rdoc-6.6.3.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
 
+# remove net-imap gem as it has a known CVE (CVE-2025-43857) and is not used by the agent
 gem uninstall net-imap -v "0.4.19"
 
 sudo tdnf install -y azure-mdsd-1.35.1

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -86,6 +86,9 @@ gem install ipaddress --no-document
 gem install jwt -v "2.7.1" --no-document
 gem install racc --no-document
 
+# Fix CVE-2025-43857: Update net-imap to a non-vulnerable version
+gem install net-imap -v 0.5.7 --no-document
+
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml
 rm -f $TMPDIR/envmdsd

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -33,6 +33,9 @@ RUN refreshenv \
 && gem install win32-event -v 0.6.3 \
 # remove rexml gem to avoid vulnerability
 && gem uninstall rexml -v 3.2.5 --force\
+# remove net-imap gem and strscan as it has a known CVE (CVE-2025-43857) and is not used by the agent
+&& gem uninstall net-imap --force \
+&& gem uninstall strscan --force \
 # The following gems are required for fluentd plugins, or ruby for configuration parsing
 && gem install windows-pr -v 1.2.6 \
 && gem install tomlrb -v 2.0.1 \

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -32,10 +32,9 @@ RUN refreshenv \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \
 # remove rexml gem to avoid vulnerability
-&& gem uninstall rexml -v 3.2.5 --force\
-# remove net-imap gem and strscan as it has a known CVE (CVE-2025-43857) and is not used by the agent
+&& gem uninstall rexml -v 3.2.5 --force \
+# remove net-imap gem as it has a known CVE (CVE-2025-43857) and is not used by the agent
 && gem uninstall net-imap --force \
-&& gem uninstall strscan --force \
 # The following gems are required for fluentd plugins, or ruby for configuration parsing
 && gem install windows-pr -v 1.2.6 \
 && gem install tomlrb -v 2.0.1 \


### PR DESCRIPTION
Memory usage (3.1.27 vs this change):
![image](https://github.com/user-attachments/assets/5fdce62f-cc54-4a86-9043-9fa2c61004b3)


No issues in the data flow or resource consumption.