### PR TITLE
Refactor validation script for ai_prod commit tagging checks

### DIFF
--- a/.pipelines/azure_pipeline_validation_appmonitoring.yaml
+++ b/.pipelines/azure_pipeline_validation_appmonitoring.yaml
@@ -96,7 +96,7 @@ jobs:
     imageTag: $[ dependencies.common.outputs['setup.imageTag'] ]
     testImageTagSuffix: $(imageTag)-$(Build.BuildId)
     testImageName: ${{ variables.repoTestImageName }}:${{ variables.testImageTagSuffix }}
-    fullImageName: ${{ variables.repoImageName }}:$(imageTag)-rc-$(Build.BuildId)
+    fullImageName: ${{ variables.repoImageName }}:$(imageTag)-rc.$(Build.BuildId)
     # This is necessary because of: https://github.com/moby/moby/issues/37965
     DOCKER_BUILDKIT: 1
 

--- a/.pipelines/azure_pipeline_validation_appmonitoring_extension.yaml
+++ b/.pipelines/azure_pipeline_validation_appmonitoring_extension.yaml
@@ -469,23 +469,23 @@ jobs:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        # # Check if current commit is tagged and branch is ai_prod
-        # CURRENT_BRANCH="$BUILD_SOURCEBRANCHNAME"
-        # echo "Current branch is: $CURRENT_BRANCH"
-        # if git describe --exact-match --tags >/dev/null 2>&1 && [ "$CURRENT_BRANCH" = "ai_prod" ]; then
-        #   echo "Current commit is tagged with: $(git describe --exact-match --tags) and branch is ai_prod."
-        # else
-        #   if [ "$CURRENT_BRANCH" != "ai_prod" ]; then
-        #     echo "Current branch is not ai_prod. Cannot publish from another branch"
-        #     echo "##vso[task.logissue type=warning]Current branch is not ai_prod. YOU CANNOT RELEASE WITH THIS BUILD."
-        #     echo "##vso[task.complete result=SucceededWithIssues;]Cannot Publish with a branch other than ai_prod. Exiting...."
-        #   else
-        #     echo "Current commit is not tagged."
-        #     echo "##vso[task.logissue type=warning]Current commit is not tagged. YOU CANNOT RELEASE WITH THIS BUILD and we also cannot publish images without a tagged commit on ai_prod. Please tag this commit with the appropriate semver value and format."
-        #     echo "##vso[task.complete result=SucceededWithIssues;]Cannot Publish with Untagged Commits. Exiting...."
-        #   fi
-        #   exit 0
-        # fi
+        # Check if current commit is tagged and branch is ai_prod
+        CURRENT_BRANCH="$BUILD_SOURCEBRANCHNAME"
+        echo "Current branch is: $CURRENT_BRANCH"
+        if git describe --exact-match --tags >/dev/null 2>&1 && [ "$CURRENT_BRANCH" = "ai_prod" ]; then
+          echo "Current commit is tagged with: $(git describe --exact-match --tags) and branch is ai_prod."
+        else
+          if [ "$CURRENT_BRANCH" != "ai_prod" ]; then
+            echo "Current branch is not ai_prod. Cannot publish from another branch"
+            echo "##vso[task.logissue type=warning]Current branch is not ai_prod. YOU CANNOT RELEASE WITH THIS BUILD."
+            echo "##vso[task.complete result=SucceededWithIssues;]Cannot Publish with a branch other than ai_prod. Exiting...."
+          else
+            echo "Current commit is not tagged."
+            echo "##vso[task.logissue type=warning]Current commit is not tagged. YOU CANNOT RELEASE WITH THIS BUILD and we also cannot publish images without a tagged commit on ai_prod. Please tag this commit with the appropriate semver value and format."
+            echo "##vso[task.complete result=SucceededWithIssues;]Cannot Publish with Untagged Commits. Exiting...."
+          fi
+          exit 0
+        fi
 
         az --version
         az account show


### PR DESCRIPTION
Enhance the validation script to ensure that only tagged commits on the ai_prod branch can be published, improving release management.