### PR TITLE
Zane/fluentdissue

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -79,12 +79,16 @@ echo "$(fluent-bit --version)" >> packages_version.txt
 # install fluentd
 fluentd_version="1.16.3"
 
-# Pre-install cool.io to avoid ARM64 build issues (segfault during native extension compilation)
 if [ "$ARCH" == "arm64" ]; then
-    gem install cool.io -v "1.8.0" --no-document
+    # Pre-install a fixed version of cool.io to avoid ARM64 build issues.
+    # when upgrading fluentd in the future, check cool.io compatibility first.
+    # https://rubygems.org/gems/fluentd
+    gem install cool.io -v "1.9.0" --no-document
+    gem install fluentd -v $fluentd_version --no-document
+else
+    gem install fluentd -v $fluentd_version --no-document
 fi
 
-gem install fluentd -v $fluentd_version --no-document
 
 # remove the test directory from fluentd
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/fluentd-$fluentd_version/test/

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -80,9 +80,10 @@ echo "$(fluent-bit --version)" >> packages_version.txt
 fluentd_version="1.16.3"
 
 if [ "$ARCH" == "arm64" ]; then
-    # Pre-install a fixed version of cool.io to avoid ARM64 build issues.
+    # Pre-install a fixed version of cool.io to avoid ARM64 build issues. cool.io 1.9.1 has high failure rate.
     # when upgrading fluentd in the future, check cool.io compatibility first.
     # https://rubygems.org/gems/fluentd
+    # long-term solution: consider building arm version on arm host, currently qemu is used on amd64 host.
     gem install cool.io -v "1.8.0" --no-document
     gem install fluentd -v $fluentd_version --no-document
 else

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -78,6 +78,12 @@ echo "$(fluent-bit --version)" >> packages_version.txt
 
 # install fluentd
 fluentd_version="1.16.3"
+
+# Pre-install cool.io to avoid ARM64 build issues (segfault during native extension compilation)
+if [ "$ARCH" == "arm64" ]; then
+    gem install cool.io -v "1.8.0" --no-document
+fi
+
 gem install fluentd -v $fluentd_version --no-document
 
 # remove the test directory from fluentd

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -83,7 +83,7 @@ if [ "$ARCH" == "arm64" ]; then
     # Pre-install a fixed version of cool.io to avoid ARM64 build issues.
     # when upgrading fluentd in the future, check cool.io compatibility first.
     # https://rubygems.org/gems/fluentd
-    gem install cool.io -v "1.9.0" --no-document
+    gem install cool.io -v "1.8.0" --no-document
     gem install fluentd -v $fluentd_version --no-document
 else
     gem install fluentd -v $fluentd_version --no-document

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -84,7 +84,7 @@ if [ "$ARCH" == "arm64" ]; then
     # when upgrading fluentd in the future, check cool.io compatibility first.
     # https://rubygems.org/gems/fluentd
     # long-term solution: consider building arm version on arm host, currently qemu is used on amd64 host.
-    gem install cool.io -v "1.8.0" --no-document
+    gem install cool.io -v "1.9.0" --no-document # use 1.9.0 which is used in 3.1.32, 3.1.31, etc.
     gem install fluentd -v $fluentd_version --no-document
 else
     gem install fluentd -v $fluentd_version --no-document


### PR DESCRIPTION
cool.io is a dependency of fluentd, the cool.io 1.9.1 has high failure rate on arm64 when compiling it on amd64 using qemu simulator. 

sol: pin cool.io  to 1.8.0 that passed build successfully. note any cool.io version in below range works for fluentd 1.16 .3.

[cool.io](https://rubygems.org/gems/cool.io) >= 1.4.5, < 2.0.0

long-term solution: consider build arm version on arm64 host instead of using qemu on amd host.