### PR TITLE
Add high logs scale support for ARC

### DIFF
--- a/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
@@ -128,6 +128,11 @@
     "dceName":"[if(greater(length(variables('dcrName')), 43), substring(variables('dcrName'), 0, 43), variables('dcrName'))]",
     "dceAssociationName": "configurationAccessEndpoint",
     "dataCollectionEndpointId": "[resourceId(variables('clusterSubscriptionId'), variables('clusterResourceGroup'), 'Microsoft.Insights/dataCollectionEndpoints', variables('dceName'))]",
+    "enableHighLogScaleMode": "[if(contains(parameters('streams'),'Microsoft-ContainerLogV2-HighScale'), bool('true'), bool('false'))]",
+    "ingestionDCENameFull": "[Concat('MSCI-ingest', '-', variables('workspaceLocation'), '-', variables('clusterName'))]",
+    "ingestionDCEName": "[if(greater(length(variables('ingestionDCENameFull')), 43), substring(variables('ingestionDCENameFull'), 0, 43), variables('ingestionDCENameFull'))]",
+    "ingestionDCE": "[if(endsWith(variables('ingestionDCEName'), '-'), substring(variables('ingestionDCEName'), 0, 42), variables('ingestionDCEName'))]",
+    "ingestionDataCollectionEndpointId": "[resourceId(variables('clusterSubscriptionId'), variables('clusterResourceGroup'), 'Microsoft.Insights/dataCollectionEndpoints', variables('ingestionDCE'))]",
     "privateLinkScopeName": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[8]]",
     "privateLinkScopeResourceGroup": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[4]]",
     "privateLinkScopeSubscriptionId": "[split(parameters('azureMonitorPrivateLinkScopeResourceId'),'/')[2]]",
@@ -178,7 +183,7 @@
                 ]
               }
             ],
-            "dataCollectionEndpointId": "[if(parameters('useAzureMonitorPrivateLinkScope'), variables('dataCollectionEndpointId'), json('null'))]"
+            "dataCollectionEndpointId": "[if(variables('enableHighLogScaleMode'), variables('ingestionDataCollectionEndpointId'), json('null'))]"
           }
         }
       ]
@@ -248,7 +253,7 @@
                 ]
               }
             ],
-            "dataCollectionEndpointId": "[if(parameters('useAzureMonitorPrivateLinkScope'), variables('dataCollectionEndpointId'), json('null'))]"
+            "dataCollectionEndpointId": "[if(variables('enableHighLogScaleMode'), variables('ingestionDataCollectionEndpointId'), json('null'))]"
           }
         }
       ]
@@ -267,6 +272,16 @@
               "publicNetworkAccess": "Disabled"
           }
       }
