### PR TITLE
update dotnet8

### DIFF
--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -143,7 +143,6 @@ def substituteFluentBitPlaceHolders
     networkFlowLogsThrottleEnabled = ENV["NETWORKFLOW_LOGS_THROTTLE_ENABLED"]
     enableCustomMetrics = ENV["ENABLE_CUSTOM_METRICS"]
     windowsFluentBitEnabled = ENV["AZMON_WINDOWS_FLUENT_BIT_ENABLED"]
-    windowsFluentBitEnabled = "true"
     kubernetesMetadataCollection = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
     annotationBasedLogFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]
     storageMaxChunksUp = ENV["FBIT_STORAGE_MAX_CHUNKS_UP"]

--- a/build/common/installer/scripts/fluent-bit-conf-customizer.rb
+++ b/build/common/installer/scripts/fluent-bit-conf-customizer.rb
@@ -143,6 +143,7 @@ def substituteFluentBitPlaceHolders
     networkFlowLogsThrottleEnabled = ENV["NETWORKFLOW_LOGS_THROTTLE_ENABLED"]
     enableCustomMetrics = ENV["ENABLE_CUSTOM_METRICS"]
     windowsFluentBitEnabled = ENV["AZMON_WINDOWS_FLUENT_BIT_ENABLED"]
+    windowsFluentBitEnabled = "true"
     kubernetesMetadataCollection = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]
     annotationBasedLogFiltering = ENV["AZMON_ANNOTATION_BASED_LOG_FILTERING"]
     storageMaxChunksUp = ENV["FBIT_STORAGE_MAX_CHUNKS_UP"]

--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -80,7 +80,7 @@ Write-Host("Successfully added dotnet packages") -ForegroundColor Green
 dotnet build  -f $dotnetcoreframework
 Write-Host("Building Certificate generator code and ...") -ForegroundColor Green
 
-Write-Host("Publish release and win10-x64 binaries of certificate generator code  ...")
+Write-Host("Publish release and win-x64 binaries of certificate generator code  ...")
 $isCDPxEnvironment = $false
 if (![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable("IsCDPXBuildMachine", "PROCESS")) -or
 ![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable("IsCDPXBuildMachine", "USER")) -or
@@ -90,14 +90,14 @@ if (![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable("IsCDP
 }
 if ($isCDPxEnvironment) {
     Write-Host("running on CDPX build machine so setting --no-restore since there is no n/w connectivity during build")
-    dotnet publish -c Release -r win10-x64 --no-restore
+    dotnet publish -c Release -r win-x64 --no-restore
 } else {
-  dotnet publish -c Release -r win10-x64
+  dotnet publish -c Release -r win-x64
 }
 
 Write-Host("Successfully published certificate generator code binaries") -ForegroundColor Green
 
-$certreleasebinpath =  Join-Path -PATH $certsrcdir -ChildPath "bin\Release\$dotnetcoreframework\win10-x64\publish\*.*"
+$certreleasebinpath =  Join-Path -PATH $certsrcdir -ChildPath "bin\Release\$dotnetcoreframework\win-x64\publish\*.*"
 if ($false -eq (Test-Path -Path $certreleasebinpath)) {
     Write-Host("certificate release bin path doesnt exist : " + $certreleasebinpath + " ") -ForegroundColor Red
     exit 1

--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -5,7 +5,7 @@
 #  3. copy the files under installer directory to ..\..\kubernetes\windows\amalogswindows
 #  4. Builds the livenessprobe cpp and copy the executable to the under directory ..\..\kubernetes\windows\amalogswindows
 
-$dotnetcoreframework = "net6.0"
+$dotnetcoreframework = "net8.0"
 
 Write-Host("Building Certificate generator code...")
 $currentdir =  $PSScriptRoot

--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -90,9 +90,9 @@ if (![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable("IsCDP
 }
 if ($isCDPxEnvironment) {
     Write-Host("running on CDPX build machine so setting --no-restore since there is no n/w connectivity during build")
-    dotnet publish -c Release -r win-x64 --no-restore
+    dotnet publish -c Release -r win-x64 --self-contained true --no-restore
 } else {
-  dotnet publish -c Release -r win-x64
+  dotnet publish -c Release -r win-x64 --self-contained true
 }
 
 Write-Host("Successfully published certificate generator code binaries") -ForegroundColor Green

--- a/build/windows/installer/certificategenerator/CertificateGenerator.csproj
+++ b/build/windows/installer/certificategenerator/CertificateGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -93,17 +93,17 @@ function Install-DotNetCoreSDK() {
         exit 1
     }
 
-   $url = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.exe"
-   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-8.0.415-win-x64.exe"
+   $url = "https://download.visualstudio.microsoft.com/download/pr/4e88f517-196e-4b17-a40c-2692c689661d/eed3f5fca28262f764d8b650585a7278/dotnet-sdk-3.1.301-win-x64.exe"
+   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-3.1.301-win-x64.exe"
 
-   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + "  ...")
+   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + "  ...")
    Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop
-   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + " completed")
+   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + " completed")
 
-   # install dotNet sdk
-   Write-Host("installing .NET 8 SDK ...")
+   # install dotNet core sdk
+   Write-Host("installing .net core sdk 3.1 ...")
    Start-Process -Wait $output -ArgumentList " /q /norestart"
-   Write-Host("installing .NET 8 SDK completed")
+   Write-Host("installing .net core sdk 3.1 completed")
 }
 
 function Install-Docker() {
@@ -160,7 +160,7 @@ Install-Go
 Write-Host "Install Build dependencies"
 Build-Dependencies
 
-Write-Host "Install .NET 8 SDK"
+Write-Host "Install .NET core sdk 3.1"
 Install-DotNetCoreSDK
 
 Write-Host "Install Docker"

--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -93,17 +93,17 @@ function Install-DotNetCoreSDK() {
         exit 1
     }
 
-   $url = "https://download.visualstudio.microsoft.com/download/pr/4e88f517-196e-4b17-a40c-2692c689661d/eed3f5fca28262f764d8b650585a7278/dotnet-sdk-3.1.301-win-x64.exe"
-   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-3.1.301-win-x64.exe"
+   $url = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.exe"
+   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-8.0.415-win-x64.exe"
 
-   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + "  ...")
+   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + "  ...")
    Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop
