### PR TITLE
Setting APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED for Java to send to Breeze

### DIFF
--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -225,6 +225,10 @@ export class Mutations {
             {
                 name: "APPLICATIONINSIGHTS_CONNECTION_STRING",
                 value: connectionString
+            },
+            {
+                name: "APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED",
+                value: "true"
             },           
         ];
 
@@ -312,7 +316,7 @@ export class Mutations {
                     {
                         returnValue.push(...[{
                             name: "JAVA_TOOL_OPTIONS",
-                            value: `-javaagent:${Mutations.agentVolumeMountPathJava}/applicationinsights-agent-codeless.jar -Dotel.metrics.exporter=otlp,azure_monitor`,
+                            value: `-javaagent:${Mutations.agentVolumeMountPathJava}/applicationinsights-agent-codeless.jar`,
                             platformSpecific: platforms[i]
                         },
                         {

--- a/appmonitoring/ts/src/tests/Mutator.spec.ts
+++ b/appmonitoring/ts/src/tests/Mutator.spec.ts
@@ -746,6 +746,9 @@ describe("Mutator", () => {
         const connectionStringEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_CONNECTION_STRING");
         expect(connectionStringEnv.value).toBe("InstrumentationKey=cr1");
 
+        const metricsToLAEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED");
+        expect(metricsToLAEnv.value).toBe("true");
+
         const nodeIpEnv = container.env.find(env => env.name === "OTEL_ENDPOINT_NODE_IP");
         expect(nodeIpEnv.valueFrom.fieldRef.fieldPath).toBe("status.hostIP");
         
@@ -858,6 +861,9 @@ describe("Mutator", () => {
         const connectionStringEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_CONNECTION_STRING");
         expect(connectionStringEnv.value).toBe("InstrumentationKey=default");
         
+        const metricsToLAEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED");
+        expect(metricsToLAEnv.value).toBe("true");
+        
         // Verify node IP environment variable for OTEL endpoint
         const nodeIpEnv = container.env.find(env => env.name === "OTEL_ENDPOINT_NODE_IP");
         expect(nodeIpEnv.valueFrom.fieldRef.fieldPath).toBe("status.hostIP");
@@ -954,6 +960,9 @@ describe("Mutator", () => {
             
             const connectionStringEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_CONNECTION_STRING");
             expect(connectionStringEnv).toBeUndefined();
+            
+            const metricsToLAEnv = container.env.find(env => env.name === "APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED");
+            expect(metricsToLAEnv).toBeUndefined();
             
             const nodeIpEnv = container.env.find(env => env.name === "OTEL_ENDPOINT_NODE_IP");
             expect(nodeIpEnv).toBeUndefined();

--- a/appmonitoring/ts/src/tests/Patcher.spec.ts
+++ b/appmonitoring/ts/src/tests/Patcher.spec.ts
@@ -143,6 +143,7 @@ describe("Patcher", () => {
         (<any>result[0]).value.spec.template.spec.containers[1].env.forEach(env => expect(env.isPlatformSpecific).not.toBe(true));
         expect((<any>result[0]).value.spec.template.spec.containers[0].env).toContainEqual(<IEnvironmentVariable>{ name: "OTEL_RESOURCE_ATTRIBUTES", value: "cloud.resource_id=/subscriptions/66010356-d8a5-42d3-8593-6aaa3aeb1c11/resourceGroups/rambhatt-rnd-v2/providers/Microsoft.ContainerService/managedClusters/aks-rambhatt-test,cloud.region=eastus,k8s.cluster.name=aks-rambhatt-test,k8s.namespace.name=$(POD_NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),k8s.container.name=" + container0Name + ",cloud.provider=Azure,cloud.platform=azure_aks,k8s.deployment.name=deployment1,k8s.deployment.uid=ownerUid,service.name=deployment1,service.instance.id=$(POD_NAME)" });
         expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(<IEnvironmentVariable>{ name: "APPLICATIONINSIGHTS_CONNECTION_STRING", value: cr1.spec.destination.applicationInsightsConnectionString });
+        expect((<any>result[0]).value.spec.template.spec.containers[1].env).toContainEqual(<IEnvironmentVariable>{ name: "APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED", value: "true" });
 
 
         const newVolumeMounts: object[] = Mutations.GenerateVolumeMounts(cr1.spec.settings.autoInstrumentationPlatforms);

--- a/appmonitoring/validation-helm/test-apps/java/pom.xml
+++ b/appmonitoring/validation-helm/test-apps/java/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.12.5</version>
@@ -44,7 +44,7 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>1.12.5</version>
-        </dependency>
+        </dependency> -->
         <!-- OpenTelemetry API -->
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
Moving to setting APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED=true for Java to work instead of -Dotel.metrics.exporter=otlp,azure_monitor