### PR TITLE
ignore error of implicit func declaration from cmetrics

### DIFF
--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -146,7 +146,7 @@ function Install-cmetrics() {
 	git submodule sync
 	git -c protocol.version=2 submodule update --init --force --depth=1
 	git submodule foreach git config --local gc.auto 0
-	cmake --fresh -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX="$destinationPath" .
+	cmake --fresh -G "MinGW Makefiles" -DCMAKE_C_FLAGS="-Wno-error=implicit-function-declaration" -DCMAKE_INSTALL_PREFIX="$destinationPath" .
 	make
 	make install
 }


### PR DESCRIPTION
1es image was upgraded that comes with gcc version upgrade from 12 to 14, causing cmetrics lib compile error. (check the error in #20251104.3 • Fix FIC Auth support issues (#1547)

before this error happens: Current image version: '20250929.55.1'
https://github.com/actions/runner-images/blob/win25/20250929.44/images/windows/Windows2022-Readme.md
it shows gcc 12.x


when this error: Current image version: '20251021.76.1' 
https://github.com/actions/runner-images/blob/win25/20251021.67/images/windows/Windows2022-Readme.md
it shows gcc 14.x


about gcc 14: https://gcc.gnu.org/gcc-14/porting_to.html

solution: Don't treat implicit function declarations as errors, just gives warning like what gcc 12 does.

**test #1**
 build: see #20251104.5 • no error for implicit func declaration in build pipeline.

**test #2**
 data: force resource opt and check contianerinventory data count. data size is doubled because ci windows agent now starts to inject container inventory due to resource opt is on, which verifies cmetrics works on windows node.

<img width="1348" height="818" alt="image" src="https://github.com/user-attachments/assets/946eb018-03fe-413e-992e-63a7ef9b60ab" />

 
 



