### PR TITLE
TAF pipeline fix

### DIFF
--- a/.pipelines/azure_pipeline_testframework.yaml
+++ b/.pipelines/azure_pipeline_testframework.yaml
@@ -7,199 +7,363 @@
 trigger: none
 pr: none
 
-jobs:
-- deployment: Testkube_Monitoring_Model_Cluster_WCUS
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "Monitoring-Model-Cluster-WCUS tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+stages:
+- stage: TestKube
+  jobs:
+  - job: Testkube_Monitoring_Model_Cluster_WCUS
+    timeoutInMinutes: 120
+    displayName: "Monitoring-Model-Cluster-WCUS tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g monitoring-model-cluster-wcus -n Monitoring-Model-Cluster-WCUS'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(MonitoringModelClusterWCUSClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
 
-- deployment: Testkube_Monitoring_Model_Cluster_WEU
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "Monitoring-Model-Cluster-WEU tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+    # Ensure kubectl & helm are available before running tests
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g Monitoring-Model-Cluster-WEU -n Monitoring-Model-Cluster-WEU'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(MonitoringModelClusterWEUClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g monitoring-model-cluster-wcus -n Monitoring-Model-Cluster-WCUS'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(MonitoringModelClusterWCUSClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"
 
-- deployment: Testkube_ci_logs_prod_aks_geneva_integration
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "ci-logs-prod-aks-geneva-integration tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+  - job: Testkube_Monitoring_Model_Cluster_WEU
+    timeoutInMinutes: 120
+    displayName: "Monitoring-Model-Cluster-WEU tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-geneva-integration'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(AksGenevaIntegrationClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) GenevaIntegration=true
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
 
-- deployment: Testkube_ci_logs_prod_aks_geneva_integration_multi_tenancy
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "ci-logs-prod-aks-geneva-integration-multi-tenancy tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-geneva-integration-multi-tenancy'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(AksGenevaIntegrationMultiTenancyClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) GenevaIntegration=true
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g Monitoring-Model-Cluster-WEU -n Monitoring-Model-Cluster-WEU'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(MonitoringModelClusterWEUClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"
 
-- deployment: Testkube_ci_logs_prod_aks_work_load_identity
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "ci-logs-prod-aks-work-load-identity tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+  # - job: Testkube_ci_logs_prod_aks_geneva_integration
+  #   timeoutInMinutes: 120
+  #   displayName: "ci-logs-prod-aks-geneva-integration tests"
+  #   pool:
+  #     name: Azure-Pipelines-CI-Test-EO
+  #   variables:
+  #     skipComponentGovernanceDetection: true
+  #   steps:
+  #   - checkout: self
+  #     persistCredentials: true
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-work-load-identity'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(AksWorkLoadIdentityClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) LinuxTestsOnly=true
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+  #   - script: |
+  #       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  #     displayName: 'Install Azure CLI'
 
-- deployment: Testkube_ci_logs_prod_wcus_fips
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "ci-logs-prod-wcus-fips tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+  #   - script: |
+  #       set -euo pipefail
+  #       echo "Ensuring kubectl & helm are installed (with proper permissions)"
+  #       if ! command -v az >/dev/null 2>&1; then
+  #         echo "Azure CLI not found; aborting" >&2
+  #         exit 1
+  #       fi
+  #       if ! command -v kubectl >/dev/null 2>&1; then
+  #         echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+  #         sudo az aks install-cli
+  #       else
+  #         echo "kubectl already installed: $(kubectl version --client --short || true)"
+  #       fi
+  #       if ! command -v helm >/dev/null 2>&1; then
+  #         echo "Helm not found. Installing Helm 3"
+  #         curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+  #       else
+  #         echo "Helm already installed: $(helm version --short || true)"
+  #       fi
+  #       echo "kubectl version: $(kubectl version --client --short || true)"
+  #     displayName: 'Install kubectl and Helm'
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-wcus-fips'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(WcusFipsClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+  #   - task: AzureCLI@2
+  #     displayName: Get kubeconfig
+  #     inputs:
+  #       azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+  #       scriptLocation: 'inlineScript'
+  #       scriptType: 'bash'
+  #       inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-geneva-integration'
+      
+  #   - bash: |
+  #       chmod +x ./install-and-execute-testkube-tests.sh
+  #       ./install-and-execute-testkube-tests.sh AzureClientId=$(AksGenevaIntegrationClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) GenevaIntegration=false
+  #     workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+  #     displayName: "Install and execute testkube tests"
 
-- deployment: Testkube_ci_logs_prod_aks_networkflowlogs
-  environment: container-insights
-  timeoutInMinutes: 120
-  displayName: "ci-logs-prod-aks-networkflowlogs tests"
-  pool:
-    name: Azure-Pipelines-CI-Test-EO
-  variables:
-    skipComponentGovernanceDetection: true
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - checkout: self
-          persistCredentials: true
+  - job: Testkube_ci_logs_prod_aks_geneva_integration_multi_tenancy
+    timeoutInMinutes: 120
+    displayName: "ci-logs-prod-aks-geneva-integration-multi-tenancy tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
 
-        - task: AzureCLI@1
-          displayName: Get kubeconfig
-          inputs:
-            azureSubscription: 'ContainerInsights_Build_Subscription_CI'
-            scriptLocation: 'inlineScript'
-            inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-networkflowlogs'
-          
-        - bash: |
-            chmod +x ./install-and-execute-testkube-tests.sh
-            ./install-and-execute-testkube-tests.sh AzureClientId=$(NetworkFlowLogsClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) LinuxTestsOnly=true
-          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
-          displayName: "Install and execute testkube tests"
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
+
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-geneva-integration-multi-tenancy'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(AksGenevaIntegrationMultiTenancyClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) GenevaIntegration=true
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"
+
+  - job: Testkube_ci_logs_prod_aks_work_load_identity
+    timeoutInMinutes: 120
+    displayName: "ci-logs-prod-aks-work-load-identity tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
+
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
+
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-work-load-identity'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(AksWorkLoadIdentityClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) LinuxTestsOnly=true
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"
+
+  - job: Testkube_ci_logs_prod_wcus_fips
+    timeoutInMinutes: 120
+    displayName: "ci-logs-prod-wcus-fips tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
+
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
+
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-wcus-fips'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(WcusFipsClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri)
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"
+
+  - job: Testkube_ci_logs_prod_aks_networkflowlogs
+    timeoutInMinutes: 120
+    displayName: "ci-logs-prod-aks-networkflowlogs tests"
+    pool:
+      name: Azure-Pipelines-CI-Test-EO
+    variables:
+      skipComponentGovernanceDetection: true
+    steps:
+    - checkout: self
+      persistCredentials: true
+
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+
+    - script: |
+        set -euo pipefail
+        echo "Ensuring kubectl & helm are installed (with proper permissions)"
+        if ! command -v az >/dev/null 2>&1; then
+          echo "Azure CLI not found; aborting" >&2
+          exit 1
+        fi
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "kubectl not found. Installing via 'az aks install-cli' with sudo to write to /usr/local/bin"
+          sudo az aks install-cli
+        else
+          echo "kubectl already installed: $(kubectl version --client --short || true)"
+        fi
+        if ! command -v helm >/dev/null 2>&1; then
+          echo "Helm not found. Installing Helm 3"
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        else
+          echo "Helm already installed: $(helm version --short || true)"
+        fi
+        echo "kubectl version: $(kubectl version --client --short || true)"
+      displayName: 'Install kubectl and Helm'
+
+    - task: AzureCLI@2
+      displayName: Get kubeconfig
+      inputs:
+        azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+        scriptLocation: 'inlineScript'
+        scriptType: 'bash'
+        inlineScript: 'az aks get-credentials -g ci-logs-prod-aks -n ci-logs-prod-aks-networkflowlogs'
+      
+    - bash: |
+        chmod +x ./install-and-execute-testkube-tests.sh
+        ./install-and-execute-testkube-tests.sh AzureClientId=$(NetworkFlowLogsClientId) AzureTenantId=$(AzureTenantId) TeamsWebhookUri=$(TeamsWebhookUri) LinuxTestsOnly=true
+      workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+      displayName: "Install and execute testkube tests"


### PR DESCRIPTION
- Migrated from AzureCLI@1 to AzureCLI@2.
- Manually install AzureCLI, helm and kubectl as 1es compliant node doesn't have these installed.
- Converted Deployment to Jobs to resolve: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/changemanagement/deploymentjobs-to-release
- Commented out Geneva cluster as this is not setup properly. We will re-enable it once the setup is fixed hence commenting and not removing.