### PR TITLE
Cert mount fix for AGC

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -675,7 +675,7 @@ if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ "
     if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
       cp /etc/ama-logs-secret/PROXYCERT.crt /etc/pki/ca-trust/source/PROXYCERT.crt
     fi
-    update-ca-trust     
+    update-ca-trust
   else
     if [ $OS_ID != "ubuntu" ]; then
       echo "Error: The ID in /etc/os-release is not ubuntu or azurelinux. Defaulting to ubuntu."

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -669,17 +669,7 @@ fi
 # Adding AzureLinux now even though the elif will never currently evaluate.
 if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ "$IS_CUSTOM_CERT" == "true" ]; then
   OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f2 | tr -d '"' | tr -d "'")
-  if [ $OS_ID == "azurelinux" ]; then
-    cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
-    cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
-    if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
-      cp /etc/ama-logs-secret/PROXYCERT.crt /etc/pki/ca-trust/source/PROXYCERT.crt
-    fi
-    update-ca-trust
-  else
-    if [ $OS_ID != "ubuntu" ]; then
-      echo "Error: The ID in /etc/os-release is not ubuntu or azurelinux. Defaulting to ubuntu."
-    fi
+  if [ $OS_ID == "ubuntu" ]; then
     cp /anchors/ubuntu/* /usr/local/share/ca-certificates/
     cp /anchors/mariner/* /usr/local/share/ca-certificates/
     if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
@@ -687,6 +677,16 @@ if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ "
     fi
     update-ca-certificates
     cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+  else
+    if [ $OS_ID != "azurelinux" ]; then
+      echo "Error: The ID in /etc/os-release is not ubuntu or azurelinux. Defaulting to azurelinux."
+    fi
+    cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
+    cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
+    if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
+      cp /etc/ama-logs-secret/PROXYCERT.crt /etc/pki/ca-trust/source/PROXYCERT.crt
+    fi
+    update-ca-trust
   fi
 fi
 

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -660,25 +660,25 @@ else
       echo "LA Onboarding:Workspace Id not mounted, skipping the telemetry check"
 fi
 
-# Copying over CA certs for airgapped clouds. This is needed for Mariner vs Ubuntu hosts.
-# We are unable to tell if the host is Mariner or Ubuntu,
-# so both /anchors/ubuntu and /anchors/mariner are mounted in the yaml.
+# Copying over CA certs for airgapped clouds. This is needed for AzureLinux vs Ubuntu hosts.
+# We are unable to tell if the host is AzureLinux or Ubuntu,
+# so both /anchors/ubuntu and /anchors/mariner (for AzureLinux) are mounted in the yaml.
 # One will have the certs and the other will be empty.
-# These need to be copied to a different location for Mariner vs Ubuntu containers.
+# These need to be copied to a different location for AzureLinux vs Ubuntu containers.
 # OS_ID here is the container distro.
-# Adding Mariner now even though the elif will never currently evaluate.
+# Adding AzureLinux now even though the elif will never currently evaluate.
 if [ $CLOUD_ENVIRONMENT == "usnat" ] || [ $CLOUD_ENVIRONMENT == "ussec" ] || [ "$IS_CUSTOM_CERT" == "true" ]; then
   OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f2 | tr -d '"' | tr -d "'")
-  if [ $OS_ID == "mariner" ]; then
+  if [ $OS_ID == "azurelinux" ]; then
     cp /anchors/ubuntu/* /etc/pki/ca-trust/source/anchors
     cp /anchors/mariner/* /etc/pki/ca-trust/source/anchors
     if [ -e "/etc/ama-logs-secret/PROXYCERT.crt" ]; then
       cp /etc/ama-logs-secret/PROXYCERT.crt /etc/pki/ca-trust/source/PROXYCERT.crt
     fi
-    update-ca-trust
+    update-ca-trust     
   else
     if [ $OS_ID != "ubuntu" ]; then
-      echo "Error: The ID in /etc/os-release is not ubuntu or mariner. Defaulting to ubuntu."
+      echo "Error: The ID in /etc/os-release is not ubuntu or azurelinux. Defaulting to ubuntu."
     fi
     cp /anchors/ubuntu/* /usr/local/share/ca-certificates/
     cp /anchors/mariner/* /usr/local/share/ca-certificates/


### PR DESCRIPTION
Cert mount fix for AGC for Mariner 3.
The OS host name is changed from "mariner" to "azurelinux" in Mariner 3. Since we already rolled out on the public cloud, we don't need the "mariner" check anymore.

Test notes:
The change only impacts AGC so we will toggle the test sub in AGC and validate the fix.