### PR TITLE
fix k8s events DCR filter bug

### DIFF
--- a/source/plugins/ruby/in_kube_events.rb
+++ b/source/plugins/ruby/in_kube_events.rb
@@ -188,11 +188,12 @@ module Fluent::Plugin
           end
 
           # drop the events if the event of the excluded namespace
-          next unless !KubernetesApiClient.isExcludeResourceItem("", items["involvedObject"]["namespace"], @namespaceFilteringMode, @namespaces)
+          involvedObjectName = items["involvedObject"]["name"]
+          next unless !KubernetesApiClient.isExcludeResourceItem(involvedObjectName, items["involvedObject"]["namespace"], @namespaceFilteringMode, @namespaces)
 
           record["ObjectKind"] = items["involvedObject"]["kind"]
           record["Namespace"] = items["involvedObject"]["namespace"]
-          record["Name"] = items["involvedObject"]["name"]
+          record["Name"] = involvedObjectName
           record["Reason"] = items["reason"]
           record["Message"] = items["message"]
           record["KubeEventType"] = items["type"]


### PR DESCRIPTION
This pull request updates the event filtering logic in the `in_kube_events.rb` plugin to improve how Kubernetes events are processed. The main change is to pass the involved object's name to the exclusion filter, which enables more precise filtering of events by resource name in addition to namespace.

**Event filtering improvements:**

* The `parse_and_emit_records` method now passes the involved object's name (`involvedObjectName`) as a parameter to `KubernetesApiClient.isExcludeResourceItem`, allowing exclusion checks to consider both the resource name and namespace.
* The object's name is now assigned to a variable and reused for both filtering and record population, simplifying the code.