### PR TITLE
3.1.31 CVEs fixes

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -62,7 +62,7 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.36.4/azl3/x86_64/telegraf-agent-1.36.4-1.azl3.x86_64.rpm -y
+sudo tdnf install telegraf-agent-1.36.4 -y
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -62,7 +62,7 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install telegraf-agent-1.36.1 -y
+sudo tdnf install -y https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.36.3/azl3/x86_64/telegraf-agent-1.36.3-1.azl3.x86_64.rpm
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -62,7 +62,7 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install telegraf-agent-1.36.3 -y
+sudo tdnf install https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.36.4/azl3/x86_64/telegraf-agent-1.36.4-1.azl3.x86_64.rpm -y
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -62,7 +62,7 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install -y https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.36.3/azl3/x86_64/telegraf-agent-1.36.3-1.azl3.x86_64.rpm
+sudo tdnf install telegraf-agent-1.36.3 -y
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/source/plugins/go/input/go.mod
+++ b/source/plugins/go/input/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/input
 
-go 1.24.6
+go 1.24.10
 
 require github.com/calyptia/plugin v1.0.2
 

--- a/source/plugins/go/src/go.mod
+++ b/source/plugins/go/src/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/src
 
-go 1.24.6
+go 1.24.10
 
 require (
 	github.com/Microsoft/go-winio v0.6.1

--- a/test/ginkgo-e2e/utils/constants.go
+++ b/test/ginkgo-e2e/utils/constants.go
@@ -13,6 +13,7 @@ var (
 		"internet connectivity",
 		"GetAgentConfigurations",
 		"RefreshConfigurations",
+		"canceled by user",
 	}
 )
 


### PR DESCRIPTION
### Comet scan 
For windows:
<img width="1660" height="1166" alt="image" src="https://github.com/user-attachments/assets/29cabb15-91bb-40f6-9bfc-3771e417fe22" />

For Linux:
<img width="1667" height="527" alt="image" src="https://github.com/user-attachments/assets/0f4a1df5-2b6c-4b63-8dc1-9bcf9decd392" />

### Data validation
Before (with 3.1.31):
<img width="1038" height="781" alt="image" src="https://github.com/user-attachments/assets/a54de12e-83a1-4c90-962e-e9a2436f2748" />

After (with test image):
<img width="1014" height="1344" alt="image" src="https://github.com/user-attachments/assets/b17d25bf-9646-4e57-8d7d-4dad2fc8115f" />
