### PR TITLE
Bug fix for OTEL_RESOURCE_ATTRIBUTES handling: must preserve user-defined attributes for kubectl apply case

### DIFF
--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -166,35 +166,14 @@ export class Mutations {
      * Generates environment variables necessary to configure agents. Agents take configuration from these environment variables once they run.
      */
     public static GenerateEnvironmentVariables(podInfo: PodInfo, platforms: AutoInstrumentationPlatforms[], disableAppLogs: boolean, connectionString: string, armId: string, armRegion: string, clusterName: string, otelParams: OtelParams, existingEnvironmentVariables?: Record<string, IEnvironmentVariable>, isPythonEnabled?: boolean): IEnvironmentVariable[] {
-        const ownerNameAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.name=${podInfo.ownerName}`;
-        const ownerUidAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.uid=${podInfo.ownerUid}`;
-        const containerNameAttribute = `k8s.container.name=${podInfo.onlyContainerName}`;
         const applicationId = Mutations.parseApplicationIdFromConnectionString(connectionString);
         
         // Build our OTEL resource attributes
-        const otelResourceAttributesList = [
-            `cloud.resource_id=${armId}`,
-            `cloud.region=${armRegion}`,
-            `k8s.cluster.name=${clusterName}`,
-            `k8s.namespace.name=$(POD_NAMESPACE)`,
-            `k8s.node.name=$(NODE_NAME)`,
-            `k8s.pod.name=$(POD_NAME)`,
-            `k8s.pod.uid=$(POD_UID)`,
-            containerNameAttribute,
-            `cloud.provider=Azure`,
-            `cloud.platform=azure_aks`,
-            ownerNameAttribute,
-            ownerUidAttribute
-        ];
-        
-        if (applicationId) {
-            otelResourceAttributesList.push(`microsoft.applicationId=${applicationId}`);
-        }
-        
+        const otelResourceAttributesList: string[] = Mutations.buildOtelResourceAttributesList(podInfo, armId, armRegion, clusterName, applicationId);
         const otelResourceAttributes = otelResourceAttributesList.join(',');
 
         // Check if there's an existing OTEL_RESOURCE_ATTRIBUTES and merge if needed
-        const existingOtelResourceAttributes = existingEnvironmentVariables?.["OTEL_RESOURCE_ATTRIBUTES"]?.value;
+        const existingOtelResourceAttributes: string = existingEnvironmentVariables?.["OTEL_RESOURCE_ATTRIBUTES"]?.value;
         const mergedOtelResourceAttributes = Mutations.mergeOtelResourceAttributes(existingOtelResourceAttributes, otelResourceAttributes);
         
         const returnValue: IEnvironmentVariable[] = [
@@ -632,5 +611,68 @@ export class Mutations {
         return Object.entries(mergedAttributes)
             .map(([key, value]) => `${key}=${value}`)
             .join(',');
+    }
+
+    /**
+     * Builds the list of OTEL resource attributes that our mutation injects.
+     * This is the single source of truth for mutation-injected attributes.
+     * @returns Array of attribute strings in "key=value" format
+     */
+    private static buildOtelResourceAttributesList(podInfo: PodInfo, armId: string, armRegion: string, clusterName: string, applicationId: string | null): string[] {
+        const ownerNameAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.name=${podInfo.ownerName}`;
+        const ownerUidAttribute = `k8s.${podInfo.ownerKind?.toLowerCase()}.uid=${podInfo.ownerUid}`;
+        const containerNameAttribute = `k8s.container.name=${podInfo.onlyContainerName}`;
+        
+        const attributes = [
+            `cloud.resource_id=${armId}`,
+            `cloud.region=${armRegion}`,
+            `k8s.cluster.name=${clusterName}`,
+            `k8s.namespace.name=$(POD_NAMESPACE)`,
+            `k8s.node.name=$(NODE_NAME)`,
+            `k8s.pod.name=$(POD_NAME)`,
+            `k8s.pod.uid=$(POD_UID)`,
+            containerNameAttribute,
+            `cloud.provider=Azure`,
+            `cloud.platform=azure_aks`,
+            ownerNameAttribute,
+            ownerUidAttribute
+        ];
+        
+        if (applicationId) {
+            attributes.push(`microsoft.applicationId=${applicationId}`);
+        }
+        
+        return attributes;
+    }
+
+    /**
+     * Returns the set of OTEL_RESOURCE_ATTRIBUTES keys that are injected by our mutation.
+     * This is derived from buildOtelResourceAttributesList to ensure single source of truth.
+     * Used during unpatch to differentiate mutation-injected attributes from user-provided attributes.
+     * @returns Set of attribute key strings (e.g., "cloud.resource_id", "k8s.pod.name")
+     */
+    public static GetMutationOtelResourceAttributeKeys(): Set<string> {
+        // build with dummy values to extract the keys
+        const dummyPodInfo = new PodInfo();
+        dummyPodInfo.ownerKind = "deployment"; // use a concrete value to get k8s.deployment.name/uid
+        const attributesList = Mutations.buildOtelResourceAttributesList(dummyPodInfo, "", "", "", "dummy-app-id");
+        
+        // extract just the keys (part before '=')
+        const keys = new Set<string>();
+        for (const attr of attributesList) {
+            const [key] = attr.split('=');
+            if (key) {
+                keys.add(key.trim());
+            }
+        }
+        
+        // also add all possible owner kind variations since ownerKind is dynamic
+        const ownerKinds = ['deployment', 'replicaset', 'statefulset', 'daemonset', 'job', 'cronjob'];
+        for (const kind of ownerKinds) {
+            keys.add(`k8s.${kind}.name`);
+            keys.add(`k8s.${kind}.uid`);
+        }
+        
+        return keys;
     }
 }

--- a/appmonitoring/ts/src/Patcher.ts
+++ b/appmonitoring/ts/src/Patcher.ts
@@ -158,12 +158,25 @@ export class Patcher {
                 // find the environment variable in the container
                 const evIndex = container.env?.findIndex(ev => ev.name === evtr.name);
 
-                if(evIndex === -1) {
+                if(evIndex === -1 || evIndex === undefined) {
                     // container doesn't have this environment variable, continue
                     return;
                 }
 
                 // container contains this environment variable
+
+                // special handling for OTEL_RESOURCE_ATTRIBUTES - parse and preserve user's custom attributes
+                if(evtr.name === "OTEL_RESOURCE_ATTRIBUTES") {
+                    const currentValue = container.env[evIndex].value;
+                    const userAttributes = this.extractUserOtelResourceAttributes(currentValue);
+                    
+                    if(userAttributes) {
+                        // user has custom attributes, preserve them
+                        container.env[evIndex].value = userAttributes;
+                        return; // don't remove or restore from backup
+                    }
+                    // if no user attributes, fall through to normal removal logic
+                }
 
                 // is there a backup environment variable that we created during mutation to hold the original value?
                 const backupEvName = `${evtr.name}${Patcher.EnvironmentVariableBackupSuffix}`;
@@ -177,7 +190,7 @@ export class Patcher {
                     // remove the old primary one
                     container.env?.splice(evIndex, 1);
                 } else {
-                    // there is not, so this is either the original, never mutated, object, or a mutated objected where the original didn't have this environment varialbe specified
+                    // there is not, so this is either the original, never mutated, object, or a mutated object where the original didn't have this environment variable specified
                     if(instrumentationState?.crName) {
                         // this is a mutated object
                         if(!evtr.platformSpecific || instrumentationState.platforms.includes(evtr.platformSpecific)) {
@@ -199,5 +212,46 @@ export class Patcher {
      
             container.volumeMounts = container.volumeMounts?.filter(vm => !volumeMountsToRemove.find(vmtr => vm.name === vmtr.name));
         });
+    }
+
+    /**
+     * Extracts user-provided OTEL_RESOURCE_ATTRIBUTES by filtering out mutation-injected attributes
+     * Returns null if no user attributes remain, otherwise returns a comma-separated string
+     */
+    private static extractUserOtelResourceAttributes(currentValue: string): string | null {
+        if (!currentValue) {
+            return null;
+        }
+
+        // get the attribute keys that our mutation injects - these should be removed during unpatch
+        const mutationAttributeKeys = Mutations.GetMutationOtelResourceAttributeKeys();
+
+        // Parse existing attributes
+        const userAttributes: Record<string, string> = {};
+        const pairs = currentValue.split(',');
+        
+        for (const pair of pairs) {
+            const trimmedPair = pair.trim();
+            if (trimmedPair) {
+                const [key, ...valueParts] = trimmedPair.split('=');
+                if (key && valueParts.length > 0) {
+                    const trimmedKey = key.trim();
+                    // keep only attributes that aren't mutation-injected
+                    if (!mutationAttributeKeys.has(trimmedKey)) {
+                        userAttributes[trimmedKey] = valueParts.join('=').trim();
+                    }
+                }
+            }
+        }
+
+        // if no user attributes remain, return null
+        if (Object.keys(userAttributes).length === 0) {
+            return null;
+        }
+
+        // convert back to string
+        return Object.entries(userAttributes)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(',');
     }
 }

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -986,5 +986,173 @@ describe("Patcher", () => {
             expect(otelResourceAttributes!.value).toContain("cloud.provider=Azure");
             expect(otelResourceAttributes!.value).toContain("k8s.cluster.name=" + clusterName);
         });
+
+        it("should preserve user's OTEL_RESOURCE_ATTRIBUTES when they edit a mutated deployment via kubectl apply", () => {
+            // SCENARIO:
+            // 1. User deploys with OTEL_RESOURCE_ATTRIBUTES=mytag=myvalue1
+            // 2. Deployment gets mutated
+            // 3. User does kubectl apply to change OTEL_RESOURCE_ATTRIBUTES to mytag=myvalue2
+            // 4. We need to verify the new value (myvalue2) is preserved and backed up correctly
+
+            const cr1: InstrumentationCR = JSON.parse(JSON.stringify(cr));
+            const platforms = [AutoInstrumentationPlatforms.Java];
+
+            // STEP 1: Initial deployment with mytag=myvalue1
+            const initialDeployment = JSON.parse(JSON.stringify(TestDeployment2.request.object));
+            initialDeployment.spec.template.spec.containers[0].env = [{
+                name: "OTEL_RESOURCE_ATTRIBUTES",
+                value: "mytag=myvalue1"
+            }];
+
+            // STEP 2: First mutation - deployment gets mutated
+            const firstMutationResult: object[] = Patcher.PatchObject(
+                JSON.parse(JSON.stringify(initialDeployment)), 
+                cr1, 
+                podInfo, 
+                platforms, 
+                clusterArmId, 
+                clusterArmRegion, 
+                clusterName, 
+                testOtelParams
+            );
+
+            const firstMutatedDeployment: IObjectType = (<any>firstMutationResult[0]).value as IObjectType;
+            
+            // Verify first mutation has backup and merged attributes
+            const firstMutatedEnv = firstMutatedDeployment.spec.template.spec.containers[0].env;
+            const firstOtelAttr = firstMutatedEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES");
+            const firstBackupAttr = firstMutatedEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES_BEFORE_AUTO_INSTRUMENTATION");
+            
+            expect(firstOtelAttr).toBeDefined();
+            expect(firstOtelAttr!.value).toContain("mytag=myvalue1"); // user's original value
+            expect(firstOtelAttr!.value).toContain("cloud.provider=Azure"); // our mutation
+            expect(firstBackupAttr).toBeDefined();
+            expect(firstBackupAttr!.value).toBe("mytag=myvalue1"); // backup of original
+
+            // STEP 3: User edits via kubectl apply - changes mytag=myvalue1 to mytag=myvalue2
+            // When kubectl apply happens, Kubernetes merges the user's new YAML with the live state
+            // The webhook receives the merged result, which includes the user's new simple value
+            // AND all the mutations that were previously applied (volumes, initContainers, annotations, etc.)
+            const editedDeployment = JSON.parse(JSON.stringify(firstMutatedDeployment));
+            
+            // Simulate kubectl apply behavior: The user's YAML only contains OTEL_RESOURCE_ATTRIBUTES=mytag=myvalue2
+            // Kubernetes merges this with the live state, so the webhook receives:
+            // - The mutated deployment structure (volumes, initContainers, our env vars, etc.)
+            // - BUT with the user's NEW value for OTEL_RESOURCE_ATTRIBUTES (just mytag=myvalue2, not the full mutated string)
+            // This is because kubectl apply uses the user's manifest as the source of truth for fields they specified
+            const editedOtelAttrIndex = editedDeployment.spec.template.spec.containers[0].env.findIndex(
+                (env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES"
+            );
+            // Replace the fully mutated OTEL_RESOURCE_ATTRIBUTES with just the user's new value
+            editedDeployment.spec.template.spec.containers[0].env[editedOtelAttrIndex].value = "mytag=myvalue2";
+
+            // STEP 4: Second mutation - webhook processes the edited deployment
+            const secondMutationResult: object[] = Patcher.PatchObject(
+                editedDeployment,
+                cr1,
+                podInfo,
+                platforms,
+                clusterArmId,
+                clusterArmRegion,
+                clusterName,
+                testOtelParams
+            );
+
+            const finalMutatedDeployment: IObjectType = (<any>secondMutationResult[0]).value as IObjectType;
+            const finalEnv = finalMutatedDeployment.spec.template.spec.containers[0].env;
+            const finalOtelAttr = finalEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES");
+            const finalBackupAttr = finalEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES_BEFORE_AUTO_INSTRUMENTATION");
+
+            // ASSERT: The final mutation should preserve the user's NEW value (myvalue2)
+            expect(finalOtelAttr).toBeDefined();
+            expect(finalOtelAttr!.value).toContain("mytag=myvalue2"); // user's NEW value must be preserved
+            expect(finalOtelAttr!.value).not.toContain("mytag=myvalue1"); // old value should NOT be there
+            expect(finalOtelAttr!.value).toContain("cloud.provider=Azure"); // our mutation attributes still present
+            expect(finalOtelAttr!.value).toContain("k8s.cluster.name=" + clusterName); // our mutation attributes still present
+
+            // ASSERT: The backup should contain the user's NEW value (myvalue2)
+            expect(finalBackupAttr).toBeDefined();
+            expect(finalBackupAttr!.value).toContain("mytag=myvalue2"); // backup must contain the NEW value
+            expect(finalBackupAttr!.value).not.toContain("cloud.provider"); // backup should NOT contain our mutation attributes
+        });
+
+        it("should preserve user's OTEL_RESOURCE_ATTRIBUTES when kubectl rollout restart is executed on a mutated deployment", () => {
+            // SCENARIO:
+            // 1. User deploys with OTEL_RESOURCE_ATTRIBUTES=mytag=myvalue1
+            // 2. Deployment gets mutated
+            // 3. User runs kubectl rollout restart (triggers new pods without changing deployment spec)
+            // 4. Webhook receives the FULLY mutated deployment (including all our env vars with merged attributes)
+            // 5. We need to verify that the user's attribute (mytag=myvalue1) is still preserved after re-mutation
+
+            const cr1: InstrumentationCR = JSON.parse(JSON.stringify(cr));
+            const platforms = [AutoInstrumentationPlatforms.Java];
+
+            // STEP 1: Initial deployment with mytag=myvalue1
+            const initialDeployment = JSON.parse(JSON.stringify(TestDeployment2.request.object));
+            initialDeployment.spec.template.spec.containers[0].env = [{
+                name: "OTEL_RESOURCE_ATTRIBUTES",
+                value: "mytag=myvalue1"
+            }];
+
+            // STEP 2: First mutation - deployment gets mutated
+            const firstMutationResult: object[] = Patcher.PatchObject(
+                JSON.parse(JSON.stringify(initialDeployment)), 
+                cr1, 
+                podInfo, 
+                platforms, 
+                clusterArmId, 
+                clusterArmRegion, 
+                clusterName, 
+                testOtelParams
+            );
+
+            const firstMutatedDeployment: IObjectType = (<any>firstMutationResult[0]).value as IObjectType;
+            
+            // Verify first mutation has backup and merged attributes
+            const firstMutatedEnv = firstMutatedDeployment.spec.template.spec.containers[0].env;
+            const firstOtelAttr = firstMutatedEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES");
+            const firstBackupAttr = firstMutatedEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES_BEFORE_AUTO_INSTRUMENTATION");
+            
+            expect(firstOtelAttr).toBeDefined();
+            expect(firstOtelAttr!.value).toContain("mytag=myvalue1"); // user's original value
+            expect(firstOtelAttr!.value).toContain("cloud.provider=Azure"); // our mutation
+            expect(firstBackupAttr).toBeDefined();
+            expect(firstBackupAttr!.value).toBe("mytag=myvalue1"); // backup of original
+
+            // STEP 3: kubectl rollout restart
+            // When kubectl rollout restart happens, Kubernetes doesn't change the deployment spec
+            // The webhook receives the FULLY MUTATED deployment exactly as it exists in the cluster
+            // This includes all our mutations: volumes, initContainers, env vars with merged values, backup env vars, etc.
+            // The webhook needs to handle this already-mutated deployment without losing user's custom attributes
+            const rolloutRestartDeployment = JSON.parse(JSON.stringify(firstMutatedDeployment));
+            
+            // STEP 4: Second mutation - webhook processes the rollout restart
+            // This simulates the webhook being called again on the same mutated deployment
+            const secondMutationResult: object[] = Patcher.PatchObject(
+                rolloutRestartDeployment,
+                cr1,
+                podInfo,
+                platforms,
+                clusterArmId,
+                clusterArmRegion,
+                clusterName,
+                testOtelParams
+            );
+
+            const finalMutatedDeployment: IObjectType = (<any>secondMutationResult[0]).value as IObjectType;
+            const finalEnv = finalMutatedDeployment.spec.template.spec.containers[0].env;
+            const finalOtelAttr = finalEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES");
+            const finalBackupAttr = finalEnv.find((env: IEnvironmentVariable) => env.name === "OTEL_RESOURCE_ATTRIBUTES_BEFORE_AUTO_INSTRUMENTATION");
+
+            // ASSERT: The user's original attribute should still be preserved
+            expect(finalOtelAttr).toBeDefined();
+            expect(finalOtelAttr!.value).toContain("mytag=myvalue1"); // user's original value must be preserved
+            expect(finalOtelAttr!.value).toContain("cloud.provider=Azure"); // our mutation attributes still present
+            expect(finalOtelAttr!.value).toContain("k8s.cluster.name=" + clusterName); // our mutation attributes still present
+
+            // ASSERT: The backup should still contain the user's original value
+            expect(finalBackupAttr).toBeDefined();
+            expect(finalBackupAttr!.value).toBe("mytag=myvalue1"); // backup must contain the original value
+        });
     });
 });


### PR DESCRIPTION
Enhance OTEL_RESOURCE_ATTRIBUTES handling to preserve user-defined attributes during mutations and unpatching