### PR TITLE
Gangams/fix cosmic large scale issue

### DIFF
--- a/source/plugins/ruby/CustomMetricsUtils.rb
+++ b/source/plugins/ruby/CustomMetricsUtils.rb
@@ -20,7 +20,7 @@ class CustomMetricsUtils
                 return true
             end
 
-            if enable_custom_metrics.nil? || enable_custom_metrics.to_s.downcase == 'false'
+            if enable_custom_metrics.nil? || enable_custom_metrics.to_s.empty? || enable_custom_metrics.to_s.downcase == 'false'
                 return false
             end
 

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -874,6 +874,7 @@ class KubernetesApiClient
         end
         parsed_items = []
         metadata_continue = nil
+        resource_version = nil
         parse_mode = "stream"
         total_uncompressed_bytes = 0
         total_compressed_bytes = 0
@@ -953,6 +954,7 @@ class KubernetesApiClient
                       end
                       if obj.key?('metadata') && obj['metadata'].is_a?(Hash)
                         metadata_continue = obj['metadata']['continue']
+                        resource_version = obj['metadata']['resourceVersion'] if obj['metadata'].key?('resourceVersion')
                       end
                     end
                   end
@@ -1000,7 +1002,7 @@ class KubernetesApiClient
 
                   # Build minimal inventory structure
                   resourceInventory = {
-                    'metadata' => { 'continue' => metadata_continue },
+                    'metadata' => { 'continue' => metadata_continue, 'resourceVersion' => resource_version },
                     'items' => parsed_items
                   }
 

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -12,6 +12,7 @@ class KubernetesApiClient
   require "jwt"
   require "zlib"
   require "stringio"
+  require 'yajl'
 
   require_relative "oms_common"
   require_relative "constants"
@@ -890,7 +891,7 @@ class KubernetesApiClient
             kubeApiRequest['User-Agent'] = getUserAgent
             kubeApiRequest['Accept-Encoding'] = 'gzip'
             kubeApiRequest['Accept'] = 'application/json'
-            
+
             @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2(stream): Requesting #{uri} (api_group=#{api_group}) @ #{started_at.iso8601}"
 
             http.request(kubeApiRequest) do |response|
@@ -898,6 +899,8 @@ class KubernetesApiClient
               unless responseCode == '200'
                 parse_mode = 'error'
                 @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: Non-success code #{responseCode} for #{uri}"
+                # Send telemetry for non-success response codes
+                @@K8sApiResponseTelemetryTimeTracker = ApplicationInsightsUtility.sendAPIResponseTelemetry(responseCode, uri, "K8sAPIStatus", @@K8sApiResponseCodeHash, @@K8sApiResponseTelemetryTimeTracker)
                 break
               end
 
@@ -909,7 +912,7 @@ class KubernetesApiClient
               small_threshold = 256 * 1024 # 256KB
 
               if content_length && content_length <= small_threshold
-                # Read whole (possibly compressed) body then JSON.parse normally (fast path for small payloads)
+                # Read whole (possibly compressed) body then use faster parser for small payloads
                 body_buf = +"" # mutable string
                 response.read_body { |c| body_buf << c }
                 total_compressed_bytes = body_buf.bytesize
@@ -926,128 +929,89 @@ class KubernetesApiClient
                 total_uncompressed_bytes = body_buf.bytesize
                 resourceInventory = JSON.parse(body_buf)
               else
-                # Streaming path
+                # Streaming path - CRITICAL: Create parser ONCE outside the read_body loop
+                parse_mode = 'stream'
                 is_gzip = (response['Content-Encoding'] == 'gzip')
                 inflater = nil
-                if is_gzip
-                  # Use Inflate with gzip window bits for streaming
-                  inflater = Zlib::Inflate.new(Zlib::MAX_WBITS + 32)
-                end
-
-                # Simple streaming JSON list parser tailored to k8s list structure.
-                header_scanned = false
-                header_buffer = +""
-                in_items_array = false
-                brace_depth = 0
-                in_string = false
-                escape_next = false
-                current_item = nil
-                after_items = false
-
-                response.read_body do |compressed_chunk|
-                  total_compressed_bytes += compressed_chunk.bytesize
-                  chunk = compressed_chunk
+                yajl_parser = nil
+                accumulated_buffer = +""  # Buffer for incomplete JSON chunks
+                begin
                   if is_gzip
