### PR TITLE
OTLP optimize telemetry

### DIFF
--- a/build/linux/installer/conf/fluent-bit-common.conf
+++ b/build/linux/installer/conf/fluent-bit-common.conf
@@ -103,12 +103,6 @@
     #  - "Will retry one more time in 5 seconds." retry notice (does not include AMACoreAgent keyword)
     Exclude log (OtlpTokenFetcher.*AMACoreAgent tenant not started|CreateSocket.*AMACoreAgent|ConnectToPipelineAgent.*AMACoreAgent|PAConnector::StartTenant.*AMACoreAgent|PAConnector::SendAmcsData.*AMACoreAgent|PAConnector::AmcsStopTenant.*AMACoreAgent|Will retry one more time in 5 seconds\.)
 
-[FILTER]
-    Name grep
-    Alias ama-logs_amaca_log_tail
-    Match oms.container.log.flbplugin.amaca.*
-    Exclude log Information
-
 [OUTPUT]
     Name                            oms
     Alias                           oms_output

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -738,12 +738,17 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 			UpdateTracesErrorMetrics("AddonTokenAdapterErrorModifyingIptableRules")
 		} else if strings.Contains(logEntry, "Token last updated at") && strings.Contains(logEntry, "exiting the container") {
 			UpdateTracesErrorMetrics("AddonTokenAdapterExitContainerTokenNotUpdated")
-		} else if strings.Contains(logEntry, "Google.Protobuf") || strings.Contains(logEntry, "OtlpPipeline.HttpListenerConfigService") {
-			UpdateTracesErrorMetrics("OtlpInvalidProtocol")
-		} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
-			UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
-		} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {
-			UpdateTracesInfoMetrics("OtlpSpansEPS", logEntry)
+		} else if strings.Contains(tag, "microsoft.linuxmonagent.amaca.log") {
+			if strings.Contains(logEntry, "Google.Protobuf") || strings.Contains(logEntry, "OtlpPipeline.HttpListenerConfigService") {
+				// This error occurs when the OTLP receiver receives data in an unsupported protocol format or compression is enabled.
+				UpdateTracesErrorMetrics("OtlpInvalidProtocol")
+			} else if strings.Contains(logEntry, "ContentType application/json not supported") {
+				UpdateTracesErrorMetrics("OtlpInvalidContentType")
+			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
+				UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
+			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {
+				UpdateTracesInfoMetrics("OtlpSpansEPS", logEntry)
+			}
 		} else {
 			if !strings.Contains(tag, "addon-token-adapter") && !(strings.Contains(tag, "microsoft.linuxmonagent.amaca.log") && strings.Contains(logEntry, "Information")) {
 				logLines = append(logLines, logEntry)

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -105,7 +105,7 @@ var (
 	// MultitenantNamespaceCount indicates the number of unique k8s namespaces enabled for multi-tenancy
 	MultitenantNamespaceCount int
 	// Regex to capture Received and Published EPS values from GigOtlpDataOutput log lines
-	otlpEPSRegex = regexp.MustCompile(`Received EPS:(\d+(?:\.\d+)?),\s*Published EPS:(\d+(?:\.\d+)?)`)
+	OtlpEPSRegex = regexp.MustCompile(`Received EPS:(\d+(?:\.\d+)?),\s*Published EPS:(\d+(?:\.\d+)?)`)
 )
 
 const (
@@ -456,19 +456,26 @@ func SendTracesAsMetrics(telemetryPushIntervalProperty string) {
 	TracesMetricsTicker = time.NewTicker(time.Second * time.Duration(telemetryPushInterval))
 
 	for ; true; <-TracesMetricsTicker.C {
+		// Capture and clear error metrics atomically
 		TracesErrorMetricsMutex.Lock()
-		for metricName, metricValue := range TracesErrorMetrics {
-			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricName, metricValue))
-		}
+		errorMetricsSnapshot := TracesErrorMetrics
 		TracesErrorMetrics = map[string]float64{}
 		TracesErrorMetricsMutex.Unlock()
 
-		TracesInfoMetricsMutex.Lock()
-		for metricName, metricValue := range TracesInfoMetrics {
+		// Send metrics outside the lock
+		for metricName, metricValue := range errorMetricsSnapshot {
 			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricName, metricValue))
 		}
+
+		// Same pattern for info metrics
+		TracesInfoMetricsMutex.Lock()
+		infoMetricsSnapshot := TracesInfoMetrics
 		TracesInfoMetrics = map[string]float64{}
 		TracesInfoMetricsMutex.Unlock()
+
+		for metricName, metricValue := range infoMetricsSnapshot {
+			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricName, metricValue))
+		}
 	}
 }
 
