### PR TITLE
Zane/win ama agent 46.31.3

### DIFF
--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -29,7 +29,7 @@ amalogs:
     pullPolicy: IfNotPresent
     dockerProviderVersion: "18.0.1-0"
     agentVersion: "azure-mdsd-1.35.1"
-    winAgentVersion: "46.17.2" # there is no base agent version for windows agent
+    winAgentVersion: "46.31.3" # there is no base agent version for windows agent
 
   # The priority used by the ama-logs priority class for the daemonset pods
   # Note that this is not execution piority - it is scheduling priority, as

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -29,6 +29,7 @@ amalogs:
     pullPolicy: IfNotPresent
     dockerProviderVersion: "18.0.1-0"
     agentVersion: "azure-mdsd-1.35.1"
+    # TODO: update it to 46.31.3 after windows ama agent version update is merged
     winAgentVersion: "46.17.2" # there is no base agent version for windows agent
 
   # The priority used by the ama-logs priority class for the daemonset pods

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -1257,6 +1257,7 @@ spec:
         component: ama-logs-agent-windows
         tier: node-win
       annotations:
+        # TODO: update it to 46.31.3 after windows ama agent version update is merged
         agentVersion: "46.17.2"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -1257,7 +1257,7 @@ spec:
         component: ama-logs-agent-windows
         tier: node-win
       annotations:
-        agentVersion: "46.17.2"
+        agentVersion: "46.31.3"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
         kubernetes.azure.com/no-http-proxy-vars: "true"

