### PR TITLE
inject images to default component detection used by 1ES

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -323,14 +323,10 @@ extends:
           inputs:
             BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
             DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
-        - task: ComponentGovernanceComponentDetection@0
-          condition: eq(variables.IS_PR, true)
-          inputs:
-            DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE)'
-        - task: ComponentGovernanceComponentDetection@0
-          condition: eq(variables.IS_PR, false)
-          inputs:
-            DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+        - bash: |
+            dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+            echo "Docker images to scan: $dockerImagesToScan"
+          displayName: 'Set Docker images to scan'
       - job: build_windows_2019
         pool:
           name: Azure-Pipelines-CI-Test-EO

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -326,6 +326,7 @@ extends:
         - bash: |
             dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
             echo "Docker images to scan: $dockerImagesToScan"
+            echo "##vso[task.setvariable variable=dockerImagesToScan]$dockerImagesToScan"
           displayName: 'Set Docker images to scan'
       - job: build_windows_2019
         pool:


### PR DESCRIPTION
1ES has already component detection (CD) integrated, we can set `dockerImagesToScan`, and CD will scan the images we passed in.
