### PR TITLE
geneva identity

### DIFF
--- a/Documentation/Internal/ContainerLogV2-Linux.xml
+++ b/Documentation/Internal/ContainerLogV2-Linux.xml
@@ -8,9 +8,9 @@
       <IdentityComponent name="ClusterResourceId" envariable="AKS_RESOURCE_ID"/>
       <IdentityComponent name="ClusterRegion" envariable="AKS_REGION"/>
       <IdentityComponent name="Computer" envariable="HOSTNAME"/>
-      <IdentityComponent name="Tenant">TENANT_ID</IdentityComponent>
-      <IdentityComponent name="Role">ROLE_ID</IdentityComponent>
-      <IdentityComponent name="RoleInstance">ROLEINSTANCE_ID</IdentityComponent>
+      <IdentityComponent name="Tenant" envariable="AKS_RESOURCE_ID"/>
+      <IdentityComponent name="Role" envariable="AKS_REGION"/>
+      <IdentityComponent name="RoleInstance" envariable="HOSTNAME"/>
     </Identity>
     <AgentResourceUsage diskQuotaInMB="50000" />
   </Management>

--- a/Documentation/Internal/ContainerLogV2-Windows.xml
+++ b/Documentation/Internal/ContainerLogV2-Windows.xml
@@ -7,9 +7,9 @@
       <IdentityComponent name="ClusterResourceId">GetEnvironmentVariable("AKS_RESOURCE_ID")</IdentityComponent>
       <IdentityComponent name="ClusterRegion">GetEnvironmentVariable("AKS_REGION")</IdentityComponent>
       <IdentityComponent name="Computer">GetEnvironmentVariable("HOSTNAME")</IdentityComponent>
-      <IdentityComponent name="Tenant">"TENANT_ID"</IdentityComponent>
-      <IdentityComponent name="Role">"ROLE_ID"</IdentityComponent>
-      <IdentityComponent name="RoleInstance">"ROLEINSTANCE_ID"</IdentityComponent>
+      <IdentityComponent name="Tenant">GetEnvironmentVariable("AKS_RESOURCE_ID")</IdentityComponent>
+      <IdentityComponent name="Role">GetEnvironmentVariable("AKS_REGION")</IdentityComponent>
+      <IdentityComponent name="RoleInstance">GetEnvironmentVariable("HOSTNAME")</IdentityComponent>
     </Identity>
     <AgentResourceUsage diskQuotaInMB="50000" />
   </Management>


### PR DESCRIPTION
geneva identity being used to load balance logs to different monikers.  This needs to be unique so that agent will load balances the correctly.