+    },
+    {
+      "condition": "[variables('enableHighLogScaleMode')]",
+      "type": "Microsoft.Insights/dataCollectionEndpoints",
+      "apiVersion": "2022-06-01",
+      "name": "[variables('ingestionDCE')]",
+      "location": "[variables('workspaceLocation')]",
+      "tags": "[parameters('resourceTagValues')]",
+      "kind": "Linux",
+      "properties": {}
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -345,7 +360,7 @@
       }
   },
   {
-      "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
+      "condition": "[and(parameters('useAzureMonitorPrivateLinkScope'), variables('enableHighLogScaleMode'))]",
       "type": "Microsoft.Resources/deployments",
       "name": "[Concat('arc-k8s-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('clusterResourceId')))]",
       "apiVersion": "2017-05-10",

--- a/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
@@ -364,7 +364,7 @@
       }
   },
   {
-      "condition": "[(parameters('useAzureMonitorPrivateLinkScope')]",
+      "condition": "[parameters('useAzureMonitorPrivateLinkScope')]",
       "type": "Microsoft.Resources/deployments",
       "name": "[Concat('arc-k8s-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('clusterResourceId')))]",
       "apiVersion": "2017-05-10",

--- a/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
@@ -281,7 +281,11 @@
       "location": "[variables('workspaceLocation')]",
       "tags": "[parameters('resourceTagValues')]",
       "kind": "Linux",
-      "properties": {}
+      "properties": {
+          "networkAcls": {
+              "publicNetworkAccess": "[if(parameters('useAzureMonitorPrivateLinkScope'), 'Disabled', 'Enabled')]"
+          }
+      }
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -360,14 +364,14 @@
       }
   },
   {
-      "condition": "[and(parameters('useAzureMonitorPrivateLinkScope'), variables('enableHighLogScaleMode'))]",
+      "condition": "[(parameters('useAzureMonitorPrivateLinkScope')]",
       "type": "Microsoft.Resources/deployments",
       "name": "[Concat('arc-k8s-monitoring-msi-ampls-scope', '-',  uniqueString(parameters('clusterResourceId')))]",
       "apiVersion": "2017-05-10",
       "subscriptionId": "[variables('privateLinkScopeSubscriptionId')]",
       "resourceGroup": "[variables('privateLinkScopeResourceGroup')]",
       "dependsOn": [
-          "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('ingestionDCE'))]"
+          "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
        ],
       "properties": {
         "mode": "Incremental",
@@ -379,7 +383,7 @@
           "resources": [
               {
                   "type": "microsoft.insights/privatelinkscopes/scopedresources",
-                  "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('ingestionDCE'), '-connection'))]",
+                  "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('dceName'), '-connection'))]",
                   "apiVersion": "2021-07-01-preview",
                   "properties": {
                       "linkedResourceId": "[variables('dataCollectionEndpointId')]"
@@ -389,6 +393,37 @@
           ]
         },
         "parameters": {}
+      }
+  },
+  {
+      "condition": "[and(parameters('useAzureMonitorPrivateLinkScope'), variables('enableHighLogScaleMode'))]",
+      "type": "Microsoft.Resources/deployments",
+      "name": "[Concat('aks-monitoring-msi-ampls-scope-ingest', '-',  uniqueString(parameters('aksResourceId')))]",
+      "apiVersion": "2017-05-10",
+      "subscriptionId": "[variables('privateLinkScopeSubscriptionId')]",
+      "resourceGroup": "[variables('privateLinkScopeResourceGroup')]",
+      "dependsOn": [
+          "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('ingestionDCE'))]"
+      ],
+      "properties": {
+          "mode": "Incremental",
+          "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {},
+              "variables": {},
+              "resources": [
+                  {
+                      "type": "microsoft.insights/privatelinkscopes/scopedresources",
+                      "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('ingestionDCE'), '-connection'))]",
+                      "apiVersion": "2021-07-01-preview",
+                      "properties": {
+                          "linkedResourceId": "[variables('ingestionDataCollectionEndpointId')]"
+                      }
+                  }
+              ]
+          },
+          "parameters": {}
       }
   },
   {

--- a/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
+++ b/scripts/onboarding/templates/arc-k8s-extension-msi-auth/existingClusterOnboarding.json
@@ -367,7 +367,7 @@
       "subscriptionId": "[variables('privateLinkScopeSubscriptionId')]",
       "resourceGroup": "[variables('privateLinkScopeResourceGroup')]",
       "dependsOn": [
-          "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('dceName'))]"
+          "[resourceId('Microsoft.Insights/dataCollectionEndpoints/', variables('ingestionDCE'))]"
        ],
       "properties": {
         "mode": "Incremental",
@@ -379,7 +379,7 @@
           "resources": [
               {
                   "type": "microsoft.insights/privatelinkscopes/scopedresources",
-                  "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('dceName'), '-connection'))]",
+                  "name": "[concat(variables('privateLinkScopeName'), '/', concat(variables('ingestionDCE'), '-connection'))]",
                   "apiVersion": "2021-07-01-preview",
                   "properties": {
                       "linkedResourceId": "[variables('dataCollectionEndpointId')]"


### PR DESCRIPTION
Add high logs scale support for ARC 
with high log scale: 
![image](https://github.com/user-attachments/assets/a32b8ef4-5743-4bec-af60-495456ee6346)
without: 
![image](https://github.com/user-attachments/assets/21b6e2f3-9eb5-4d19-a9af-0676f6493900)

Added ampls support:
similar to logic: https://github.com/microsoft/Docker-Provider/blob/a1a39074e228a0606074b52eefd4fec875fe4214/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterOnboarding.json#L394