### PR TITLE
Exclude AMACoreAgent connect logs when OTLP is disabled

### DIFF
--- a/build/linux/installer/conf/fluent-bit-common.conf
+++ b/build/linux/installer/conf/fluent-bit-common.conf
@@ -15,7 +15,7 @@
 [INPUT]
     Name tail
     Alias ama-logs_mdsd_err_tail
-    Tag oms.container.log.flbplugin.mdsd.*
+    Tag oms.container.log.flbplugin.mdsd.err.*
     Path /var/opt/microsoft/linuxmonagent/log/mdsd.err
     Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/mdsd-ai.db
@@ -90,6 +90,18 @@
     Alias ama-logs_mdsd_qos_filter
     Match oms.container.log.flbplugin.mdsd.qos.*
     regex log ^MaODSRequest,https.*_LogManagement_LINUX_SYSLOGS_BLOB
+
+[FILTER]
+    Name grep
+    Alias ama-logs_mdsd_err_filter
+    Match oms.container.log.flbplugin.mdsd.err.*
+    # Exclude noisy AMACoreAgent startup tenant not started messages in RS
+    # Consolidated exclusion of specific transient AMACoreAgent startup/connection retry messages:
+    #  - OtlpTokenFetcher AMACoreAgent tenant not started
+    #  - CreateSocket / ConnectToPipelineAgent socket connection failures to AMACoreAgent
+    #  - PAConnector::StartTenant / SendAmcsData failures
+    #  - "Will retry one more time in 5 seconds." retry notice (does not include AMACoreAgent keyword)
+    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|Will retry one more time in 5 seconds\.)
 
 [FILTER]
     Name grep

--- a/build/linux/installer/conf/fluent-bit-common.conf
+++ b/build/linux/installer/conf/fluent-bit-common.conf
@@ -101,7 +101,7 @@
     #  - CreateSocket / ConnectToPipelineAgent socket connection failures to AMACoreAgent
     #  - PAConnector::StartTenant / SendAmcsData failures
     #  - "Will retry one more time in 5 seconds." retry notice (does not include AMACoreAgent keyword)
-    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|Will retry one more time in 5 seconds\.)
+    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|PAConnector::AmcsStopTenant.*AMACoreAgent|Will retry one more time in 5 seconds\.)
 
 [FILTER]
     Name grep

--- a/build/linux/installer/conf/fluent-bit-rs.conf
+++ b/build/linux/installer/conf/fluent-bit-rs.conf
@@ -45,6 +45,18 @@
     Buffer_Size ${AZMON_FBIT_BUFFER_SIZE}
     Mem_Buf_Limit ${AZMON_FBIT_MEM_BUF_LIMIT}
 
+[FILTER]
+    Name grep
+    Alias ama-logs_mdsd_err_filter
+    Match oms.container.log.flbplugin.mdsd.err.*
+    # Exclude noisy AMACoreAgent startup tenant not started messages in RS
+    # Consolidated exclusion of specific transient AMACoreAgent startup/connection retry messages:
+    #  - OtlpTokenFetcher AMACoreAgent tenant not started
+    #  - CreateSocket / ConnectToPipelineAgent socket connection failures to AMACoreAgent
+    #  - PAConnector::StartTenant / SendAmcsData failures
+    #  - "Will retry one more time in 5 seconds." retry notice (does not include AMACoreAgent keyword)
+    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|Will retry one more time in 5 seconds\.)
+
 [OUTPUT]
     Name                            oms
     EnableTelemetry                 true

--- a/build/linux/installer/conf/fluent-bit-rs.conf
+++ b/build/linux/installer/conf/fluent-bit-rs.conf
@@ -55,7 +55,7 @@
     #  - CreateSocket / ConnectToPipelineAgent socket connection failures to AMACoreAgent
     #  - PAConnector::StartTenant / SendAmcsData failures
     #  - "Will retry one more time in 5 seconds." retry notice (does not include AMACoreAgent keyword)
-    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|Will retry one more time in 5 seconds\.)
+    Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|PAConnector::AmcsStopTenant.*AMACoreAgent|Will retry one more time in 5 seconds\.)
 
 [OUTPUT]
     Name                            oms

--- a/build/linux/installer/conf/fluent-bit-rs.conf
+++ b/build/linux/installer/conf/fluent-bit-rs.conf
@@ -25,7 +25,7 @@
 
 [INPUT]
     Name tail
-    Tag oms.container.log.flbplugin.mdsd.*
+    Tag oms.container.log.flbplugin.mdsd.err.*
     Path /var/opt/microsoft/linuxmonagent/log/mdsd.err
     Read_from_Head true
     DB /var/opt/microsoft/docker-cimprov/state/mdsd-ai.db


### PR DESCRIPTION
MDSD starts looking for AMACoreAgent as soon as the OTLP DCR is attached. As AMACoreAgent will never run in RS, the following logs will be added to mdsd.err file:

```
2025-10-13T22:15:56.7559940Z: [OtlpTokenFetcher] AMACoreAgent tenant not started, trying to start it. DCR Contents: {"configurations":[{"configurationId":"d2025-10-13T22:16:01.7515460Z: [CreateSocket] Failed to connect port 12564 socketId: Config:2 to AMACoreAgent: Connection refused
2025-10-13T22:16:01.7516080Z: [ConnectToPipelineAgent] Failed to create socket to AMACoreAgent with id Config:2
2025-10-13T22:16:01.7516220Z: [ConnectToPipelineAgent] Failed to connect socket to AMACoreAgent.
2025-10-13T22:16:01.7551570Z: Exception while calling PAConnector::StartTenant: Failed to connect socket to AMACoreAgent.
2025-10-13T22:16:01.7552900Z: [CreateSocket] Failed to connect port 12564 socketId: Config:3 to AMACoreAgent: Connection refused
2025-10-13T22:16:01.7553180Z: [ConnectToPipelineAgent] Failed to create socket to AMACoreAgent with id Config:3
Will retry one more time in 5 seconds.
2025-10-13T22:16:06.7557970Z: [CreateSocket] Failed to connect port 12564 socketId: Config:4 to AMACoreAgent: Connection refused
2025-10-13T22:16:06.7559130Z: [ConnectToPipelineAgent] Failed to create socket to AMACoreAgent with id Config:4
2025-10-13T22:16:06.7560160Z: Exception while calling PAConnector::SendAmcsData: Failed to connect socket to AMACoreAgent.
2025-10-13T22:16:06.7562700Z: [CreateSocket] Failed to connect port 12564 socketId: Config:5 to AMACoreAgent: Connection refused
2025-10-13T22:16:06.7562990Z: [ConnectToPipelineAgent] Failed to create socket to AMACoreAgent with id Config:5
```

Since we tail mdsd.err file, we need to exclude these messages to avoid an increase in telemetry.
The similar messages will also be present in DS when OTLP is disabled but DCR is still attached.

**Before:**
<img width="1589" height="621" alt="image" src="https://github.com/user-attachments/assets/d24a049e-0b17-45bf-843f-96689c26eb2e" />

**After:**
<img width="849" height="550" alt="image" src="https://github.com/user-attachments/assets/ca3e3c59-5b15-444e-a9db-206cfd4c05a7" />