-                    begin
-                      decompressed = inflater.inflate(chunk)
-                    rescue Zlib::Error => zerr
-                      @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: gzip inflate failed mid-stream: #{zerr}"
-                      raise
-                    end
-                  else
-                    decompressed = chunk
+                    # Use Inflate with gzip window bits for streaming
+                    inflater = Zlib::Inflate.new(Zlib::MAX_WBITS + 32)
+                    parse_mode = 'stream_gzip'
                   end
-                  total_uncompressed_bytes += decompressed.bytesize
 
-                  # If we've already passed items end, ignore rest
-                  next if after_items
+                  # Create Yajl parser ONCE and reuse for all chunks
+                  yajl_parser = Yajl::Parser.new
 
-                  decompressed.each_char do |ch|
-                    # Basic JSON string handling to not confuse braces inside strings
-                    if in_string
-                      if escape_next
-                        escape_next = false
-                      elsif ch == '\\'
-                        escape_next = true
-                      elsif ch == '"'
-                        in_string = false
+                  # Set up the parser callback to extract items and continuation token
+                  yajl_parser.on_parse_complete = lambda do |obj|
+                    if obj.is_a?(Hash)
+                      if obj.key?('items') && obj['items'].is_a?(Array)
+                        parsed_items.concat(obj['items'])
                       end
-                      current_item << ch if brace_depth > 0 && current_item
-                      next
-                    else
-                      if ch == '"'
-                        in_string = true
-                        if brace_depth > 0 && current_item
-                          current_item << ch
-                        elsif brace_depth == 0 && in_items_array && current_item
-                          current_item << ch
-                        end
-                        next
+                      if obj.key?('metadata') && obj['metadata'].is_a?(Hash)
+                        metadata_continue = obj['metadata']['continue']
                       end
                     end
+                  end
 
-                    unless in_items_array
-                      header_buffer << ch unless header_scanned
-                      # Detect start of items array
-                      if header_buffer.include?('"items"')
-                        # Look for the '[' following '"items"'
-                        if ch == '['
-                          in_items_array = true
-                          header_scanned = true
-                          # Attempt to extract continuation token (if present) from header_buffer
-                          if header_buffer.include?('"continue"')
-                            # naive regex extraction
-                            m = header_buffer.match(/"continue"\s*:\s*"([^"]*)"/)
-                            metadata_continue = m[1] if m && !m[1].empty?
-                          end
-                        end
-                      end
-                      next unless in_items_array
-                    end
+                  # Stream and parse chunks
+                  chunk_count = 0
+                  response.read_body do |compressed_chunk|
+                    chunk_count += 1
+                    total_compressed_bytes += compressed_chunk.bytesize
 
-                    # Inside items array
-                    if !current_item
-                      if ch == '{'
-                        current_item = +"{"
-                        brace_depth = 1
-                      elsif ch == ']'
-                        # End of items array
-                        in_items_array = false
-                        after_items = true
-                        break
-                      else
-                        # Skip commas/whitespace
+                    decompressed = if is_gzip
+                      begin
+                        inflater.inflate(compressed_chunk)
+                      rescue Zlib::Error => zerr
+                        @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: gzip inflate failed at chunk #{chunk_count}: #{zerr}"
+                        raise
                       end
                     else
-                      # Building current item
-                      if ch == '{'
-                        brace_depth += 1
-                        current_item << ch
-                      elsif ch == '}'
-                        brace_depth -= 1
-                        current_item << ch
-                        if brace_depth == 0
-                          # Complete object
-                          begin
-                            parsed_items << JSON.parse(current_item)
-                          rescue => perr
-                            @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: failed to parse item (ignored): #{perr}"
-                          end
-                          current_item = nil
-                        end
-                      else
-                        current_item << ch
-                      end
+                      compressed_chunk
                     end
-                  end # each_char
-                end # read_body
 
