### PR TITLE
Fix testkube mongodb issue

### DIFF
--- a/test/testkube/helm-testkube-values.yaml
+++ b/test/testkube/helm-testkube-values.yaml
@@ -110,11 +110,11 @@ mongodb:
   # Currently Bitnami doesn't support ARM: https://github.com/bitnami/charts/issues/7305
   image:
     # -- MongoDB image registry
-    registry: mcr.microsoft.com
+    registry: docker.io
     # -- MongoDB image repository
-    repository: azuremonitor/containerinsights/cidev
+    repository: bitnami/mongodb
     # -- MongoDB image tag
-    tag: mongodb_6.0.5-debian-11-r64
+    tag: latest
     # -- MongoDB image pull Secret
     pullSecrets: []
   nodeSelector: 

--- a/test/testkube/install-and-execute-testkube-tests.sh
+++ b/test/testkube/install-and-execute-testkube-tests.sh
@@ -24,6 +24,19 @@ echo "deb https://repo.testkube.io/linux linux main" | sudo tee -a /etc/apt/sour
 sudo apt-get update
 sudo apt-get install -y testkube
 
+echo "Checking for existing Testkube installation..."    
+if helm list -n testkube 2>/dev/null | grep -q testkube; then
+    echo "Found existing Testkube installation. Cleaning up..."
+    helm uninstall testkube -n testkube || true
+    echo "Deleting testkube namespace..."
+    kubectl delete namespace testkube --wait=true --timeout=120s || true
+    echo "Waiting for namespace to fully terminate..."
+    sleep 30
+    echo "Cleanup complete!"
+else
+    echo "No existing Testkube installation found."
+fi
+
 echo "Install testkube on the cluster"
 helm repo add kubeshop https://kubeshop.github.io/helm-charts
 helm repo update

--- a/test/testkube/install-and-execute-testkube-tests.sh
+++ b/test/testkube/install-and-execute-testkube-tests.sh
@@ -52,7 +52,7 @@ envsubst < ./testkube-test-crs.yaml > ./testkube-test-crs-updated.yaml
 kubectl apply -f ./testkube-test-crs-updated.yaml
 
 echo "Wait for cluster to be ready"
-sleep 120
+sleep 200
 
 echo "Run testkube tests"
 execution_id=""


### PR DESCRIPTION
This pull request updates the Testkube installation and testing scripts to improve reliability and ensure a clean test environment. The most important changes include switching the MongoDB Helm chart image to Bitnami, adding a cleanup step for existing Testkube installations, and increasing the wait time before running tests.

**Helm Chart Image Update:**

* Changed the MongoDB Helm chart image source from Azure Monitor to Bitnami, updating the registry to `docker.io`, repository to `bitnami/mongodb`, and tag to `latest` in `helm-testkube-values.yaml`.

**Testkube Installation Script Improvements:**

* Added logic to detect and clean up any existing Testkube installation by uninstalling the Helm release and deleting the namespace before proceeding with a new install in `install-and-execute-testkube-tests.sh`.

**Test Execution Reliability:**

* Increased the wait time after applying the test CRs from 120 seconds to 200 seconds to allow the cluster more time to become ready before running tests in `install-and-execute-testkube-tests.sh`.