### PR TITLE
OTEL_METRICS_EXPORTER fix

### DIFF
--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -167,7 +167,7 @@ export class Mutations {
     /**
      * Generates environment variables necessary to configure agents. Agents take configuration from these environment variables once they run.
      */
-    public static GenerateEnvironmentVariables(podInfo: PodInfo, containerName: string, platforms: AutoInstrumentationPlatforms[], disableAppLogs: boolean, connectionString: string, armId: string, armRegion: string, clusterName: string, otelParams: OtelParams, existingEnvironmentVariables?: Record<string, IEnvironmentVariable>, isPythonEnabled?: boolean): IEnvironmentVariable[] {
+    public static GenerateEnvironmentVariables(podInfo: PodInfo, containerName: string, platforms: AutoInstrumentationPlatforms[], disableAppLogs: boolean, connectionString: string, armId: string, armRegion: string, clusterName: string, otelParams: OtelParams, existingEnvironmentVariables?: Record<string, IEnvironmentVariable>): IEnvironmentVariable[] {
         const applicationId = Mutations.parseApplicationIdFromConnectionString(connectionString);
         
         // Build our OTEL resource attributes
@@ -284,14 +284,11 @@ export class Mutations {
         }
 
         if (otelParams.metricsEnabled) {
-            // //!!! temporary special case: when Python is enabled (via private-preview annotation), set OTEL_METRICS_EXPORTER to "otlp" only
-            // Python distro can't handle azure_monitor currently
-            const metricsExporterValue = isPythonEnabled ? "otlp" : "otlp,azure_monitor";
             returnValue.push(
                 // setting this to ensure Microsoft distros do send OTLP metrics (forked, sent to Breeze and OTLP endpoint). For OSS SDKs this defaults to "otlp" anyway, so no impact
                 {
                     name: "OTEL_METRICS_EXPORTER",
-                    value: metricsExporterValue
+                    value: "otlp"
                 },
                 {
                     name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", //!!! http -> https
@@ -315,7 +312,7 @@ export class Mutations {
                     {
                         returnValue.push(...[{
                             name: "JAVA_TOOL_OPTIONS",
-                            value: `-javaagent:${Mutations.agentVolumeMountPathJava}/applicationinsights-agent-codeless.jar`,
+                            value: `-javaagent:${Mutations.agentVolumeMountPathJava}/applicationinsights-agent-codeless.jar -Dotel.metrics.exporter=otlp,azure_monitor`,
                             platformSpecific: platforms[i]
                         },
                         {

--- a/appmonitoring/ts/src/Patcher.ts
+++ b/appmonitoring/ts/src/Patcher.ts
@@ -51,9 +51,6 @@ export class Patcher {
             const enableApplicationLogsAnnotation = spec.template.metadata?.annotations?.[EnableApplicationLogsAnnotationName]; 
             const enableApplicationLogs: boolean = enableApplicationLogsAnnotation?.toLocaleLowerCase() === "true" || enableApplicationLogsAnnotation?.toLocaleLowerCase() === "1";
             
-            // determine if Python is enabled (Python can only be enabled via private-preview annotation)
-            const isPythonPrivatePreview: boolean = platforms.includes(AutoInstrumentationPlatforms.Python);
-            
             // add new volumes (used to store agent binaries)
             const newVolumes: IVolume[] = Mutations.GenerateVolumes(platforms);
             podSpec.volumes = (podSpec.volumes ?? <IVolume[]>[]).concat(newVolumes);
@@ -70,7 +67,7 @@ export class Patcher {
                 container.env?.forEach(env => allEnvironmentVariables[env.name] = env);
 
                 // Generate environment variables with knowledge of existing ones for OTEL_RESOURCE_ATTRIBUTES merging
-                const newEnvironmentVariables: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(podInfo, container.name, platforms, !enableApplicationLogs, cr.spec?.destination?.applicationInsightsConnectionString, armId, armRegion, clusterName, otelParams, allEnvironmentVariables, isPythonPrivatePreview);
+                const newEnvironmentVariables: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(podInfo, container.name, platforms, !enableApplicationLogs, cr.spec?.destination?.applicationInsightsConnectionString, armId, armRegion, clusterName, otelParams, allEnvironmentVariables);
 
                 /*
                     We could be receiving customer's original set of environment variables (e.g. in case of kubectl apply),
@@ -152,7 +149,7 @@ export class Patcher {
         // remove environment variables and volume mounts from all containers by name
         // we don't care about values of environment variables here, we just need all names, so set parameters to get all of them
         const otelParams: OtelParams = { logsEnabled: true, metricsEnabled: true, logsPortHttpProtobuf: 0, metricsPortHttpProtobuf: 0 };
-        const environmentVariablesToRemove: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(new PodInfo(), "dummy-container", allPlatforms, true, "", "", "", "", otelParams, undefined, false);
+        const environmentVariablesToRemove: IEnvironmentVariable[] = Mutations.GenerateEnvironmentVariables(new PodInfo(), "dummy-container", allPlatforms, true, "", "", "", "", otelParams);
         const volumeMountsToRemove: IVolumeMount[] = Mutations.GenerateVolumeMounts(allPlatforms);
 
         podSpec.containers?.forEach(container => {

--- a/appmonitoring/ts/src/tests/Mutations.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutations.spec.ts
@@ -34,8 +34,7 @@ describe("OTEL Resource Attributes Merging", () => {
             "eastus", 
             "test-cluster", 
             testOtelParams,
-            existingEnvironmentVariables,
-            false
+            existingEnvironmentVariables
         );
 
         const otelResourceAttributes = generatedEnvVars.find(env => env.name === "OTEL_RESOURCE_ATTRIBUTES");
@@ -319,7 +318,7 @@ describe("OTEL Metrics Exporter Environment Variable", () => {
 
         const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
         expect(otelMetricsExporter).toBeDefined();
-        expect(otelMetricsExporter!.value).toBe("otlp,azure_monitor");
+        expect(otelMetricsExporter!.value).toBe("otlp");
     });
 
     it("should not include OTEL_METRICS_EXPORTER when metrics are disabled", () => {
@@ -371,7 +370,7 @@ describe("OTEL Metrics Exporter Environment Variable", () => {
         // Should have OTEL_METRICS_EXPORTER
         const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
         expect(otelMetricsExporter).toBeDefined();
-        expect(otelMetricsExporter!.value).toBe("otlp,azure_monitor");
+        expect(otelMetricsExporter!.value).toBe("otlp");
 
         // Should also have other metrics-related variables
         const otelMetricsEndpoint = generatedEnvVars.find(env => env.name === "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
@@ -385,59 +384,5 @@ describe("OTEL Metrics Exporter Environment Variable", () => {
         const otelMetricsInsecure = generatedEnvVars.find(env => env.name === "OTEL_EXPORTER_OTLP_METRICS_INSECURE");
         expect(otelMetricsInsecure).toBeDefined();
         expect(otelMetricsInsecure!.value).toBe("true");
-    });
-
-    it("should set OTEL_METRICS_EXPORTER to 'otlp' only when Python is enabled", () => {
-        const testOtelParams: OtelParams = {
-            logsEnabled: false,
-            metricsEnabled: true,
-            logsPortHttpProtobuf: 4318,
-            metricsPortHttpProtobuf: 4319
-        };
-
-        const generatedEnvVars = Mutations.GenerateEnvironmentVariables(
-            podInfo,
-            "main-container",
-            [AutoInstrumentationPlatforms.Python],
-            false,
-            "InstrumentationKey=test-key",
-            "/subscriptions/test/resourceGroups/test-rg",
-            "eastus",
-            "test-cluster",
-            testOtelParams,
-            undefined,
-            true // isPythonEnabled = true
-        );
-
-        const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
-        expect(otelMetricsExporter).toBeDefined();
-        expect(otelMetricsExporter!.value).toBe("otlp");
-    });
-
-    it("should set OTEL_METRICS_EXPORTER to 'otlp,azure_monitor' when Python is not enabled", () => {
-        const testOtelParams: OtelParams = {
-            logsEnabled: false,
-            metricsEnabled: true,
-            logsPortHttpProtobuf: 4318,
-            metricsPortHttpProtobuf: 4319
-        };
-
-        const generatedEnvVars = Mutations.GenerateEnvironmentVariables(
-            podInfo,
-            "main-container",
-            [AutoInstrumentationPlatforms.Python],
-            false,
-            "InstrumentationKey=test-key",
-            "/subscriptions/test/resourceGroups/test-rg",
-            "eastus",
-            "test-cluster",
-            testOtelParams,
-            undefined,
-            false // isPythonEnabled = false
-        );
-
-        const otelMetricsExporter = generatedEnvVars.find(env => env.name === "OTEL_METRICS_EXPORTER");
-        expect(otelMetricsExporter).toBeDefined();
-        expect(otelMetricsExporter!.value).toBe("otlp,azure_monitor");
     });
 });

--- a/appmonitoring/ts/src/tests/Mutator.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutator.spec.ts
@@ -1252,7 +1252,7 @@ describe("Mutator", () => {
         // Verify OTEL_METRICS_EXPORTER is present and set to "otlp"
         const otelMetricsExporter = container.env.find(env => env.name === "OTEL_METRICS_EXPORTER");
         expect(otelMetricsExporter).toBeDefined();
-        expect(otelMetricsExporter.value).toBe("otlp,azure_monitor");
+        expect(otelMetricsExporter.value).toBe("otlp");
 
         // Verify logs-related OTEL environment variables are NOT present
         const otelTracesEndpoint = container.env.find(env => env.name === "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -68,8 +68,8 @@ describe("Patcher", () => {
         // Generate environment variables for each container with their actual names
         const container0Name = admissionReview.request.object.spec.template.spec.containers[0].name;
         const container1Name = admissionReview.request.object.spec.template.spec.containers[1].name;
-        const newEnvironmentVariablesContainer0: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container0Name, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, platforms.includes(AutoInstrumentationPlatforms.Python));
-        const newEnvironmentVariablesContainer1: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container1Name, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, platforms.includes(AutoInstrumentationPlatforms.Python));
+        const newEnvironmentVariablesContainer0: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container0Name, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
+        const newEnvironmentVariablesContainer1: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container1Name, platforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
         expect((<any>result[0]).value.spec.template.spec.containers.length).toBe(admissionReview.request.object.spec.template.spec.containers.length);
         newEnvironmentVariablesContainer0.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[0].env).toContainEqual(env));
         newEnvironmentVariablesContainer1.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(env));
@@ -132,8 +132,8 @@ describe("Patcher", () => {
         // Generate environment variables for each container with their actual names
         const container0Name = admissionReview.request.object.spec.template.spec.containers[0].name;
         const container1Name = admissionReview.request.object.spec.template.spec.containers[1].name;
-        const newEnvironmentVariablesContainer0: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container0Name, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, cr1.spec.settings.autoInstrumentationPlatforms.includes(AutoInstrumentationPlatforms.Python));
-        const newEnvironmentVariablesContainer1: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container1Name, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams, undefined, cr1.spec.settings.autoInstrumentationPlatforms.includes(AutoInstrumentationPlatforms.Python));
+        const newEnvironmentVariablesContainer0: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container0Name, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
+        const newEnvironmentVariablesContainer1: object[] = Mutations.GenerateEnvironmentVariables(podInfo, container1Name, cr1.spec.settings.autoInstrumentationPlatforms, true, cr1.spec.destination.applicationInsightsConnectionString, clusterArmId, clusterArmRegion, clusterName, testOtelParams);
         expect((<any>result[0]).value.spec.template.spec.containers.length).toBe(admissionReview.request.object.spec.template.spec.containers.length);
         newEnvironmentVariablesContainer0.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[0].env).toContainEqual(env));
         newEnvironmentVariablesContainer1.forEach(env => expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(env));
@@ -730,7 +730,7 @@ describe("Patcher", () => {
         expect(metricsEndpointEnv.value).toBe("http://$(OTEL_ENDPOINT_NODE_IP):4319/v1/metrics");
 
         const metricsExporterEnv = containerEnv.find((ev: IEnvironmentVariable) => ev.name === "OTEL_METRICS_EXPORTER");
-        expect(metricsExporterEnv.value).toBe("otlp,azure_monitor");
+        expect(metricsExporterEnv.value).toBe("otlp");
     });
 
     it("OTEL environment variables - includes only logs variables when only logsEnabled is true", async () => {
@@ -827,7 +827,7 @@ describe("Patcher", () => {
         expect(containerEnv.find((ev: IEnvironmentVariable) => ev.name === "OTEL_METRICS_EXPORTER")).toBeDefined();
 
         const metricsExporterEnv = containerEnv.find((ev: IEnvironmentVariable) => ev.name === "OTEL_METRICS_EXPORTER");
-        expect(metricsExporterEnv.value).toBe("otlp,azure_monitor");
+        expect(metricsExporterEnv.value).toBe("otlp");
     });
 
     it("OTEL environment variables - excludes all OTEL variables when both logsEnabled and metricsEnabled are false", async () => {


### PR DESCRIPTION
Change OTEL_METRICS_EXPORTER to contain "otlp" for all cases, and enhance Java auto-instrumentation with a System variable override to "otlp,azure_monitor".