-                # Finish inflater
-                inflater.finish if inflater
-                inflater.close if inflater
+                    total_uncompressed_bytes += decompressed.bytesize
 
-                # Build minimal inventory structure
-                resourceInventory = { 'metadata' => { 'continue' => metadata_continue }, 'items' => parsed_items }
+                    # Feed decompressed chunk to the parser
+                    # Yajl can handle incomplete JSON and will buffer internally
+                    begin
+                      yajl_parser << decompressed
+                    rescue Yajl::ParseError => perr
+                      # Only log parse errors, don't break the stream - might be incomplete chunk
+                      @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: Yajl parse error at chunk #{chunk_count}: #{perr}"
+                    end
+
+                    # Yield control periodically to allow other threads to run (every 10 chunks)
+                    Thread.pass if chunk_count % 10 == 0
+                  end # read_body
+
+                  # Finalize the parsing - this triggers on_parse_complete callback
+                  yajl_parser.parse("")  rescue nil
+
+                  # Finish and clean up inflater
+                  if inflater
+                    inflater.finish rescue nil
+                    inflater.close rescue nil
+                  end
+
+                  # Build minimal inventory structure
+                  resourceInventory = {
+                    'metadata' => { 'continue' => metadata_continue },
+                    'items' => parsed_items
+                  }
+
+                  @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2: Successfully parsed #{parsed_items.length} items in #{chunk_count} chunks"
+
+                rescue => stream_err
+                  @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: Stream processing error: #{stream_err}"
+                  # Clean up resources
+                  inflater.close if inflater rescue nil
+                  raise
+                end
               end # streaming path
             end # http.request
           end # Net::HTTP.start
@@ -1056,10 +1020,14 @@ class KubernetesApiClient
           parse_mode = 'fallback'
           begin
             # Fallback to legacy path
-            responseCode, resourceInfo = getKubeResourceInfoV2(uri, api_group: api_group)
-            if responseCode == '200' && resourceInfo && resourceInfo.body
+            fallbackResponseCode, resourceInfo = getKubeResourceInfoV2(uri, api_group: api_group)
+            responseCode = fallbackResponseCode if responseCode.nil?
+            if fallbackResponseCode == '200' && resourceInfo && resourceInfo.body && !resourceInfo.body.empty?
               resourceInventory = JSON.parse(resourceInfo.body)
-              continuationToken = resourceInventory.dig('metadata', 'continue') if resourceInventory && resourceInventory['metadata']
+              # Set continuationToken from fallback response
+              if resourceInventory && resourceInventory['metadata']
+                continuationToken = resourceInventory['metadata']['continue']
+              end
             end
           rescue => legacy_err
             @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: legacy fallback also failed: #{legacy_err}"

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -10,6 +10,8 @@ class KubernetesApiClient
   require "time"
   require "ipaddress"
   require "jwt"
+  require "zlib"
+  require "stringio"
 
   require_relative "oms_common"
   require_relative "constants"
@@ -864,20 +866,14 @@ class KubernetesApiClient
       resourceInventory = nil
       responseCode = nil
       begin
-        # Localized implementation with gzip request + streaming decompression + incremental JSON item parsing.
-        # Caller already paginates (passes limited chunk via 'uri'), so we optimize single-chunk parse CPU & memory.
-        require 'zlib'
-        require 'stringio'
-
         resource_path = getResourceUri(uri, api_group)
         if resource_path.nil?
           @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: resource path nil for #{uri}"
           return continuationToken, resourceInventory, responseCode
         end
-
         parsed_items = []
         metadata_continue = nil
-        parse_mode = 'stream'
+        parse_mode = "stream"
         total_uncompressed_bytes = 0
         total_compressed_bytes = 0
         started_at = Time.now.utc
@@ -894,7 +890,7 @@ class KubernetesApiClient
             kubeApiRequest['User-Agent'] = getUserAgent
             kubeApiRequest['Accept-Encoding'] = 'gzip'
             kubeApiRequest['Accept'] = 'application/json'
-
+            
             @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2(stream): Requesting #{uri} (api_group=#{api_group}) @ #{started_at.iso8601}"
 
             http.request(kubeApiRequest) do |response|

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -885,10 +885,10 @@ class KubernetesApiClient
             raise "#{@@CaFile} doesnt exist"
           end
 