@@ -686,7 +693,7 @@ func UpdateTracesInfoMetrics(key string, logEntry string) {
 
 // extractOtlpEPS returns Received and Published EPS values when present in a log entry
 func extractOtlpEPS(logEntry string) (float64, float64, bool) {
-	matches := otlpEPSRegex.FindStringSubmatch(logEntry)
+	matches := OtlpEPSRegex.FindStringSubmatch(logEntry)
 	if len(matches) != 3 {
 		return 0, 0, false
 	}
@@ -745,16 +752,20 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 				// This error occurs when the OTLP receiver receives data in an unsupported protocol or compression is enabled.
 				UpdateTracesErrorMetrics("OtlpInvalidConfig")
 			} else if matched, _ := regexp.MatchString(`ContentType .* not supported`, logEntry); matched {
-				UpdateTracesErrorMetrics("OtlpInvalidContentType")
+				UpdateTracesErrorMetrics("InvalidContentType")
 			} else if strings.Contains(logEntry, "GigLA Token not available") {
-				UpdateTracesErrorMetrics("OtlpInvalidToken")
-			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
-				UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
-			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {
-				UpdateTracesInfoMetrics("OtlpSpansEPS", logEntry)
+				UpdateTracesErrorMetrics("InvalidGigLAToken")
+			} else if strings.Contains(logEntry, "GigOtlpDataOutput") {
+				if strings.Contains(logEntry, "Event:Log") {
+					UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
+				} else if strings.Contains(logEntry, "Event:Span") {
+					UpdateTracesInfoMetrics("OtlpSpansEPS", logEntry)
+				}
+			} else if !strings.Contains(logEntry, "Information") {
+				logLines = append(logLines, logEntry)
 			}
 		} else {
-			if !strings.Contains(tag, "addon-token-adapter") && !(strings.Contains(tag, "microsoft.linuxmonagent.amaca.log") && strings.Contains(logEntry, "Information")) {
+			if !strings.Contains(tag, "addon-token-adapter") {
 				logLines = append(logLines, logEntry)
 			}
 		}

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -740,10 +740,12 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 			UpdateTracesErrorMetrics("AddonTokenAdapterExitContainerTokenNotUpdated")
 		} else if strings.Contains(tag, "microsoft.linuxmonagent.amaca.log") {
 			if strings.Contains(logEntry, "Google.Protobuf") || strings.Contains(logEntry, "OtlpPipeline.HttpListenerConfigService") {
-				// This error occurs when the OTLP receiver receives data in an unsupported protocol format or compression is enabled.
-				UpdateTracesErrorMetrics("OtlpInvalidProtocol")
-			} else if strings.Contains(logEntry, "ContentType application/json not supported") {
+				// This error occurs when the OTLP receiver receives data in an unsupported protocol or compression is enabled.
+				UpdateTracesErrorMetrics("OtlpInvalidConfig")
+			} else if matched, _ := regexp.MatchString(`ContentType .* not supported`, logEntry); matched {
 				UpdateTracesErrorMetrics("OtlpInvalidContentType")
+			} else if strings.Contains(logEntry, "GigLA Token not available") {
+				UpdateTracesInfoMetrics("OtlpInvalidToken", logEntry)
 			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
 				UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
 			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -738,7 +738,7 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 			UpdateTracesErrorMetrics("AddonTokenAdapterErrorModifyingIptableRules")
 		} else if strings.Contains(logEntry, "Token last updated at") && strings.Contains(logEntry, "exiting the container") {
 			UpdateTracesErrorMetrics("AddonTokenAdapterExitContainerTokenNotUpdated")
-		} else if strings.Contains(logEntry, "Google.Protobuf.InvalidProtocolBufferException") {
+		} else if strings.Contains(logEntry, "Google.Protobuf") || strings.Contains(logEntry, "OtlpPipeline.HttpListenerConfigService") {
 			UpdateTracesErrorMetrics("OtlpInvalidProtocol")
 		} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
 			UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -665,18 +665,20 @@ func UpdateTracesErrorMetrics(key string) {
 
 func UpdateTracesInfoMetrics(key string, logEntry string) {
 	TracesInfoMetricsMutex.Lock()
-	// 2025-09-18T17:23:19.0195013+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Log, Total Received:10762, Total Published:10762, Total Failed:0, Received EPS:81.18, Published EPS:81.18.
-	// 2025-09-18T17:23:19.0246002+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Span, Total Received:39080, Total Published:39080, Total Failed:0, Received EPS:264.30, Published EPS:264.30.
-	if received, published, ok := extractOtlpEPS(logEntry); ok {
-		if existingReceived, ok := TracesInfoMetrics[key+"Received"]; ok {
-			TracesInfoMetrics[key+"Received"] = math.Max(existingReceived, received)
-		} else {
-			TracesInfoMetrics[key+"Received"] = received
-		}
-		if existingPublished, ok := TracesInfoMetrics[key+"Published"]; ok {
-			TracesInfoMetrics[key+"Published"] = math.Max(existingPublished, published)
-		} else {
-			TracesInfoMetrics[key+"Published"] = published
+	if strings.Contains(key, "Otlp") && strings.Contains(key, "EPS") {
+		// 2025-09-18T17:23:19.0195013+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Log, Total Received:10762, Total Published:10762, Total Failed:0, Received EPS:81.18, Published EPS:81.18.
+		// 2025-09-18T17:23:19.0246002+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Span, Total Received:39080, Total Published:39080, Total Failed:0, Received EPS:264.30, Published EPS:264.30.
+		if received, published, ok := extractOtlpEPS(logEntry); ok {
+			if existingReceived, ok := TracesInfoMetrics[key+"Received"]; ok {
+				TracesInfoMetrics[key+"Received"] = math.Max(existingReceived, received)
+			} else {
+				TracesInfoMetrics[key+"Received"] = received
+			}
+			if existingPublished, ok := TracesInfoMetrics[key+"Published"]; ok {
+				TracesInfoMetrics[key+"Published"] = math.Max(existingPublished, published)
+			} else {
+				TracesInfoMetrics[key+"Published"] = published
+			}
 		}
 	}
 	TracesInfoMetricsMutex.Unlock()
@@ -745,7 +747,7 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 			} else if matched, _ := regexp.MatchString(`ContentType .* not supported`, logEntry); matched {
 				UpdateTracesErrorMetrics("OtlpInvalidContentType")
 			} else if strings.Contains(logEntry, "GigLA Token not available") {
-				UpdateTracesInfoMetrics("OtlpInvalidToken", logEntry)
+				UpdateTracesErrorMetrics("OtlpInvalidToken")
 			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
 				UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
 			} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {
@@ -758,9 +760,11 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 		}
 	}
 
-	traceEntry := strings.Join(logLines, "\n")
-	traceTelemetryItem := appinsights.NewTraceTelemetry(traceEntry, severityLevel)
-	traceTelemetryItem.Properties["tag"] = tag
-	TelemetryClient.Track(traceTelemetryItem)
+	if len(logLines) > 0 {
+		traceEntry := strings.Join(logLines, "\n")
+		traceTelemetryItem := appinsights.NewTraceTelemetry(traceEntry, severityLevel)
+		traceTelemetryItem.Properties["tag"] = tag
+		TelemetryClient.Track(traceTelemetryItem)
+	}
 	return output.FLB_OK
 }

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -90,14 +91,20 @@ var (
 	}
 	//Metrics map for the mdsd traces
 	TracesErrorMetrics = map[string]float64{}
-	//Time ticker for sending mdsd errors as metrics
-	TracesErrorMetricsTicker *time.Ticker
+	//Time ticker for sending traces as metrics
+	TracesMetricsTicker *time.Ticker
 	//Mutex for mdsd error metrics
 	TracesErrorMetricsMutex = &sync.Mutex{}
+	//Metrics map for traces information
+	TracesInfoMetrics = map[string]float64{}
+	//Mutex for traces information metrics
+	TracesInfoMetricsMutex = &sync.Mutex{}
 	// ContainerLogV2ExtensionDCRCount indicates the number of ContainerLogV2 extension DCRs
 	ContainerLogV2ExtensionDCRCount int
 	// MultitenantNamespaceCount indicates the number of unique k8s namespaces enabled for multi-tenancy
 	MultitenantNamespaceCount int
+	// Regex to capture Received and Published EPS values from GigOtlpDataOutput log lines
+	otlpEPSRegex = regexp.MustCompile(`Received EPS:(\d+(?:\.\d+)?),\s*Published EPS:(\d+(?:\.\d+)?)`)
 )
 
 const (
@@ -445,15 +452,22 @@ func SendTracesAsMetrics(telemetryPushIntervalProperty string) {
 		telemetryPushInterval = defaultTelemetryPushIntervalSeconds
 	}
 
-	TracesErrorMetricsTicker = time.NewTicker(time.Second * time.Duration(telemetryPushInterval))
+	TracesMetricsTicker = time.NewTicker(time.Second * time.Duration(telemetryPushInterval))
 
-	for ; true; <-TracesErrorMetricsTicker.C {
+	for ; true; <-TracesMetricsTicker.C {
 		TracesErrorMetricsMutex.Lock()
 		for metricName, metricValue := range TracesErrorMetrics {
 			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricName, metricValue))
 		}
 		TracesErrorMetrics = map[string]float64{}
 		TracesErrorMetricsMutex.Unlock()
+
+		TracesInfoMetricsMutex.Lock()
+		for metricName, metricValue := range TracesInfoMetrics {
+			TelemetryClient.Track(appinsights.NewMetricTelemetry(metricName, metricValue))
+		}
+		TracesInfoMetrics = map[string]float64{}
+		TracesInfoMetricsMutex.Unlock()
 	}
 }
 
@@ -648,6 +662,37 @@ func UpdateTracesErrorMetrics(key string) {
 	TracesErrorMetricsMutex.Unlock()
 }
 
+func UpdateTracesInfoMetrics(key string, logEntry string) {
+	TracesInfoMetricsMutex.Lock()
+	// 2025-09-18T17:23:19.0195013+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Log, Total Received:10762, Total Published:10762, Total Failed:0, Received EPS:81.18, Published EPS:81.18.
+	// 2025-09-18T17:23:19.0246002+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Span, Total Received:39080, Total Published:39080, Total Failed:0, Received EPS:264.30, Published EPS:264.30.
+	if received, published, ok := extractOtlpEPS(logEntry); ok {
+		TracesInfoMetrics[key+"Received"] = received
+		TracesInfoMetrics[key+"Published"] = published
+	}
+	TracesInfoMetricsMutex.Unlock()
+}
+
+// extractOtlpEPS returns Received and Published EPS values when present in a log entry
+func extractOtlpEPS(logEntry string) (float64, float64, bool) {
+	matches := otlpEPSRegex.FindStringSubmatch(logEntry)
+	if len(matches) != 3 {
+		return 0, 0, false
+	}
+
+	received, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	published, err := strconv.ParseFloat(matches[2], 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return received, published, true
+}
+
 // PushToAppInsightsTraces sends the log lines as trace messages to the configured App Insights Instance
 func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLevel contracts.SeverityLevel, tag string) int {
 	var logLines []string
@@ -684,8 +729,14 @@ func PushToAppInsightsTraces(records []map[interface{}]interface{}, severityLeve
 			UpdateTracesErrorMetrics("AddonTokenAdapterErrorModifyingIptableRules")
 		} else if strings.Contains(logEntry, "Token last updated at") && strings.Contains(logEntry, "exiting the container") {
 			UpdateTracesErrorMetrics("AddonTokenAdapterExitContainerTokenNotUpdated")
+		} else if strings.Contains(logEntry, "Google.Protobuf.InvalidProtocolBufferException") {
+			UpdateTracesErrorMetrics("OtlpInvalidProtocol")
+		} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Log") {
+			UpdateTracesInfoMetrics("OtlpLogsEPS", logEntry)
+		} else if strings.Contains(logEntry, "GigOtlpDataOutput") && strings.Contains(logEntry, "Event:Span") {
+			UpdateTracesInfoMetrics("OtlpSpansEPS", logEntry)
 		} else {
-			if !strings.Contains(tag, "addon-token-adapter") {
+			if !strings.Contains(tag, "addon-token-adapter") && !(strings.Contains(tag, "microsoft.linuxmonagent.amaca.log") && strings.Contains(logEntry, "Information")) {
 				logLines = append(logLines, logEntry)
 			}
 		}

--- a/source/plugins/go/src/telemetry.go
+++ b/source/plugins/go/src/telemetry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"errors"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -667,8 +668,16 @@ func UpdateTracesInfoMetrics(key string, logEntry string) {
 	// 2025-09-18T17:23:19.0195013+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Log, Total Received:10762, Total Published:10762, Total Failed:0, Received EPS:81.18, Published EPS:81.18.
 	// 2025-09-18T17:23:19.0246002+00:00, amacoreagent, Information, Pid: 243334, Tid: 15] GigOtlpDataOutput: Identifier:dcr-**.gigl-dce-**, Event:Span, Total Received:39080, Total Published:39080, Total Failed:0, Received EPS:264.30, Published EPS:264.30.
 	if received, published, ok := extractOtlpEPS(logEntry); ok {
-		TracesInfoMetrics[key+"Received"] = received
-		TracesInfoMetrics[key+"Published"] = published
+		if existingReceived, ok := TracesInfoMetrics[key+"Received"]; ok {
+			TracesInfoMetrics[key+"Received"] = math.Max(existingReceived, received)
+		} else {
+			TracesInfoMetrics[key+"Received"] = received
+		}
+		if existingPublished, ok := TracesInfoMetrics[key+"Published"]; ok {
+			TracesInfoMetrics[key+"Published"] = math.Max(existingPublished, published)
+		} else {
+			TracesInfoMetrics[key+"Published"] = published
+		}
 	}
 	TracesInfoMetricsMutex.Unlock()
 }


### PR DESCRIPTION
This PR optimizes OTLP related telemetry by converting the logs to metrics for following scenarios:
1. Invalid config - compression is enabled.
2. Unsupported protocol
3. GIG LA token error
4. Logs Published and received EPS.

Metrics Output:
<img width="485" height="411" alt="image" src="https://github.com/user-attachments/assets/9752017c-0199-47cd-8221-162b2927d8ce" />

Verified that no otlp errors are getting logged in traces.
