### PR TITLE
Fix arc prod pipeline timeout issue

### DIFF
--- a/.pipelines/ci-arc-k8s-extension-prod-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-prod-release.yaml
@@ -588,12 +588,12 @@ extends:
       jobs:
       - job: WaitJob
         displayName: Wait for Bake Time
-        timeoutInMinutes: 120
+        timeoutInMinutes: 1600
         pool: server
         steps:
         - task: Delay@1
           inputs:
-            delayForMinutes: 60
+            delayForMinutes: 1500
     - stage: Stage_3
       displayName: Light Load Region
       dependsOn:

--- a/.pipelines/ci-arc-k8s-extension-prod-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-prod-release.yaml
@@ -588,11 +588,12 @@ extends:
       jobs:
       - job: WaitJob
         displayName: Wait for Bake Time
+        timeoutInMinutes: 120
         pool: server
         steps:
         - task: Delay@1
           inputs:
-            delayForMinutes: 1500
+            delayForMinutes: 60
     - stage: Stage_3
       displayName: Light Load Region
       dependsOn:
@@ -864,6 +865,7 @@ extends:
       jobs:
       - job: WaitJob
         displayName: Wait for Bake Time
+        timeoutInMinutes: 1600
         pool: server
         steps:
         - task: Delay@1
@@ -1140,6 +1142,7 @@ extends:
       jobs:
       - job: WaitJob
         displayName: Wait for Bake Time
+        timeoutInMinutes: 1600
         pool: server
         steps:
         - task: Delay@1


### PR DESCRIPTION
This pull request makes a small configuration change to the CI pipeline for the production release of the Arc Kubernetes extension. The change increases the timeout for the "Wait for Bake Time" job, allowing the job to run for a longer period before timing out.

* Increased the `timeoutInMinutes` value to 1600 for the `WaitJob` ("Wait for Bake Time") in the `.pipelines/ci-arc-k8s-extension-prod-release.yaml` file, ensuring the job has sufficient time to complete. [[1]](diffhunk://#diff-317016d989ef1f7d2059372ba0594c47f224468fd5e6971d9c82d7246e2a3552R591) [[2]](diffhunk://#diff-317016d989ef1f7d2059372ba0594c47f224468fd5e6971d9c82d7246e2a3552R868) [[3]](diffhunk://#diff-317016d989ef1f7d2059372ba0594c47f224468fd5e6971d9c82d7246e2a3552R1145)