### PR TITLE
add workload identity support

### DIFF
--- a/build/common/installer/scripts/tomlparser-geneva-config.rb
+++ b/build/common/installer/scripts/tomlparser-geneva-config.rb
@@ -215,6 +215,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
           puts "Using config map value: MONITORING_GCS_ACCOUNT=#{@geneva_account_name}"
           puts "Using config map value: MONITORING_GCS_REGION=#{@geneva_gcs_region}"
           puts "Using config map value: MONITORING_GCS_AUTH_ID=#{@geneva_gcs_authid}"
+          puts "Using config map value: MONITORING_GCS_AUTH_ID_TYPE=#{@geneva_gcs_authid_type}"
           if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
             puts "Using config map value: MONITORING_CONFIG_VERSION=#{@geneva_logs_config_version_windows}"
           else

--- a/build/common/installer/scripts/tomlparser-geneva-config.rb
+++ b/build/common/installer/scripts/tomlparser-geneva-config.rb
@@ -24,6 +24,7 @@ GENEVA_SUPPORTED_ENVIRONMENTS = ["Test", "Stage", "DiagnosticsProd", "Firstparty
 @infra_namespaces = ""
 @tenant_namespaces = ""
 @geneva_gcs_authid = ""
+@geneva_gcs_authid_type = ""
 @azure_json_path = "/etc/kubernetes/host/azure.json"
 @enable_fbit_threading = false
 # Checking to see if this is the daemonset or replicaset to parse config accordingly
@@ -138,6 +139,10 @@ def populateSettingValuesFromConfigMap(parsedConfig)
             geneva_logs_config_version_windows = parsedConfig[:integrations][:geneva_logs][:windowsconfigversion].to_s
             geneva_gcs_region = parsedConfig[:integrations][:geneva_logs][:region].to_s
             geneva_gcs_authid = parsedConfig[:integrations][:geneva_logs][:authid].to_s
+            geneva_gcs_authid_type = parsedConfig[:integrations][:geneva_logs][:authid_type].to_s
+            if geneva_gcs_authid_type.nil? || geneva_gcs_authid_type.empty? || !["AuthMSIToken", "AuthWorkloadIdentity"].include?(geneva_gcs_authid_type)
+                geneva_gcs_authid_type = "AuthMSIToken" # default to AuthMSIToken
+            end
             if geneva_gcs_authid.nil? || geneva_gcs_authid.empty?
               # extract authid from nodes config
               begin
@@ -159,13 +164,14 @@ def populateSettingValuesFromConfigMap(parsedConfig)
                 puts "failed to get user assigned client id with an error: #{errorStr}"
               end
             end
-            if isValidGenevaConfig(geneva_account_environment, geneva_account_namespace, geneva_account_namespace_windows, geneva_account_name, geneva_gcs_authid, geneva_gcs_region)
+            if isValidGenevaConfig(geneva_account_environment, geneva_account_namespace, geneva_account_namespace_windows, geneva_account_name, geneva_gcs_authid, geneva_gcs_authid_type, geneva_gcs_region)
               @geneva_account_environment = geneva_account_environment
               @geneva_account_namespace = geneva_account_namespace
               @geneva_account_namespace_windows = geneva_account_namespace_windows
               @geneva_account_name = geneva_account_name
               @geneva_gcs_region = geneva_gcs_region
               @geneva_gcs_authid = geneva_gcs_authid
+              @geneva_gcs_authid_type = geneva_gcs_authid_type
 
               if !geneva_logs_config_version.nil? && !geneva_logs_config_version.empty?
                 @geneva_logs_config_version = geneva_logs_config_version
@@ -230,7 +236,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
   end
 end
 
-def isValidGenevaConfig(environment, namespace, namespacewindows, account, authid, region)
+def isValidGenevaConfig(environment, namespace, namespacewindows, account, authid, authid_type, region)
   isValid = false
   begin
     if environment.nil? || environment.empty?
@@ -250,6 +256,10 @@ def isValidGenevaConfig(environment, namespace, namespacewindows, account, authi
 
     if authid.nil? || authid.empty?
       puts "config::geneva_logs::error:geneva GCS AuthID MUST be valid"
+      return isValid
+    end
+    if authid_type.nil? || authid_type.empty?
+      puts "config::geneva_logs::error:geneva GCS AuthID Type MUST be valid"
       return isValid
     end
     ## namespacewindows is optional hence we dont need this validation
@@ -322,7 +332,7 @@ if !file.nil?
         file.write("export MONITORING_GCS_REGION=#{@geneva_gcs_region}\n")
         file.write("export MONITORING_CONFIG_VERSION=#{@geneva_logs_config_version}\n")
         file.write("export MONITORING_GCS_AUTH_ID=#{@geneva_gcs_authid}\n")
-        file.write("export MONITORING_GCS_AUTH_ID_TYPE=AuthMSIToken")
+        file.write("export MONITORING_GCS_AUTH_ID_TYPE=#{@geneva_gcs_authid_type}\n")
       end
       file.write("export GENEVA_LOGS_INFRA_NAMESPACES=#{@infra_namespaces}\n")
       file.write("export GENEVA_LOGS_TENANT_NAMESPACES=#{@tenant_namespaces}\n")
@@ -368,7 +378,7 @@ if !@os_type.nil? && !@os_type.empty? && @os_type.strip.casecmp("windows") == 0
         file.write(commands)
         commands = get_command_windows("MONITORING_GCS_REGION", @geneva_gcs_region)
         file.write(commands)
-        commands = get_command_windows("MONITORING_GCS_AUTH_ID_TYPE", "AuthMSIToken")
+        commands = get_command_windows("MONITORING_GCS_AUTH_ID_TYPE", @geneva_gcs_authid_type)
         file.write(commands)
         #Windows AMA expects these and these are different from Linux AMA
         authIdParts = @geneva_gcs_authid.split("#", 2)


### PR DESCRIPTION
This PR adds the workload identity support for infrastructure logs path where the agent will be used to ingest the logs of infrastructure namespaces to Geneva logs account.

For onboarding workload identity, steps would be on Workload identity enabled clusters are 

1.  created federated identity credentials for ama-logs service account in kube-system namespace following aks public docs
2. as part of the configmap, provide the clientid and AuthWorkloadIdentity option which will be covered in the docs.
3. update this workload-identity-client-id with actual client-id of the user assigned identity and run this command
kubectl annotate sa ama-logs azure.workload.identity/client-id="workload-identity-client-id" -n kube-system
4. Add the workload identity label  on ds pods 
kubectl patch daemonset ama-logs -n kube-system \
  --type=merge \
  --patch '{"spec":{"template":{"metadata":{"labels":{"azure.workload.identity/use":"true"}}}}}'

Validation
1. Both Linux and Windows validated, but only Linux works since Windows AMA doesn't have workload identity support yet. 

Notes
1. Both of these changes annotation - azure.workload.identity/client-id and  azure.workload.identity/use not reconciled based on the testing. And also, these are retained during the cluster upgrade and addon rollouts (unless the service account and ds object manually re-created)

3. internal docs will be updated with instructions after this change rolled out.



