### PR TITLE
fix endpoint name for bleu

### DIFF
--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -309,7 +309,7 @@ function Get-McsGlobalEndpoint{
                 "azureusgovernmentcloud"  { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us" }
                 "usnat"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov" }
                 "ussec"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud" }
-                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.sovcloud-api.fr" }
+                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
             }
         }
     }

--- a/test/unit-tests/test_cases/Test-GetMcsGlobalEndpoint.ps1
+++ b/test/unit-tests/test_cases/Test-GetMcsGlobalEndpoint.ps1
@@ -43,7 +43,7 @@ function Test-CloudEnvironments {
         },
         @{
             cloud = "bleu"
-            expected = "https://global.handler.control.sovcloud-api.fr"
+            expected = "https://global.handler.control.monitor.sovcloud-api.fr"
         }
     )
 

--- a/test/unit-tests/test_functions/Get-McsGlobalEndpoint.ps1
+++ b/test/unit-tests/test_functions/Get-McsGlobalEndpoint.ps1
@@ -25,7 +25,7 @@ function Get-McsGlobalEndpoint{
                 "azureusgovernmentcloud"  { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us" }
                 "usnat"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov" }
                 "ussec"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud" }
-                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.sovcloud-api.fr" }
+                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
             }
         }
     }


### PR DESCRIPTION
This pull request updates the endpoint URL for the "bleu" cloud environment across both the main script and associated test files to ensure consistency and correctness.

### Endpoint Update for "bleu" Cloud Environment:

* In `kubernetes/windows/main.ps1`, the endpoint for "bleu" was updated from `https://global.handler.control.sovcloud-api.fr` to `https://global.handler.control.monitor.sovcloud-api.fr`.
* In `test/unit-tests/test_functions/Get-McsGlobalEndpoint.ps1`, the same update was made to align the test function with the main script.
* In `test/unit-tests/test_cases/Test-GetMcsGlobalEndpoint.ps1`, the expected value for the "bleu" cloud environment was updated in the test case to reflect the new endpoint.