### PR TITLE
AMCS bug fix for Geneva

### DIFF
--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -165,9 +165,9 @@ function Set-AMA3PEnvironmentVariables {
     Set-ProcessAndMachineEnvVariables "MCS_CUSTOM_RESOURCE_ID" $aksResourceId
     $domain = Get-LogAnalyticsWorkspaceDomain
     $cloud_environment = Get-ClusterCloudEnvironment($domain)
-    $mcs_endpoint = Get-McsEndpoint($cloud_environment)
+    $mcs_azure_resource_endpoint = Get-McsAzureResourceEndpoint($cloud_environment)
     $mcs_globalendpoint = Get-McsGlobalEndpoint($cloud_environment)
-    Set-ProcessAndMachineEnvVariables "MCS_AZURE_RESOURCE_ENDPOINT" $mcs_endpoint
+    Set-ProcessAndMachineEnvVariables "MCS_AZURE_RESOURCE_ENDPOINT" $mcs_azure_resource_endpoint
     Set-ProcessAndMachineEnvVariables "MCS_GLOBAL_ENDPOINT" $mcs_globalendpoint
 }
 
@@ -263,19 +263,37 @@ function Get-LogAnalyticsWorkspaceDomain() {
     }
 }
 
+function Get-McsAzureResourceEndpoint {
+    param (
+        [string]$cloud_environment
+    )
+    $mcs_azure_resource_endpoint = "https://monitor.azure.com/"
+    if (![string]::IsNullOrEmpty($cloud_environment)) {
+        switch ($cloud_environment.ToLower()) {
+            "azurepubliccloud"        { $mcs_azure_resource_endpoint = "https://monitor.azure.com/" }
+            "azurechinacloud"         { $mcs_azure_resource_endpoint = "https://monitor.azure.cn/" }
+            "azureusgovernmentcloud"  { $mcs_azure_resource_endpoint = "https://monitor.azure.us/" }
+            "usnat"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.eaglex.ic.gov/" }
+            "ussec"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.microsoft.scloud/" }
+            "bleu"                    { $mcs_azure_resource_endpoint = "https://monitor.sovcloud-api.fr/" }
+        }
+    }
+    return $mcs_azure_resource_endpoint
+}
+
 function Get-McsEndpoint {
     param (
         [string]$cloud_environment
     )
-    $mcs_endpoint = "https://monitor.azure.com/"
+    $mcs_endpoint = "monitor.azure.com"
     if (![string]::IsNullOrEmpty($cloud_environment)) {
         switch ($cloud_environment.ToLower()) {
-            "azurepubliccloud"        { $mcs_endpoint = "https://monitor.azure.com/" }
-            "azurechinacloud"         { $mcs_endpoint = "https://monitor.azure.cn/" }
-            "azureusgovernmentcloud"  { $mcs_endpoint = "https://monitor.azure.us/" }
-            "usnat"                   { $mcs_endpoint = "https://monitor.azure.eaglex.ic.gov/" }
-            "ussec"                   { $mcs_endpoint = "https://monitor.azure.microsoft.scloud/" }
-            "bleu"                    { $mcs_endpoint = "https://monitor.sovcloud-api.fr/" }
+            "azurepubliccloud"        { $mcs_endpoint = "monitor.azure.com" }
+            "azurechinacloud"         { $mcs_endpoint = "monitor.azure.cn" }
+            "azureusgovernmentcloud"  { $mcs_endpoint = "monitor.azure.us" }
+            "usnat"                   { $mcs_endpoint = "monitor.azure.eaglex.ic.gov" }
+            "ussec"                   { $mcs_endpoint = "monitor.azure.microsoft.scloud" }
+            "bleu"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
         }
     }
     return $mcs_endpoint

--- a/source/plugins/go/src/ingestion_token_utils.go
+++ b/source/plugins/go/src/ingestion_token_utils.go
@@ -154,7 +154,7 @@ func getAccessTokenFromIMDS() (string, int64, error) {
 	if useIMDSTokenProxyEndPoint != "" && strings.Compare(strings.ToLower(useIMDSTokenProxyEndPoint), "true") == 0 {
 		Log("Info Reading IMDS Access Token from IMDS Token proxy endpoint")
 		mcsEndpoint := os.Getenv("MCS_ENDPOINT")
-		msi_endpoint_string := fmt.Sprintf("http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=%s", mcsEndpoint)
+		msi_endpoint_string := fmt.Sprintf("http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://%s/", mcsEndpoint)
 		var msi_endpoint *url.URL
 		msi_endpoint, err := url.Parse(msi_endpoint_string)
 		if err != nil {
@@ -332,8 +332,12 @@ func getAgentConfiguration(imdsAccessToken string) (configurationId string, chan
 	osType := os.Getenv("OS_TYPE")
 	resourceId := os.Getenv("AKS_RESOURCE_ID")
 	resourceRegion := os.Getenv("AKS_REGION")
-	AmcsEndpoint = os.Getenv("MCS_GLOBAL_ENDPOINT")
+	mcsEndpoint := os.Getenv("MCS_ENDPOINT")
 
+	AmcsEndpoint = fmt.Sprintf("https://global.handler.control.%s", mcsEndpoint)
+	if strings.Compare(strings.ToLower(resourceRegion), "eastus2euap") == 0 || strings.Compare(strings.ToLower(resourceRegion), "centraluseuap") == 0 {
+		AmcsEndpoint = fmt.Sprintf("https://global.handler.canary.control.%s", mcsEndpoint)
+	}
 	if AMCSRedirectedEndpoint != "" {
 		AmcsEndpoint = AMCSRedirectedEndpoint
 	}
@@ -485,8 +489,9 @@ func getIngestionAuthToken(imdsAccessToken string, configurationId string, chann
 	osType := os.Getenv("OS_TYPE")
 	resourceId := os.Getenv("AKS_RESOURCE_ID")
 	resourceRegion := os.Getenv("AKS_REGION")
-	AmcsEndpoint = os.Getenv("MCS_GLOBAL_ENDPOINT")
+	mcsEndpoint := os.Getenv("MCS_ENDPOINT")
 
+	AmcsEndpoint = fmt.Sprintf("https://global.handler.control.%s", mcsEndpoint)
 	if AMCSRedirectedEndpoint != "" {
 		AmcsEndpoint = AMCSRedirectedEndpoint
 	}

--- a/test/unit-tests/test_cases/Test-GetMcsEndpoint.ps1
+++ b/test/unit-tests/test_cases/Test-GetMcsEndpoint.ps1
@@ -8,27 +8,27 @@ function Test-CloudEnvironments {
     $testCases = @(
         @{
             cloud = "azurepubliccloud"
-            expected = "https://monitor.azure.com/"
+            expected = "monitor.azure.com"
         },
         @{
             cloud = "azurechinacloud"
-            expected = "https://monitor.azure.cn/"
+            expected = "monitor.azure.cn"
         },
         @{
             cloud = "azureusgovernmentcloud"
-            expected = "https://monitor.azure.us/"
+            expected = "monitor.azure.us"
         },
         @{
             cloud = "usnat"
-            expected = "https://monitor.azure.eaglex.ic.gov/"
+            expected = "monitor.azure.eaglex.ic.gov"
         },
         @{
             cloud = "ussec"
-            expected = "https://monitor.azure.microsoft.scloud/"
+            expected = "monitor.azure.microsoft.scloud"
         },
         @{
             cloud = "bleu"
-            expected = "https://monitor.sovcloud-api.fr/"
+            expected = "monitor.sovcloud-api.fr"
         }
     )
 
@@ -43,13 +43,13 @@ function Test-CloudEnvironments {
 function Test-DefaultEndpoint {
     Setup
     $result = Get-McsEndpoint -cloud_environment $null
-    Assert-Equals "https://monitor.azure.com/" $result "(with null cloud environment)"
+    Assert-Equals "monitor.azure.com" $result "(with null cloud environment)"
 
     $result = Get-McsEndpoint -cloud_environment ""
-    Assert-Equals "https://monitor.azure.com/" $result "(with empty cloud environment)"
+    Assert-Equals "monitor.azure.com" $result "(with empty cloud environment)"
 
     $result = Get-McsEndpoint -cloud_environment "invalid"
-    Assert-Equals "https://monitor.azure.com/" $result "(with invalid cloud environment)"
+    Assert-Equals "monitor.azure.com" $result "(with invalid cloud environment)"
     Teardown
 }
 
@@ -63,7 +63,7 @@ function Test-CaseSensitivity {
     foreach ($cloud in $testCases) {
         Setup
         $result = Get-McsEndpoint -cloud_environment $cloud
-        Assert-Equals "https://monitor.azure.com/" $result "(case sensitivity check for $cloud)"
+        Assert-Equals "monitor.azure.com" $result "(case sensitivity check for $cloud)"
         Teardown
     }
 }

--- a/test/unit-tests/test_functions/Get-McsEndpoint.ps1
+++ b/test/unit-tests/test_functions/Get-McsEndpoint.ps1
@@ -2,15 +2,15 @@ function Get-McsEndpoint {
     param (
         [string]$cloud_environment
     )
-    $mcs_endpoint = "https://monitor.azure.com/"
+    $mcs_endpoint = "monitor.azure.com"
     if (![string]::IsNullOrEmpty($cloud_environment)) {
         switch ($cloud_environment.ToLower()) {
-            "azurepubliccloud"        { $mcs_endpoint = "https://monitor.azure.com/" }
-            "azurechinacloud"         { $mcs_endpoint = "https://monitor.azure.cn/" }
-            "azureusgovernmentcloud"  { $mcs_endpoint = "https://monitor.azure.us/" }
-            "usnat"                   { $mcs_endpoint = "https://monitor.azure.eaglex.ic.gov/" }
-            "ussec"                   { $mcs_endpoint = "https://monitor.azure.microsoft.scloud/" }
-            "bleu"                    { $mcs_endpoint = "https://monitor.sovcloud-api.fr/" }
+            "azurepubliccloud"        { $mcs_endpoint = "monitor.azure.com" }
+            "azurechinacloud"         { $mcs_endpoint = "monitor.azure.cn" }
+            "azureusgovernmentcloud"  { $mcs_endpoint = "monitor.azure.us" }
+            "usnat"                   { $mcs_endpoint = "monitor.azure.eaglex.ic.gov" }
+            "ussec"                   { $mcs_endpoint = "monitor.azure.microsoft.scloud" }
+            "bleu"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
         }
     }
     return $mcs_endpoint


### PR DESCRIPTION
The changes in PR https://github.com/microsoft/Docker-Provider/pull/1501/files doesn't work for Geneva path as MCS_GLOBAL_ENDPOINT is note getting set for Geneva path.

Reverting the changes and fixed the MCS_ENDPOINT env variable.