### PR TITLE
mdsd version upgrade 1.35.7

### DIFF
--- a/charts/azuremonitor-containers-geneva/values.yaml
+++ b/charts/azuremonitor-containers-geneva/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: mcr.microsoft.com/azuremonitor/containerinsights/ciprod
   tag: "3.1.27"
   pullPolicy: IfNotPresent
-  agentVersion: "azure-mdsd-1.35.1"
+  agentVersion: "azure-mdsd-1.35.7"
 nameOverride: ""
 enableInternalMetrics: false
 enableKubernetesMetadata: false

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -28,7 +28,7 @@ amalogs:
     tagWindows: "win-3.1.27"
     pullPolicy: IfNotPresent
     dockerProviderVersion: "18.0.1-0"
-    agentVersion: "azure-mdsd-1.35.1"
+    agentVersion: "azure-mdsd-1.35.7"
     winAgentVersion: "46.17.2" # there is no base agent version for windows agent
 
   # The priority used by the ama-logs priority class for the daemonset pods

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -365,7 +365,7 @@ spec:
         #     - --health-server-listening-port=9999
         #     - --restart-pod-waiting-minutes-on-broken-connection=240
         #   # Make sure this matching with version in AKS RP side
-        #   image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.230804.1
+        #   image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.250604.1
         #   imagePullPolicy: IfNotPresent
         #   env:
         #     - name: AZMON_COLLECT_ENV
@@ -801,7 +801,7 @@ spec:
 #             - --health-server-listening-port=9999
 #             - --restart-pod-waiting-minutes-on-broken-connection=240
 #           # Make sure this matching with version in AKS RP side
-#           image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.230804.1
+#           image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.250604.1
 #           imagePullPolicy: IfNotPresent
 #           env:
 #             - name: AZMON_COLLECT_ENV
@@ -1013,7 +1013,7 @@ spec:
         #     - --health-server-listening-port=9999
         #     - --restart-pod-waiting-minutes-on-broken-connection=240
         #   # Make sure this matching with version in AKS RP side
-        #   image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.230804.1
+        #   image: mcr.microsoft.com/aks/msi/addon-token-adapter:master.250604.1
         #   imagePullPolicy: IfNotPresent
         #   env:
         #     - name: AZMON_COLLECT_ENV

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -1277,7 +1277,7 @@ spec:
       #     - --secret-name=aad-msi-auth-token
       #     - --token-server-listening-port=7777
       #     - --health-server-listening-port=9999
-      #    image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.240102.1"
+      #    image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.250604.1"
       #    imagePullPolicy: Always
       #    livenessProbe:
       #     httpGet:

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -343,7 +343,7 @@ spec:
         component: ama-logs-agent
         tier: node
       annotations:
-        agentVersion: "azure-mdsd-1.35.1"
+        agentVersion: "azure-mdsd-1.35.7"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
         kubernetes.azure.com/no-http-proxy-vars: "true"
@@ -784,7 +784,7 @@ spec:
 #       labels:
 #         rsName: "ama-logs-multitenancy"
 #       annotations:
-#         agentVersion: "azure-mdsd-1.35.1"
+#         agentVersion: "azure-mdsd-1.35.7"
 #         dockerProviderVersion: "18.0.1-0"
 #         schema-versions: "v1"
 #         kubernetes.azure.com/no-http-proxy-vars: "true"
@@ -959,7 +959,7 @@ spec:
       labels:
         rsName: "ama-logs-rs"
       annotations:
-        agentVersion: "azure-mdsd-1.35.1"
+        agentVersion: "azure-mdsd-1.35.7"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
         kubernetes.azure.com/no-http-proxy-vars: "true"

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -37,7 +37,7 @@ rm -rf /usr/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
 # remove net-imap gem as it has a known CVE (CVE-2025-43857) and is not used by the agent
 gem uninstall net-imap --force
 
-sudo tdnf install -y azure-mdsd-1.35.1
+sudo tdnf install -y azure-mdsd-1.35.7
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d
 cp -f $TMPDIR/envmdsd /etc/mdsd.d
 rm /usr/sbin/telegraf


### PR DESCRIPTION
This pull request updates the `agentVersion` of the `azure-mdsd` agent across multiple configuration files and scripts to version `1.35.7`. Additionally, it modifies the installation script to ensure the updated version is installed. These changes ensure consistency and compatibility across the deployment configurations.

### Updates to MDSD `agentVersion`:

* [`charts/azuremonitor-containers-geneva/values.yaml`](diffhunk://#diff-2ab6faba108ff1e3be9ec05ba326418f6f377227c44824395995e3fce689c551L20-R20): Updated `agentVersion` from `1.35.1` to `1.35.7` to align with the latest release.
* [`charts/azuremonitor-containers/values.yaml`](diffhunk://#diff-c143ea0bc79e879c685e11a8b334d9cf66ed4c7cdaab210e63c27b6a550942a9L31-R31): Updated `agentVersion` from `1.35.1` to `1.35.7` under the `amalogs` section.
* `kubernetes/ama-logs.yaml`: Updated `agentVersion` annotations in multiple locations to `1.35.7` for consistency:
  - `spec` section at line 343.
  - Commented `spec` section at line 784.
  - `spec` section at line 959.

### Installation script update:

* [`kubernetes/linux/setup.sh`](diffhunk://#diff-41e13b2078423187d4de7802d178ff603e09a6aec1c0c653dbe02834cfd15315L40-R40): Modified the installation command to use `azure-mdsd-1.35.7`, ensuring the latest version is installed during setup.

MDSD changes between 1.35.1 to 1.35.7
------------------------------------------------------
1. Only applicable changes related to Bleu cloud support
2. This only released version after1.35.1 and there are no other minor versions in between.

-------------------------------------------------------
Following scenarios being validated
1. Legacy auth
3. MSI auth (with and without high scale) (x64, arm64, FIPs)(Ubuntu)(Azure Linux)
4. Geneva Path

Resource Usage (before or after mdsd upgrade)
DS Memory Usage
![image](https://github.com/user-attachments/assets/6d132b02-28e2-490b-aed3-f63a31cd477a)
DS CPU Usage
![image](https://github.com/user-attachments/assets/d7cc6f63-0eaf-4110-92dc-45fddaf338a7)



RS Memory Usage
![image](https://github.com/user-attachments/assets/b162912a-94a6-4eb2-b2d7-9dae2be511d6)
 RS CPU Usage
![image](https://github.com/user-attachments/assets/818a66c3-52b6-42e2-9a8f-503b7957e709)





