### PR TITLE
bug fix

### DIFF
--- a/source/plugins/ruby/in_kube_podinventory.rb
+++ b/source/plugins/ruby/in_kube_podinventory.rb
@@ -408,7 +408,7 @@ module Fluent::Plugin
         if continuationToken.nil? # sending kube services inventory records
           kubeServicesEventStream = Fluent::MultiEventStream.new
           serviceRecords.each do |kubeServiceRecord|
-            next unless !KubernetesApiClient.isExcludeResourceItem(kubeServiceRecord["ServiceName"], kubeServiceRecord["namespace"], @namespaceFilteringMode, @namespaces)
+            next unless !KubernetesApiClient.isExcludeResourceItem(kubeServiceRecord["ServiceName"], kubeServiceRecord["Namespace"], @namespaceFilteringMode, @namespaces)
             if !kubeServiceRecord.nil?
               # adding before emit to reduce memory foot print
               kubeServiceRecord["ClusterId"] = KubernetesApiClient.getClusterId


### PR DESCRIPTION
This pull request makes a minor fix to the service records filtering logic in the `in_kube_podinventory` plugin. The change ensures that the correct key is used when checking whether to exclude a Kubernetes service record.

* Updated the call to `KubernetesApiClient.isExcludeResourceItem` to use the `Namespace` key instead of `namespace` when filtering service records in `in_kube_podinventory.rb`.

Fix has been verified.  DCR with include and "kube-system" namespace . 

<img width="3340" height="1159" alt="image" src="https://github.com/user-attachments/assets/87e99a48-6d30-4992-bbf4-75389e21c187" />