--- a/kubernetes/windows/setup.ps1
+++ b/kubernetes/windows/setup.ps1
@@ -74,7 +74,7 @@ Write-Host ('Finished Extracting Certificate Generator Package')
 $windowsazuremonitoragent = [System.Environment]::GetEnvironmentVariable("WINDOWS_AMA_URL_NEW", "process")
 if ([string]::IsNullOrEmpty($windowsazuremonitoragent)) {
     Write-Host ('Environment variable WINDOWS_AMA_URL is not set. Using default value')
-    $windowsazuremonitoragent = "https://github.com/microsoft/Docker-Provider/releases/download/windows-ama-bits/genevamonitoringagent.46.17.2.zip"
+    $windowsazuremonitoragent = "https://github.com/microsoft/Docker-Provider/releases/download/windows-ama-bits/genevamonitoringagent.46.31.3.zip"
 }
 Write-Host ('Installing Windows Azure Monitor Agent: ' + $windowsazuremonitoragent)
 try {


### PR DESCRIPTION
from AMA team suggested to use 46.31.3 and this is latest version which is already deployed to entire world for VMs

**1. MSI cluster**


**2.1 3.1.27 vs new image**
cpu, memory, and v2log
before June 22, new image
after June 22, win-3.1.27.

![image](https://github.com/user-attachments/assets/08373ba7-a0d2-42b8-ab74-882e03c7f36d)


**2.2 trend of new image in 3 days**

![image](https://github.com/user-attachments/assets/0ff08a21-9915-4565-abc9-fc9ec3456a17)

the dips likely some node maintenance because I see a container in another cluster was cycled around the same time.


----------------------------------------------------------------
**2. geneva cluster** 

**1. geneva data flow check:**
-------------------------------------
**before**
![image](https://github.com/user-attachments/assets/e54c70b5-0018-4010-ae1d-aaea02f64d01)


**after**
![image](https://github.com/user-attachments/assets/cadd02de-9966-4e88-9b7f-381aecb87db4)

<br>
<br>
<br>
<br>

----------------------------------
**before**
![image](https://github.com/user-attachments/assets/15cc7bc5-85c5-4e53-ac86-2f1e0b68d0b2)


**after**
![image](https://github.com/user-attachments/assets/72ba5912-4571-4c70-83d6-1111587f6919)

<br>
<br>
<br>
<br>

---------------------------

**before**
![image](https://github.com/user-attachments/assets/d629711c-83e7-4b39-8298-4dc2e238bc36)

**after**
![image](https://github.com/user-attachments/assets/8fae00ce-aff0-4b25-ac28-48575a694ecc)



------------
**2.2 check container logs**


Searching for pods starting with 'ama-logs-' (excluding 'ama-logs-windows-' and 'ama-logs-rs')...
Found pods starting with 'ama-logs-', checking logs for errors in 'ama-logs' containers...
----------------------------------------------
Checking logs for errors in Pod: ama-logs-9brns, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-9j9gx, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-j8dqt, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-pdjvl, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-rtjqd, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-sdbh4, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-td8vs, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-vnvl2, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-whzrt, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-geneva-deployment-56d7c64595-s5kzf, Container: ama-logs, Namespace: partner-1
----------------------------------------------
No errors found in logs.
----------------------------------------------
Searching for pods starting with 'ama-logs-rs'...
Found pods starting with 'ama-logs-rs', checking logs for errors in 'ama-logs' containers...
----------------------------------------------
Checking logs for errors in Pod: ama-logs-rs-646b49d5cb-k8dtf, Container: ama-logs, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Searching for Windows pods starting with 'ama-logs-windows-'...
Found Windows pods starting with 'ama-logs-windows-', checking logs for errors in 'ama-logs-windows' containers...
----------------------------------------------
Checking logs for errors in Pod: ama-logs-windows-4qx7t, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-windows-5qjv4, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Checking logs for errors in Pod: ama-logs-windows-s267s, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
No errors found in logs.
----------------------------------------------
Log checking complete.





**2.3. process logs**

Searching for pods starting with 'ama-logs-' (excluding 'ama-logs-windows-' and 'ama-logs-rs')...
Found pods starting with 'ama-logs-', checking process logs in 'ama-logs' containers...
----------------------------------------------
Checking process logs in Pod: ama-logs-9brns, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:34:39 extension.go:69: Error::mdsd/ama::Failed to get config response data for extension: ContainerInsights, error: dial unix /var/run/mdsd-PrometheusSidecar/default_fluent.socket: connect: no such file or directory
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-9j9gx, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:34:39 extension.go:69: Error::mdsd/ama::Failed to get config response data for extension: ContainerInsights, error: dial unix /var/run/mdsd-PrometheusSidecar/default_fluent.socket: connect: no such file or directory
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-j8dqt, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:16:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-pdjvl, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:16:27 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-rtjqd, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:34:40 extension.go:69: Error::mdsd/ama::Failed to get config response data for extension: ContainerInsights, error: dial unix /var/run/mdsd-PrometheusSidecar/default_fluent.socket: connect: no such file or directory
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:34:40 extension.go:69: Error::mdsd/ama::Failed to get config response data for extension: ContainerInsights, error: dial unix /var/run/mdsd-PrometheusSidecar/default_fluent.socket: connect: no such file or directory
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-sdbh4, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/linuxmonagent/log/mdsd.warn:2025-06-24T00:34:45.3184070Z: [/__w/1/s/external/GenevaMonAgent-Shared-CrossPlat/src/XPlatLib/src/ImdsEndpointFetcherLinux.cpp:65,CheckIfHimdsServiceInstalled]Failed to check for himdsd service via systemctl, error: execve failed: No such file or directory ErrorCode:-2146041086
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:27 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:27 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-td8vs, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:16:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-vnvl2, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:16:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-whzrt, Container: ama-logs, Namespace: kube-system
----------------------------------------------
ERRORS FOUND in container process logs:
/var/opt/microsoft/linuxmonagent/log/mdsd.warn:2025-06-24T00:34:42.2243860Z: [/__w/1/s/external/GenevaMonAgent-Shared-CrossPlat/src/XPlatLib/src/ImdsEndpointFetcherLinux.cpp:65,CheckIfHimdsServiceInstalled]Failed to check for himdsd service via systemctl, error: execve failed: No such file or directory ErrorCode:-2146041086
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 00:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:15:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:16:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:17:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:18:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:19:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:20:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:21:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:22:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:23:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:24:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:25:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:26:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:27:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:28:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:29:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:30:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:31:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:32:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:33:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:34:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:35:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:36:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:37:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:38:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:39:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:40:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:41:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:42:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:43:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:44:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:45:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:46:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:47:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:48:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:49:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:50:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:51:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:52:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:53:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:54:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:55:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:56:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:57:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:58:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 01:59:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:00:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:01:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:02:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:03:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:04:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:05:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:06:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:07:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:08:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:09:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:10:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:11:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:12:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:13:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:14:28 oms.go:645: In config error existing hash update
/var/opt/microsoft/docker-cimprov/log/fluent-bit-out-oms-runtime.log:2025/06/24 02:15:28 oms.go:645: In config error existing hash update
----------------------------------------------
Checking process logs in Pod: ama-logs-geneva-deployment-56d7c64595-s5kzf, Container: ama-logs, Namespace: partner-1
----------------------------------------------
Failed to execute command in container. Container might not be running or doesn't have bash.
----------------------------------------------
Searching for pods starting with 'ama-logs-rs'...
Found pods starting with 'ama-logs-rs', checking process logs in 'ama-logs-rs' containers...
----------------------------------------------
Searching for Windows pods starting with 'ama-logs-windows-'...
Found Windows pods starting with 'ama-logs-windows-', checking process logs in 'ama-logs-windows' containers...
----------------------------------------------
Checking process logs in Pod: ama-logs-windows-4qx7t, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
Checking C:\etc\fluent-bit logs:
No errors found in fluent-bit logs or command failed.
Checking C:\etc\amalogswindows logs:
No errors found in amalogswindows logs or command failed.
Checking C:\etc\telegraf logs:
No errors found in telegraf logs or command failed.
----------------------------------------------
Checking process logs in Pod: ama-logs-windows-5qjv4, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
Checking C:\etc\fluent-bit logs:
No errors found in fluent-bit logs or command failed.
Checking C:\etc\amalogswindows logs:
No errors found in amalogswindows logs or command failed.
Checking C:\etc\telegraf logs:
No errors found in telegraf logs or command failed.
----------------------------------------------
Checking process logs in Pod: ama-logs-windows-s267s, Container: ama-logs-windows, Namespace: kube-system
----------------------------------------------
Checking C:\etc\fluent-bit logs:
No errors found in fluent-bit logs or command failed.
Checking C:\etc\amalogswindows logs:
No errors found in amalogswindows logs or command failed.
Checking C:\etc\telegraf logs:
No errors found in telegraf logs or command failed.
----------------------------------------------
Process log checking complete.