### PR TITLE
3.1.29 release notes and version updates

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -8,6 +8,38 @@ information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeo
 additional questions or comments.
 
 ## Release History
+### 09/09/2025 -
+##### Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.29 (linux)
+##### Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.29 (windows)
+- Linux
+  - [azurelinux 3.0.20250822](https://github.com/microsoft/azurelinux/releases/tag/3.0.20250822-3.0)
+  - Golang - 1.23.8
+  - Ruby - arm64 - 3.3.5, x86_64 - 3.3.8
+  - MDSD - 1.35.7
+  - Telegraf - 1.34.3
+  - Fluent-bit - 3.1.9
+  - Fluentd - 1.16.3
+- Windows
+  - Golang - 1.23.8
+  - Ruby - 3.1.1
+  - Windows AMA - 46.31.3
+  - Telegraf - 1.24.2
+  - Fluent-bit - 4.0.3
+  - Fluentd - 1.16.3
+##### Code change log
+## What's Changed
+> Note: There are no changes to either Linux or Windows agent other than base image version update.
+- Linux
+  * N/A
+- Windows
+  * N/A
+- Common
+  * Fix release pipeline nodepool issue in https://github.com/microsoft/Docker-Provider/pull/1522
+  * Bash script to migrate for customers to migrate from legacy to msi in https://github.com/microsoft/Docker-Provider/pull/1517
+  * Add private link support for high log scale onboarding methods - Policy, ARM templates, Bicep and Terraform in  https://github.com/microsoft/Docker-Provider/pull/1512
+  * ARM templates for multi-tenancy for Arc for Kubernetes - https://github.com/microsoft/Docker-Provider/pull/1506/files
+  * Terraform templates for multi-tenancy for AKS - https://github.com/microsoft/Docker-Provider/pull/1505
+
 ### 07/11/2025 -
 ##### Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.28 (linux)
 ##### Version mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.28 (windows)

--- a/charts/azuremonitor-containers-geneva/values.yaml
+++ b/charts/azuremonitor-containers-geneva/values.yaml
@@ -15,7 +15,7 @@ genevaLogsConfig:
 
 image:
   repository: mcr.microsoft.com/azuremonitor/containerinsights/ciprod
-  tag: "3.1.28"
+  tag: "3.1.29"
   pullPolicy: IfNotPresent
   agentVersion: "azure-mdsd-1.35.7"
 nameOverride: ""

--- a/charts/azuremonitor-containers/Chart.yaml
+++ b/charts/azuremonitor-containers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 7.0.0-1
 description: Helm chart for deploying Azure Monitor container monitoring agent in Kubernetes
 name: azuremonitor-containers
-version: 3.1.28
+version: 3.1.29
 kubeVersion: "^1.10.0-0"
 keywords:
   - monitoring

--- a/charts/azuremonitor-containers/values.yaml
+++ b/charts/azuremonitor-containers/values.yaml
@@ -24,8 +24,8 @@ Azure:
 amalogs:
   image:
     repo: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod"
-    tag: "3.1.28"
-    tagWindows: "win-3.1.28"
+    tag: "3.1.29"
+    tagWindows: "win-3.1.29"
     pullPolicy: IfNotPresent
     dockerProviderVersion: "18.0.1-0"
     agentVersion: "azure-mdsd-1.35.7"

--- a/kubernetes/ama-logs.yaml
+++ b/kubernetes/ama-logs.yaml
@@ -391,7 +391,7 @@ spec:
         #         - NET_ADMIN
         #         - NET_RAW
         - name: ama-logs
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.28"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.29"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -526,7 +526,7 @@ spec:
             timeoutSeconds: 15
 #Only in sidecar scraping mode
         - name: ama-logs-prometheus
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.28"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.29"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -1039,7 +1039,7 @@ spec:
         #         - NET_ADMIN
         #         - NET_RAW
         - name: ama-logs
-          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.28"
+          image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:3.1.29"
           imagePullPolicy: IfNotPresent
           # comment resources if VPA configured since the VPA will set these values
           resources:
@@ -1296,7 +1296,7 @@ spec:
       #       add:
       #         - NET_ADMIN
        - name: ama-logs-windows
-         image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.28"
+         image: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.29"
          imagePullPolicy: IfNotPresent
          resources:
           requests:

--- a/kubernetes/linux/Dockerfile.multiarch
+++ b/kubernetes/linux/Dockerfile.multiarch
@@ -75,12 +75,12 @@ ENV KUBE_CLIENT_BACKOFF_DURATION 0
 ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR 1.0
 
 # default value will be overwritten by pipeline
-ARG IMAGE_TAG=3.1.28
+ARG IMAGE_TAG=3.1.29
 ENV AGENT_VERSION ${IMAGE_TAG}
 
 WORKDIR ${tmpdir}
 
-# files 
+# files
 COPY --from=builder /opt /opt
 COPY --from=builder /etc /etc
 COPY --from=builder /busybin /busybin
@@ -113,9 +113,9 @@ COPY --from=builder /usr/share/p11-kit/ /usr/share/p11-kit/
 
 # bash dependencies
 COPY --from=builder /usr/lib/libreadline.so.8  /usr/lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /usr/lib/
-# inotifywait dependencies 
+# inotifywait dependencies
 COPY --from=builder /usr/lib/libinotifytools.so.0 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/libc.so.6 /usr/lib/libm.so.6 /usr/lib/
-# crond dependencies 
+# crond dependencies
 COPY --from=builder /usr/lib/libselinux.so.1 /usr/lib/libpam.so.0 /usr/lib/libc.so.6 /usr/lib/
 # ruby dependencies
 COPY --from=builder /usr/lib/libruby.so.3.3 /usr/lib/libc.so.6 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
@@ -127,7 +127,7 @@ COPY --from=builder /usr/lib/libresolv.so.2 /usr/lib/libc.so.6 /usr/lib/
 # mdsd dependencies
 COPY --from=builder /usr/sbin/../lib/libpthread.so.0 /usr/sbin/../lib/libdl.so.2 /usr/sbin/../lib/libsymcrypt.so.103 /usr/sbin/../lib/librt.so.1 /usr/sbin/../lib/libm.so.6 /usr/sbin/../lib/libc.so.6 /usr/sbin/../lib/libstdc++.so.6 /usr/sbin/../lib/libgcc_s.so.1 /usr/sbin/../lib/
 COPY --from=builder /opt/microsoft/azure-mdsd/lib/libtcmalloc_minimal.so.4 /opt/microsoft/azure-mdsd/lib/
-# logrotate dependencies 
+# logrotate dependencies
 COPY --from=builder /usr/lib/libpopt.so.0 /usr/lib/libc.so.6 /usr/lib/
 # curl dependencies
 # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures

--- a/kubernetes/windows/Dockerfile
+++ b/kubernetes/windows/Dockerfile
@@ -18,7 +18,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 # rexml 3.2.5 gem was installed during ruby 3.1.1.1 installation for xml parsing, not related to fluentd (dependency of fluentd 1.16.3: https://rubygems.org/gems/fluentd/versions/1.16.3-x64-mingw-ucrt)
 # removed it for vulnerability reasons.
     # https://github.com/ManageIQ/rbvmomi2/issues/62
-    # when ruby has a version change, a different version of rexml might be installed, 
+    # when ruby has a version change, a different version of rexml might be installed,
     # so need to review the installed version of rexml, and uninstall it.
 RUN choco install -y ruby --version 3.1.1.1 --params "'/InstallDir:C:\ruby31'" \
 && choco install -y msys2 --version 20240113.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
@@ -103,7 +103,7 @@ COPY ./amalogswindows/installer/scripts/rubyKeepCertificateAlive/*.rb /etc/fluen
 COPY ./amalogswindows/ruby/ /etc/fluent/plugin/
 
 # default value will be overwritten by pipeline
-ARG IMAGE_TAG=win-3.1.28
+ARG IMAGE_TAG=win-3.1.29
 ENV AGENT_VERSION ${IMAGE_TAG}
 
 ENV OS_TYPE "windows"


### PR DESCRIPTION
This pull request updates the Azure Monitor container monitoring agent to version 3.1.29 for both Linux and Windows, and includes several enhancements and fixes in the release notes. The main changes are version bumps across Helm charts, Kubernetes manifests, and Dockerfiles, along with documentation of new features and fixes in the release notes.

**Release and Version Updates:**

* Bumped agent image versions to `3.1.29` (Linux) and `win-3.1.29` (Windows) in all relevant files, including Helm charts (`Chart.yaml`, `values.yaml`), Kubernetes manifests (`ama-logs.yaml`), and Dockerfiles (`Dockerfile.multiarch`, `Dockerfile`). [[1]](diffhunk://#diff-adc111427f94dd8721d3bece36f9d37e5bf99459780ef3cf728eb645ffabe3fbL5-R5) [[2]](diffhunk://#diff-c143ea0bc79e879c685e11a8b334d9cf66ed4c7cdaab210e63c27b6a550942a9L27-R28) [[3]](diffhunk://#diff-2ab6faba108ff1e3be9ec05ba326418f6f377227c44824395995e3fce689c551L18-R18) [[4]](diffhunk://#diff-36d02cbde2b90a572c51c987289a1cfdf4726779cefbd512e2d1663ecf2c8dd4L394-R394) [[5]](diffhunk://#diff-36d02cbde2b90a572c51c987289a1cfdf4726779cefbd512e2d1663ecf2c8dd4L529-R529) [[6]](diffhunk://#diff-36d02cbde2b90a572c51c987289a1cfdf4726779cefbd512e2d1663ecf2c8dd4L1042-R1042) [[7]](diffhunk://#diff-36d02cbde2b90a572c51c987289a1cfdf4726779cefbd512e2d1663ecf2c8dd4L1299-R1299) [[8]](diffhunk://#diff-cfbd3e6c60e3d2baf56d476657cd71fe2fdb7771f65077b0fb6b9fd6268980d2L78-R78) [[9]](diffhunk://#diff-5c511ea7097598edb1ac655fb776c2c5db7f9875c4a853f608bcc44c6145ec64L106-R106)

**Documentation and Release Notes:**

* Added a new release entry for 09/09/2025 in `ReleaseNotes.md`, documenting the new versions, updated component versions (e.g., Golang, Ruby, Telegraf, Fluentd), and summarizing key changes and fixes, such as private link support for onboarding methods, multi-tenancy templates, and migration scripts.