### PR TITLE
Adding change for networkflow logs new stream

### DIFF
--- a/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterParam.json
+++ b/scripts/onboarding/aks/onboarding-msi-bicep-syslog/existingClusterParam.json
@@ -90,7 +90,7 @@
         "Microsoft-ContainerInventory",
         "Microsoft-ContainerNodeInventory",
         "Microsoft-Perf",
-        "Microsoft-RetinaNetworkFlowLogs"
+        "Microsoft-ContainerNetworkLogs"
       ]
     },
     "useAzureMonitorPrivateLinkScope": {

--- a/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterParam.json
+++ b/scripts/onboarding/aks/onboarding-msi-bicep/existingClusterParam.json
@@ -54,7 +54,7 @@
         "Microsoft-ContainerInventory",
         "Microsoft-ContainerNodeInventory",
         "Microsoft-Perf",
-        "Microsoft-RetinaNetworkFlowLogs"
+        "Microsoft-ContainerNetworkLogs"
       ]
     },
     "useAzureMonitorPrivateLinkScope": {

--- a/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterParam.json
+++ b/scripts/onboarding/aks/onboarding-using-msi-auth/existingClusterParam.json
@@ -93,7 +93,7 @@
         "Microsoft-ContainerInventory",
         "Microsoft-ContainerNodeInventory",
         "Microsoft-Perf",
-        "Microsoft-RetinaNetworkFlowLogs"
+        "Microsoft-ContainerNetworkLogs"
       ]
     },
     "useAzureMonitorPrivateLinkScope": {

--- a/source/plugins/go/src/network_flow_logs.go
+++ b/source/plugins/go/src/network_flow_logs.go
@@ -14,8 +14,11 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// Stream name for retina networkflow logs
-const RetinaNetworkFlowLogsStreamName = "RETINA_NETWORK_FLOW_LOGS"
+// Stream names for network flow logs
+const (
+	ContainerNetworkLogsStreamName  = "CONTAINER_NETWORK_LOGS"   // New stream name
+	RetinaNetworkFlowLogsStreamName = "RETINA_NETWORK_FLOW_LOGS" // Legacy stream name
+)
 
 var (
 	// retina networkflow logs stream tag name
@@ -75,10 +78,15 @@ func PostNetworkFlowRecords(tailPluginRecords []map[interface{}]interface{}) int
 		}
 
 		if len(networkFlowLogsMsgPackEntries) > 0 {
-			MdsdNetworkFlowLogsStreamTagName = getOutputStreamIdTag(RetinaNetworkFlowLogsStreamName, MdsdNetworkFlowLogsStreamTagName, &NetworkFlowTagRefreshTracker)
+			// Try getting the stream tag with the new name first
+			MdsdNetworkFlowLogsStreamTagName = getOutputStreamIdTag(ContainerNetworkLogsStreamName, MdsdNetworkFlowLogsStreamTagName, &NetworkFlowTagRefreshTracker)
 			if MdsdNetworkFlowLogsStreamTagName == "" {
-				Log("Error::mdsd::Failed to get stream tag for networkflow logs. Will retry ...")
-				return output.FLB_RETRY
+				// If new stream name fails, try the legacy stream name
+				MdsdNetworkFlowLogsStreamTagName = getOutputStreamIdTag(RetinaNetworkFlowLogsStreamName, MdsdNetworkFlowLogsStreamTagName, &NetworkFlowTagRefreshTracker)
+				if MdsdNetworkFlowLogsStreamTagName == "" {
+					Log("Error::mdsd::Failed to get stream tag for networkflow logs. Will retry ...")
+					return output.FLB_RETRY
+				}
 			}
 			if MdsdNetworkFlowClient == nil {
 				Log("Error::mdsd::mdsd connection does not exist for networkflow mdsd client. re-connecting ...")
@@ -286,12 +294,28 @@ func mapNetworkFlowLogsToDataMap(dataMap map[string]interface{}, record map[stri
 	if traceObservationPoint := extractString(flow, "trace_observation_point"); traceObservationPoint != "" {
 		dataMap["TraceObservationPoint"] = traceObservationPoint
 	}
-	// Packets and Bytes
-	if packetsSent, ok := flow["packets_sent"]; ok {
-		dataMap["PacketsSent"] = safeToInt(packetsSent)
-	}
-	if packetsReceived, ok := flow["packets_received"]; ok {
-		dataMap["PacketsReceived"] = safeToInt(packetsReceived)
+	// Flow counts and packets
+	if MdsdNetworkFlowLogsStreamTagName == getOutputStreamIdTag(ContainerNetworkLogsStreamName, "", &NetworkFlowTagRefreshTracker) {
+		// For new CONTAINER_NETWORK_LOGS stream, use flow counts from extensions
+		if extensions, ok := flow["extensions"].(map[string]interface{}); ok {
+			if ingressCount, ok := extensions["ingress_flow_count"]; ok {
+				dataMap["IngressFlowCount"] = safeToInt(ingressCount)
+			}
+			if egressCount, ok := extensions["egress_flow_count"]; ok {
+				dataMap["EgressFlowCount"] = safeToInt(egressCount)
+			}
+			if unknownCount, ok := extensions["unknown_direction_flow_count"]; ok {
+				dataMap["UnknownDirectionFlowCount"] = safeToInt(unknownCount)
+			}
+		}
+	} else {
+		// For legacy RETINA_NETWORK_FLOW_LOGS stream, use packet counts
+		if packetsSent, ok := flow["packets_sent"]; ok {
+			dataMap["PacketsSent"] = safeToInt(packetsSent)
+		}
+		if packetsReceived, ok := flow["packets_received"]; ok {
+			dataMap["PacketsReceived"] = safeToInt(packetsReceived)
+		}
 	}
 	// Policies
 	policiesData := map[string]interface{}{}

--- a/source/plugins/go/src/network_flow_logs.go
+++ b/source/plugins/go/src/network_flow_logs.go
@@ -294,27 +294,16 @@ func mapNetworkFlowLogsToDataMap(dataMap map[string]interface{}, record map[stri
 	if traceObservationPoint := extractString(flow, "trace_observation_point"); traceObservationPoint != "" {
 		dataMap["TraceObservationPoint"] = traceObservationPoint
 	}
-	// Flow counts and packets
-	if MdsdNetworkFlowLogsStreamTagName == getOutputStreamIdTag(ContainerNetworkLogsStreamName, "", &NetworkFlowTagRefreshTracker) {
-		// For new CONTAINER_NETWORK_LOGS stream, use flow counts from extensions
-		if extensions, ok := flow["extensions"].(map[string]interface{}); ok {
-			if ingressCount, ok := extensions["ingress_flow_count"]; ok {
-				dataMap["IngressFlowCount"] = safeToInt(ingressCount)
-			}
-			if egressCount, ok := extensions["egress_flow_count"]; ok {
-				dataMap["EgressFlowCount"] = safeToInt(egressCount)
-			}
-			if unknownCount, ok := extensions["unknown_direction_flow_count"]; ok {
-				dataMap["UnknownDirectionFlowCount"] = safeToInt(unknownCount)
-			}
+	// Flow counts from extensions
+	if extensions, ok := flow["extensions"].(map[string]interface{}); ok {
+		if ingressCount, ok := extensions["ingress_flow_count"]; ok {
+			dataMap["IngressFlowCount"] = safeToInt(ingressCount)
 		}
-	} else {
-		// For legacy RETINA_NETWORK_FLOW_LOGS stream, use packet counts
-		if packetsSent, ok := flow["packets_sent"]; ok {
-			dataMap["PacketsSent"] = safeToInt(packetsSent)
+		if egressCount, ok := extensions["egress_flow_count"]; ok {
+			dataMap["EgressFlowCount"] = safeToInt(egressCount)
 		}
-		if packetsReceived, ok := flow["packets_received"]; ok {
-			dataMap["PacketsReceived"] = safeToInt(packetsReceived)
+		if unknownCount, ok := extensions["unknown_direction_flow_count"]; ok {
+			dataMap["UnknownDirectionFlowCount"] = safeToInt(unknownCount)
 		}
 	}
 	// Policies
@@ -353,8 +342,17 @@ func mapNetworkFlowLogsToDataMap(dataMap map[string]interface{}, record map[stri
 	if summary, ok := flow["Summary"]; ok {
 		additionalData["Summary"] = summary
 	}
-	if extensions, ok := flow["extensions"]; ok {
-		additionalData["Extensions"] = extensions
+	if extensions, ok := flow["extensions"].(map[string]interface{}); ok {
+		// Create a new map without the flow count fields
+		filteredExtensions := make(map[string]interface{})
+		for k, v := range extensions {
+			if k != "ingress_flow_count" && k != "egress_flow_count" && k != "unknown_direction_flow_count" {
+				filteredExtensions[k] = v
+			}
+		}
+		if len(filteredExtensions) > 0 {
+			additionalData["Extensions"] = filteredExtensions
+		}
 	}
 	if len(additionalData) > 0 {
 		dataMap["AdditionalFlowData"] = serializeToJSON(additionalData)


### PR DESCRIPTION
Summary
This PR introduces enhancements to the network flow log processing in the Fluent Bit plugin, focusing on improved stream tagging and extension handling for network flow counts.

Changes
Stream Tagging Improvements:

Added a new stream name constant: CONTAINER_NETWORK_LOGS.
Updated logic to first attempt using the new stream name when obtaining the stream tag; falls back to the legacy RETINA_NETWORK_FLOW_LOGS if unavailable.
Extension Field Handling:

Extracts ingress_flow_count, egress_flow_count, and unknown_direction_flow_count from the extensions field and maps them to top-level fields: IngressFlowCount, EgressFlowCount, and UnknownDirectionFlowCount.
Removes these flow count fields from the extensions map when serializing to AdditionalFlowData, ensuring they're not duplicated.
new stream:
<img width="1355" height="727" alt="image" src="https://github.com/user-attachments/assets/2254df08-8922-4d36-a069-e5cf6c04bb13" />

old stream:
<img width="1904" height="538" alt="image" src="https://github.com/user-attachments/assets/572166cf-4ea7-4b42-b6bf-eea0f40a7080" />