-          Net::HTTP.start(parsed_uri.host, parsed_uri.port, :use_ssl => true, :ca_file => @@CaFile, :verify_mode => OpenSSL::SSL::VERIFY_PEER, :open_timeout => 20, :read_timeout => 60) do |http|
+          Net::HTTP.start(parsed_uri.host, parsed_uri.port, :use_ssl => true, :ca_file => @@CaFile, :verify_mode => OpenSSL::SSL::VERIFY_PEER, :open_timeout => 20, :read_timeout => 40) do |http|
             kubeApiRequest = Net::HTTP::Get.new(parsed_uri.request_uri)
             kubeApiRequest['Authorization'] = 'Bearer ' + getTokenStr
-            kubeApiRequest['User-Agent'] = getUserAgent
+            kubeApiRequest['User-Agent'] = getUserAgent()
             kubeApiRequest['Accept-Encoding'] = 'gzip'
             kubeApiRequest['Accept'] = 'application/json'
 

--- a/source/plugins/ruby/KubernetesApiClient.rb
+++ b/source/plugins/ruby/KubernetesApiClient.rb
@@ -864,18 +864,219 @@ class KubernetesApiClient
       resourceInventory = nil
       responseCode = nil
       begin
-        @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2 : Getting resources from Kube API using url: #{uri} @ #{Time.now.utc.iso8601}"
-        responseCode, resourceInfo = getKubeResourceInfoV2(uri, api_group: api_group)
-        @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2 : Done getting resources from Kube API using url: #{uri} @ #{Time.now.utc.iso8601}"
-        if !responseCode.nil? && responseCode == "200" && !resourceInfo.nil?
-          @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2:Start:Parsing data for #{uri} using JSON @ #{Time.now.utc.iso8601}"
-          resourceInventory = JSON.parse(resourceInfo.body)
-          @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2:End:Parsing data for #{uri} using JSON @ #{Time.now.utc.iso8601}"
-          resourceInfo = nil
+        # Localized implementation with gzip request + streaming decompression + incremental JSON item parsing.
+        # Caller already paginates (passes limited chunk via 'uri'), so we optimize single-chunk parse CPU & memory.
+        require 'zlib'
+        require 'stringio'
+
+        resource_path = getResourceUri(uri, api_group)
+        if resource_path.nil?
+          @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: resource path nil for #{uri}"
+          return continuationToken, resourceInventory, responseCode
         end
