### PR TITLE
Introduce temporary Python distro fix for OTEL compatibility

### DIFF
--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -23,7 +23,7 @@ export class Mutations {
     };
     private static agentImagePython = {
         repositoryPath: "auto-instrumentation/python",
-        imageTag: "1.0.0b28-aks" // https://mcr.microsoft.com/v2/applicationinsights/auto-instrumentation/python/tags/list
+        imageTag: "1.0.0b26-aks" // https://mcr.microsoft.com/v2/applicationinsights/auto-instrumentation/python/tags/list
     };
     private static agentImageDotNet = {
         repositoryPath: "opentelemetry-auto-instrumentation/dotnet",

--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -165,7 +165,7 @@ export class Mutations {
     /**
      * Generates environment variables necessary to configure agents. Agents take configuration from these environment variables once they run.
      */
-    public static GenerateEnvironmentVariables(podInfo: PodInfo, platforms: AutoInstrumentationPlatforms[], disableAppLogs: boolean, connectionString: string, armId: string, armRegion: string, clusterName: string, otelParams: OtelParams, existingEnvironmentVariables?: Record<string, IEnvironmentVariable>): IEnvironmentVariable[] {
+    public static GenerateEnvironmentVariables(podInfo: PodInfo, platforms: AutoInstrumentationPlatforms[], disableAppLogs: boolean, connectionString: string, armId: string, armRegion: string, clusterName: string, otelParams: OtelParams, existingEnvironmentVariables?: Record<string, IEnvironmentVariable>, isPythonEnabled?: boolean): IEnvironmentVariable[] {
         const ownerNameAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.name=${podInfo.ownerName}`;
         const ownerUidAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.uid=${podInfo.ownerUid}`;
         const containerNameAttribute = `k8s.container.name=${podInfo.onlyContainerName}`;
@@ -303,11 +303,14 @@ export class Mutations {
         }
 
         if (otelParams.metricsEnabled) {
+            // //!!! temporary special case: when Python is enabled (via private-preview annotation), set OTEL_METRICS_EXPORTER to "otlp" only
+            // Python distro can't handle azure_monitor currently
+            const metricsExporterValue = isPythonEnabled ? "otlp" : "otlp,azure_monitor";
             returnValue.push(
                 // setting this to ensure Microsoft distros do send OTLP metrics (forked, sent to Breeze and OTLP endpoint). For OSS SDKs this defaults to "otlp" anyway, so no impact
                 {
                     name: "OTEL_METRICS_EXPORTER",
-                    value: `otlp,azure_monitor`
+                    value: metricsExporterValue
                 },
                 {
                     name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", //!!! http -> https

--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -23,7 +23,7 @@ export class Mutations {
     };
     private static agentImagePython = {
         repositoryPath: "auto-instrumentation/python",
-        imageTag: "1.0.0b26-aks" // https://mcr.microsoft.com/v2/applicationinsights/auto-instrumentation/python/tags/list
+        imageTag: "1.0.0b28-aks" // https://mcr.microsoft.com/v2/applicationinsights/auto-instrumentation/python/tags/list
     };
     private static agentImageDotNet = {
         repositoryPath: "opentelemetry-auto-instrumentation/dotnet",

--- a/appmonitoring/ts/src/Patcher.ts
+++ b/appmonitoring/ts/src/Patcher.ts
@@ -49,6 +49,9 @@ export class Patcher {
             const enableApplicationLogsAnnotation = spec.template.metadata?.annotations?.[EnableApplicationLogsAnnotationName]; 
             const enableApplicationLogs: boolean = enableApplicationLogsAnnotation?.toLocaleLowerCase() === "true" || enableApplicationLogsAnnotation?.toLocaleLowerCase() === "1";
             
+            // determine if Python is enabled (Python can only be enabled via private-preview annotation)
+            const isPythonPrivatePreview: boolean = platforms.includes(AutoInstrumentationPlatforms.Python);
+            
             // add new volumes (used to store agent binaries)
             const newVolumes: IVolume[] = Mutations.GenerateVolumes(platforms);
             podSpec.volumes = (podSpec.volumes ?? <IVolume[]>[]).concat(newVolumes);
@@ -65,7 +68,7 @@ export class Patcher {
                 container.env?.forEach(env => allEnvironmentVariables[env.name] = env);
 
                 // Generate environment variables with knowledge of existing ones for OTEL_RESOURCE_ATTRIBUTES merging
-                const newEnvironmentVariables: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(podInfo, platforms, !enableApplicationLogs, cr.spec?.destination?.applicationInsightsConnectionString, armId, armRegion, clusterName, otelParams, allEnvironmentVariables);
+                const newEnvironmentVariables: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(podInfo, platforms, !enableApplicationLogs, cr.spec?.destination?.applicationInsightsConnectionString, armId, armRegion, clusterName, otelParams, allEnvironmentVariables, isPythonPrivatePreview);
 
                 /*
                     We could be receiving customer's original set of environment variables (e.g. in case of kubectl apply),
@@ -147,7 +150,7 @@ export class Patcher {
         // remove environment variables and volume mounts from all containers by name
         // we don't care about values of environment variables here, we just need all names, so set parameters to get all of them
         const otelParams: OtelParams = { logsEnabled: true, metricsEnabled: true, logsPortHttpProtobuf: 0, metricsPortHttpProtobuf: 0 };
-        const environmentVariablesToRemove: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(new PodInfo(), allPlatforms, true, "", "", "", "", otelParams);
+        const environmentVariablesToRemove: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(new PodInfo(), allPlatforms, true, "", "", "", "", otelParams, undefined, false);
         const volumeMountsToRemove: IVolumeMount[] = Mutations.GenerateVolumeMounts(allPlatforms);
 
         podSpec.containers?.forEach(container => {

--- a/appmonitoring/ts/src/tests/Mutations.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutations.spec.ts
@@ -34,7 +34,8 @@ describe("OTEL Resource Attributes Merging", () => {
             "eastus", 
             "test-cluster", 
             testOtelParams,
-            existingEnvironmentVariables
+            existingEnvironmentVariables,
+            false
         );
 
         const otelResourceAttributes = generatedEnvVars.find(env => env.name === "OTEL_RESOURCE_ATTRIBUTES");
@@ -207,5 +208,57 @@ describe("OTEL Metrics Exporter Environment Variable", () => {
         const otelMetricsInsecure = generatedEnvVars.find(env => env.name === "OTEL_EXPORTER_OTLP_METRICS_INSECURE");
         expect(otelMetricsInsecure).toBeDefined();
         expect(otelMetricsInsecure!.value).toBe("true");
+    });
+
+    it("should set OTEL_METRICS_EXPORTER to 'otlp' only when Python is enabled", () => {
+        const testOtelParams: OtelParams = {
+            logsEnabled: false,
+            metricsEnabled: true,
+            logsPortHttpProtobuf: 4318,
+            metricsPortHttpProtobuf: 4319
+        };
+
+        const generatedEnvVars = Mutations.GenerateEnvironmentVariables(
+            podInfo,
+            [AutoInstrumentationPlatforms.Python],
+            false,
+            "InstrumentationKey=test-key",
+            "/subscriptions/test/resourceGroups/test-rg",
+            "eastus",
+            "test-cluster",
+            testOtelParams,
+            undefined,
+            true // isPythonEnabled = true
+        );
+
+        const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
+        expect(otelMetricsExporter).toBeDefined();
+        expect(otelMetricsExporter!.value).toBe("otlp");
+    });
+
+    it("should set OTEL_METRICS_EXPORTER to 'otlp,azure_monitor' when Python is not enabled", () => {
+        const testOtelParams: OtelParams = {
+            logsEnabled: false,
+            metricsEnabled: true,
+            logsPortHttpProtobuf: 4318,
+            metricsPortHttpProtobuf: 4319
+        };
+
+        const generatedEnvVars = Mutations.GenerateEnvironmentVariables(
+            podInfo,
+            [AutoInstrumentationPlatforms.Python],
+            false,
+            "InstrumentationKey=test-key",
+            "/subscriptions/test/resourceGroups/test-rg",
+            "eastus",
+            "test-cluster",
+            testOtelParams,
+            undefined,
+            false // isPythonEnabled = false
+        );
+
+        const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
+        expect(otelMetricsExporter).toBeDefined();
+        expect(otelMetricsExporter!.value).toBe("otlp,azure_monitor");
     });
 });

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -66,7 +66,7 @@ describe("Patcher", () => {
         newVolumes.forEach(vol => expect((<any>result[0]).value.spec.template.spec.volumes).toContainEqual(vol));
         admissionReview.request.object.spec.template.spec.volumes.forEach(vol => expect((<any>result[0]).value.spec.template.spec.volumes).toContainEqual(vol));
 
-        const newEnvironmentVariables: object[] = Mutations.GenerateEnvironmentVariables(podInfo, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
+        const newEnvironmentVariables: object[] = Mutations.GenerateEnvironmentVariables(podInfo, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, platforms.includes(AutoInstrumentationPlatforms.Python));
         expect((<any>result[0]).value.spec.template.spec.containers.length).toBe(admissionReview.request.object.spec.template.spec.containers.length);
         newEnvironmentVariables.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[0].env).toContainEqual(env));
         newEnvironmentVariables.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(env));
@@ -127,7 +127,7 @@ describe("Patcher", () => {
         newVolumes.forEach(vol => expect((<any>result[0]).value.spec.template.spec.volumes).toContainEqual(vol));
         admissionReview.request.object.spec.template.spec.volumes.forEach(vol => expect((<any>result[0]).value.spec.template.spec.volumes).toContainEqual(vol));
 
-        const newEnvironmentVariables: object[] = Mutations.GenerateEnvironmentVariables(podInfo, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
+        const newEnvironmentVariables: object[] = Mutations.GenerateEnvironmentVariables(podInfo, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, cr1.spec.settings.autoInstrumentationPlatforms.includes(AutoInstrumentationPlatforms.Python));
         expect((<any>result[0]).value.spec.template.spec.containers.length).toBe(admissionReview.request.object.spec.template.spec.containers.length);
         newEnvironmentVariables.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[0].env).toContainEqual(env));
         newEnvironmentVariables.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(env));

--- a/appmonitoring/validation-helm/app-monitoring-addon/Chart.yaml
+++ b/appmonitoring/validation-helm/app-monitoring-addon/Chart.yaml
@@ -3,5 +3,5 @@
     "name": "app-monitoring-addon",
     "description": "app-monitoring addon helm chart",
     "type": "application",
-    "version": "1.0.0-beta.8"
+    "version": "1.0.0-beta.9"
 }

--- a/appmonitoring/validation-helm/test-apps/dotnet/dotnet-test-app.cs
+++ b/appmonitoring/validation-helm/test-apps/dotnet/dotnet-test-app.cs
@@ -52,7 +52,7 @@ public class HomeController : ControllerBase
         }
         catch (Exception ex)
         {
-            return StatusCode(500, new { error = $"Failed to reach {targetUrl}: {ex.Message}" });
+            return StatusCode(500, new { error = $"Failed to reach {targetUrl}" });
         }
     }
 }

--- a/appmonitoring/validation-helm/test-apps/java/src/main/java/com/example/HelloController.java
+++ b/appmonitoring/validation-helm/test-apps/java/src/main/java/com/example/HelloController.java
@@ -67,7 +67,7 @@ public class HelloController {
         try {
             logger.info("Attempting to call target URL: {}", targetUrl);
             String response = restTemplate.getForObject(targetUrl, String.class);
-            logger.info("Received response from target: {}", response);
+            logger.info("Received response from target.");
             return "Response from target: " + response;
         } catch (Exception e) {
             logger.error("Error calling target URL: {}", targetUrl, e);

--- a/appmonitoring/validation-helm/values.yaml
+++ b/appmonitoring/validation-helm/values.yaml
@@ -7,6 +7,8 @@ global:
       Kubernetes: "1.25.0"
 AppmonitoringAgent:
   isOtelToggleEnabled: true
+  isOpenTelemetryLogsEnabled: false
+  isOpenTelemetryMetricsEnabled: false
   cpuRequest: "100m"
   memoryRequest: "128Mi"
   cpuLimit: "500m"

--- a/appmonitoring/validation-helm/values.yaml
+++ b/appmonitoring/validation-helm/values.yaml
@@ -7,8 +7,8 @@ global:
       Kubernetes: "1.25.0"
 AppmonitoringAgent:
   isOtelToggleEnabled: true
-  isOpenTelemetryLogsEnabled: false
-  isOpenTelemetryMetricsEnabled: false
+  isOpenTelemetryLogsEnabled: true
+  isOpenTelemetryMetricsEnabled: true
   cpuRequest: "100m"
   memoryRequest: "128Mi"
   cpuLimit: "500m"

--- a/appmonitoring/validation-helm/values.yaml
+++ b/appmonitoring/validation-helm/values.yaml
@@ -6,6 +6,7 @@ global:
     Versions:
       Kubernetes: "1.25.0"
 AppmonitoringAgent:
+  isOtelToggleEnabled: true
   cpuRequest: "100m"
   memoryRequest: "128Mi"
   cpuLimit: "500m"


### PR DESCRIPTION
OTEL changes would break Python private preview users as that distro can't handle the unknown value in OTEL_METRICS_EXPORTER env variable (azure_monitor). We need to temporarily introduce a special case for Python. All distros will align on a single value that we will transition to soon.