-   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + " completed")
+   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + " completed")
 
-   # install dotNet core sdk
-   Write-Host("installing .net core sdk 3.1 ...")
+   # install dotNet sdk
+   Write-Host("installing .NET 8 SDK ...")
    Start-Process -Wait $output -ArgumentList " /q /norestart"
-   Write-Host("installing .net core sdk 3.1 completed")
+   Write-Host("installing .NET 8 SDK completed")
 }
 
 function Install-Docker() {
@@ -160,7 +160,7 @@ Install-Go
 Write-Host "Install Build dependencies"
 Build-Dependencies
 
-Write-Host "Install .NET core sdk 3.1"
+Write-Host "Install .NET 8 SDK"
 Install-DotNetCoreSDK
 
 Write-Host "Install Docker"

--- a/scripts/build/windows/install-build-pre-requisites.ps1
+++ b/scripts/build/windows/install-build-pre-requisites.ps1
@@ -93,17 +93,17 @@ function Install-DotNetCoreSDK() {
         exit 1
     }
 
-   $url = "https://download.visualstudio.microsoft.com/download/pr/4e88f517-196e-4b17-a40c-2692c689661d/eed3f5fca28262f764d8b650585a7278/dotnet-sdk-3.1.301-win-x64.exe"
-   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-3.1.301-win-x64.exe"
+   $url = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.exe"
+   $output = Join-Path -Path $dotNetSdkTemp -ChildPath "dotnet-sdk-8.0.415-win-x64.exe"
 
-   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + "  ...")
+   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + "  ...")
    Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop
-   Write-Host("downloading .net core sdk 3.1: " + $dotNetSdkTemp + " completed")
+   Write-Host("downloading .NET 8 SDK: " + $dotNetSdkTemp + " completed")
 
-   # install dotNet core sdk
-   Write-Host("installing .net core sdk 3.1 ...")
+   # install dotNet sdk
+   Write-Host("installing .NET 8 SDK ...")
    Start-Process -Wait $output -ArgumentList " /q /norestart"
-   Write-Host("installing .net core sdk 3.1 completed")
+   Write-Host("installing .NET 8 SDK completed")
 }
 
 function Install-Docker() {
@@ -160,7 +160,7 @@ Install-Go
 Write-Host "Install Build dependencies"
 Build-Dependencies
 
-Write-Host "Install .NET core sdk 3.1"
+Write-Host "Install .NET core sdk 8.0"
 Install-DotNetCoreSDK
 
 Write-Host "Install Docker"


### PR DESCRIPTION
## description

### why?
dotnet 6 has security risk and is no longer supported by MSFT.

### why use win-64 instead of win10-64?
win10-64 no longer a valid release platform. 

### why self-contained?
better practice since it copies all necessary runtime lib into container. Actually we have self-contained in dotnet6 too (we just did not need specify it for dotnet6.)



## tests

### build succeed, cert is generated, and fluentd start up running successfully. see log below

`Starting Windows in Cert Auth Mode
Generating Certificates
Dotnet executable starting :
Writing certificate and key to two files
Successfully created self-signed certificate  for agentGuid : {723d2c59-a6d6-445c-9f2c-1dc733c22065} and workspace: 72a09362-2b7a-4367-9642-e60c645bb105
OMS endpoint Url : https://72a09362-2b7a-4367-9642-e60c645bb105.oms.opinsights.azure.com/AgentService.svc/AgentTopologyRequest
`

`
Certificate file found at C://oms.crt
Key file found at C://oms.key
`

`
Running  fluentdwinaks      Fluentd Windows Service
`

`
-a----         11/6/2025  12:11 AM           1362 oms.crt
-a----         11/6/2025  12:11 AM           1702 oms.key
`

### data ingestion
deployment happens around 12:10 am. blue line uses 3.1.31, and red line uses test image with dotnet8. it can be seen log continue injecting into la without loss.
<img width="1346" height="797" alt="image" src="https://github.com/user-attachments/assets/a0363ba2-13bd-4e88-9c28-4bb3e4b9b8f2" />