-        if (!resourceInventory.nil? && !resourceInventory["metadata"].nil?)
-          continuationToken = resourceInventory["metadata"]["continue"]
+
+        parsed_items = []
+        metadata_continue = nil
+        parse_mode = 'stream'
+        total_uncompressed_bytes = 0
+        total_compressed_bytes = 0
+        started_at = Time.now.utc
+
+        begin
+          parsed_uri = URI.parse(resource_path)
+          if !File.exist?(@@CaFile)
+            raise "#{@@CaFile} doesnt exist"
+          end
+
+          Net::HTTP.start(parsed_uri.host, parsed_uri.port, :use_ssl => true, :ca_file => @@CaFile, :verify_mode => OpenSSL::SSL::VERIFY_PEER, :open_timeout => 20, :read_timeout => 60) do |http|
+            kubeApiRequest = Net::HTTP::Get.new(parsed_uri.request_uri)
+            kubeApiRequest['Authorization'] = 'Bearer ' + getTokenStr
+            kubeApiRequest['User-Agent'] = getUserAgent
+            kubeApiRequest['Accept-Encoding'] = 'gzip'
+            kubeApiRequest['Accept'] = 'application/json'
+
+            @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2(stream): Requesting #{uri} (api_group=#{api_group}) @ #{started_at.iso8601}"
+
+            http.request(kubeApiRequest) do |response|
+              responseCode = response.code
+              unless responseCode == '200'
+                parse_mode = 'error'
+                @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: Non-success code #{responseCode} for #{uri}"
+                break
+              end
+
+              # Decide whether to stream or fallback to full parse based on Content-Length (if small, cheaper to full-parse)
+              content_length = nil
+              begin
+                content_length = Integer(response['Content-Length']) if response['Content-Length']
+              rescue; end
+              small_threshold = 256 * 1024 # 256KB
+
+              if content_length && content_length <= small_threshold
+                # Read whole (possibly compressed) body then JSON.parse normally (fast path for small payloads)
+                body_buf = +"" # mutable string
+                response.read_body { |c| body_buf << c }
+                total_compressed_bytes = body_buf.bytesize
+                if response['Content-Encoding'] == 'gzip'
+                  begin
+                    body_buf = Zlib::GzipReader.new(StringIO.new(body_buf)).read
+                    parse_mode = 'full_gzip'
+                  rescue => gzerr
+                    @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: gzip decompress(small) failed: #{gzerr}; using compressed body (parse will likely fail)"
+                  end
+                else
+                  parse_mode = 'full_plain'
+                end
+                total_uncompressed_bytes = body_buf.bytesize
+                resourceInventory = JSON.parse(body_buf)
+              else
+                # Streaming path
+                is_gzip = (response['Content-Encoding'] == 'gzip')
+                inflater = nil
+                if is_gzip
+                  # Use Inflate with gzip window bits for streaming
+                  inflater = Zlib::Inflate.new(Zlib::MAX_WBITS + 32)
+                end
+
+                # Simple streaming JSON list parser tailored to k8s list structure.
+                header_scanned = false
+                header_buffer = +""
+                in_items_array = false
+                brace_depth = 0
+                in_string = false
+                escape_next = false
+                current_item = nil
+                after_items = false
+
+                response.read_body do |compressed_chunk|
+                  total_compressed_bytes += compressed_chunk.bytesize
+                  chunk = compressed_chunk
+                  if is_gzip
+                    begin
+                      decompressed = inflater.inflate(chunk)
+                    rescue Zlib::Error => zerr
+                      @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: gzip inflate failed mid-stream: #{zerr}"
+                      raise
+                    end
+                  else
+                    decompressed = chunk
+                  end
+                  total_uncompressed_bytes += decompressed.bytesize
+
+                  # If we've already passed items end, ignore rest
+                  next if after_items
+
+                  decompressed.each_char do |ch|
+                    # Basic JSON string handling to not confuse braces inside strings
+                    if in_string
+                      if escape_next
+                        escape_next = false
+                      elsif ch == '\\'
+                        escape_next = true
+                      elsif ch == '"'
+                        in_string = false
+                      end
+                      current_item << ch if brace_depth > 0 && current_item
+                      next
+                    else
+                      if ch == '"'
+                        in_string = true
+                        if brace_depth > 0 && current_item
+                          current_item << ch
+                        elsif brace_depth == 0 && in_items_array && current_item
+                          current_item << ch
+                        end
+                        next
+                      end
+                    end
+
+                    unless in_items_array
+                      header_buffer << ch unless header_scanned
+                      # Detect start of items array
+                      if header_buffer.include?('"items"')
+                        # Look for the '[' following '"items"'
+                        if ch == '['
+                          in_items_array = true
+                          header_scanned = true
+                          # Attempt to extract continuation token (if present) from header_buffer
+                          if header_buffer.include?('"continue"')
+                            # naive regex extraction
+                            m = header_buffer.match(/"continue"\s*:\s*"([^"]*)"/)
+                            metadata_continue = m[1] if m && !m[1].empty?
+                          end
+                        end
+                      end
+                      next unless in_items_array
+                    end
+
+                    # Inside items array
+                    if !current_item
+                      if ch == '{'
+                        current_item = +"{"
+                        brace_depth = 1
+                      elsif ch == ']'
+                        # End of items array
+                        in_items_array = false
+                        after_items = true
+                        break
+                      else
+                        # Skip commas/whitespace
+                      end
+                    else
+                      # Building current item
+                      if ch == '{'
+                        brace_depth += 1
+                        current_item << ch
+                      elsif ch == '}'
+                        brace_depth -= 1
+                        current_item << ch
+                        if brace_depth == 0
+                          # Complete object
+                          begin
+                            parsed_items << JSON.parse(current_item)
+                          rescue => perr
+                            @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: failed to parse item (ignored): #{perr}"
+                          end
+                          current_item = nil
+                        end
+                      else
+                        current_item << ch
+                      end
+                    end
+                  end # each_char
+                end # read_body
+
+                # Finish inflater
+                inflater.finish if inflater
+                inflater.close if inflater
+
+                # Build minimal inventory structure
+                resourceInventory = { 'metadata' => { 'continue' => metadata_continue }, 'items' => parsed_items }
+              end # streaming path
+            end # http.request
+          end # Net::HTTP.start
+        rescue => inner_err
+          @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: streaming fetch/parse failed for #{uri}: #{inner_err}; falling back to legacy getKubeResourceInfoV2"
+          parse_mode = 'fallback'
+          begin
+            # Fallback to legacy path
+            responseCode, resourceInfo = getKubeResourceInfoV2(uri, api_group: api_group)
+            if responseCode == '200' && resourceInfo && resourceInfo.body
+              resourceInventory = JSON.parse(resourceInfo.body)
+              continuationToken = resourceInventory.dig('metadata', 'continue') if resourceInventory && resourceInventory['metadata']
+            end
+          rescue => legacy_err
+            @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2: legacy fallback also failed: #{legacy_err}"
+            ApplicationInsightsUtility.sendExceptionTelemetry(legacy_err)
+          end
         end
+
+        # Derive continuation token if not already set
+        if continuationToken.nil? && resourceInventory && resourceInventory['metadata']
+          continuationToken = resourceInventory['metadata']['continue']
+        end
+        duration_ms = ((Time.now.utc - started_at) * 1000).round(1)
+        @Log.info "KubernetesApiClient::getResourcesAndContinuationTokenV2: mode=#{parse_mode} code=#{responseCode} items=#{resourceInventory && resourceInventory['items'] ? resourceInventory['items'].length : 'n/a'} cont=#{continuationToken.nil? ? 'nil' : continuationToken.empty? ? 'empty' : 'set'} compBytes=#{total_compressed_bytes} uncompBytes=#{total_uncompressed_bytes} ms=#{duration_ms} uri=#{uri}"
       rescue => errorStr
         @Log.warn "KubernetesApiClient::getResourcesAndContinuationTokenV2:Failed in get resources for #{uri} and continuation token: #{errorStr}"
         ApplicationInsightsUtility.sendExceptionTelemetry(errorStr)

--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -689,7 +689,9 @@ module Fluent::Plugin
           records.push(record)
         end  #container status block end
 
-        @mdmPodRecordItems.push(mdmPodRecord.dup)
+        if CustomMetricsUtils.check_custom_metrics_availability
+            @mdmPodRecordItems.push(mdmPodRecord.dup)
+        end
 
         records.each do |record|
           if !record.nil?


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Kubernetes API client and related utilities, primarily focusing on improving the robustness and efficiency of resource fetching and parsing from the Kubernetes API. The changes include switching to a streaming JSON parser for large responses, handling gzip-compressed payloads, and adding more resilient error handling and telemetry. Additionally, there are minor improvements to custom metrics availability checks and conditional record processing.

### Kubernetes API Client improvements

* Switched the resource fetching logic in `KubernetesApiClient#getResourcesAndContinuationTokenV2` to use streaming JSON parsing via `Yajl::Parser`, with support for gzip-compressed responses for improved performance and lower memory usage on large payloads. Fallback to legacy parsing is retained for error cases.
* Added new dependencies (`zlib`, `stringio`, and `yajl`) to `KubernetesApiClient.rb` to enable streaming and compressed JSON parsing.

### Error handling and telemetry

* Enhanced error handling in the resource fetch logic: logs warnings, sends telemetry for non-success responses, and attempts fallback parsing if streaming fails. Also, comprehensive logging of parse modes, response codes, and performance metrics is included.

### Custom metrics and pod inventory

* Improved the custom metrics availability check to handle empty string values for the `enable_custom_metrics` configuration, making the check more robust.
* Updated `in_kube_podinventory.rb` to only push pod records for custom metrics when custom metrics are available, preventing unnecessary processing.