### PR TITLE
Non-root user in initcontainer

### DIFF
--- a/.pipelines/azure_pipeline_validation_appmonitoring.yaml
+++ b/.pipelines/azure_pipeline_validation_appmonitoring.yaml
@@ -108,7 +108,7 @@ stages:
 
     - task: PublishBuildArtifacts@1
       condition: and(succeeded(), eq(variables['IS_PR'], 'False'))
-      displayName: "Publish artifacts for PR"
+      displayName: "Publish artifacts"
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)'
         artifactName: drop

--- a/.pipelines/azure_pipeline_validation_appmonitoring_extension.yaml
+++ b/.pipelines/azure_pipeline_validation_appmonitoring_extension.yaml
@@ -80,7 +80,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     condition: and(succeeded(), eq(variables['IS_PR'], 'False'))
-    displayName: "Publish artifacts for PR"
+    displayName: "Publish artifacts"
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: drop

--- a/appmonitoring/ts/src/Mutations.ts
+++ b/appmonitoring/ts/src/Mutations.ts
@@ -68,12 +68,16 @@ export class Mutations {
                     containers.push({
                         name: Mutations.initContainerNameJava,
                         image: Mutations.GenerateImagePath(platforms[i], imageRepoPath),
-                        command: ["cp"],
-                        args: ["-r", Mutations.imagePathJava, Mutations.agentVolumeMountPathJava], // cp -r <source> <destination> 
+                        command: ["/bin/sh"],
+                        args: Mutations.generateInitContainerArgs(Mutations.imagePathJava, Mutations.agentVolumeMountPathJava),
                         volumeMounts: [{
                             name: Mutations.agentVolumeJava,
                             mountPath: Mutations.agentVolumeMountPathJava
                         }],
+                        securityContext: {
+                            runAsUser: 1000,
+                            runAsNonRoot: true
+                        },
                         resources: {
                             requests: {
                                 cpu: "100m",
@@ -91,12 +95,16 @@ export class Mutations {
                     containers.push({
                         name: Mutations.initContainerNameNodeJs,
                         image: Mutations.GenerateImagePath(platforms[i], imageRepoPath),
-                        command: ["cp"],
-                        args: ["-r", Mutations.imagePathNodeJs, Mutations.agentVolumeMountPathNodeJs], // cp -r <source> <destination>
+                        command: ["/bin/sh"],
+                        args: Mutations.generateInitContainerArgs(Mutations.imagePathNodeJs, Mutations.agentVolumeMountPathNodeJs),
                         volumeMounts: [{
                             name: Mutations.agentVolumeNodeJs,
                             mountPath: Mutations.agentVolumeMountPathNodeJs
                         }],
+                        securityContext: {
+                            runAsUser: 1000,
+                            runAsNonRoot: true
+                        },
                         resources: {
                             requests: {
                                 cpu: "100m",
@@ -114,12 +122,16 @@ export class Mutations {
                     containers.push({
                         name: Mutations.initContainerNamePython,
                         image: Mutations.GenerateImagePath(platforms[i], imageRepoPath),
-                        command: ["cp"],
-                        args: ["-r", Mutations.imagePathPython, Mutations.agentVolumeMountPathPython], // cp -r <source> <destination>
+                        command: ["/bin/sh"],
+                        args: Mutations.generateInitContainerArgs(Mutations.imagePathPython, Mutations.agentVolumeMountPathPython),
                         volumeMounts: [{
                             name: Mutations.agentVolumePython,
                             mountPath: Mutations.agentVolumeMountPathPython
                         }],
+                        securityContext: {
+                            runAsUser: 1000,
+                            runAsNonRoot: true
+                        },
                         resources: {
                             requests: {
                                 cpu: "100m",
@@ -137,12 +149,16 @@ export class Mutations {
                     containers.push({
                         name: Mutations.initContainerNameDotNet,
                         image: Mutations.GenerateImagePath(platforms[i], imageRepoPath),
-                        command: ["cp"],
-                        args: ["-r", Mutations.imagePathDotNet, Mutations.agentVolumeMountPathDotNet], // cp -r <source> <destination>
+                        command: ["/bin/sh"],
+                        args: Mutations.generateInitContainerArgs(Mutations.imagePathDotNet, Mutations.agentVolumeMountPathDotNet),
                         volumeMounts: [{
                             name: Mutations.agentVolumeDotNet,
                             mountPath: Mutations.agentVolumeMountPathDotNet
                         }],
+                        securityContext: {
+                            runAsUser: 1000,
+                            runAsNonRoot: true
+                        },
                         resources: {
                             requests: {
                                 cpu: "100m",
@@ -489,6 +505,7 @@ export class Mutations {
     public static GenerateVolumes(platforms: AutoInstrumentationPlatforms[]) : IVolume[] {
         const volumes: IVolume[] = [];
 
+        // agent volume must be writable because agents may use their location for disk-based caching of telemetry items
         for (let i = 0; i < platforms.length; i++) {
             switch (platforms[i] as AutoInstrumentationPlatforms) {
                 case AutoInstrumentationPlatforms.Java:
@@ -681,5 +698,13 @@ export class Mutations {
 
     public static GetUserPriorityOtelResourceAttributeKeys(): Set<string> {
         return new Set(["service.name", "service.instance.id"]);
+    }
+
+    private static generateInitContainerArgs(sourcePath: string, destPath: string): string[] {
+        // we are doing chmod to make sure copied files are world-readable to every user in any container.
+        //chmod ... || true is necessary because chmod may fail on the mount point itself (root),
+        // which is acceptable to us and we don't want to fail the initcontainer in that case.
+        // cp -r <source> <destination>
+        return ["-c", `cp -r ${sourcePath} ${destPath} && (chmod -R 777 ${destPath} || true)`];
     }
 }

--- a/appmonitoring/ts/src/RequestDefinition.ts
+++ b/appmonitoring/ts/src/RequestDefinition.ts
@@ -80,6 +80,11 @@ export interface IResources {
     limits: ILimits;
 }
 
+export interface ISecurityContext {
+    runAsUser?: number;
+    runAsNonRoot?: boolean;
+}
+
 export interface IContainer {
     name: string;
     image: string;
@@ -92,6 +97,7 @@ export interface IContainer {
     imagePullPolicy?: string;
     env?: IEnvironmentVariable[];
     volumeMounts?: IVolumeMount[];
+    securityContext?: ISecurityContext;
 }
 
 export interface IVolume {

--- a/appmonitoring/ts/src/package-lock.json
+++ b/appmonitoring/ts/src/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": "^20.4.0"
+        "node": "^18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/appmonitoring/ts/src/package.json
+++ b/appmonitoring/ts/src/package.json
@@ -22,7 +22,7 @@
     "prom-client": "^15.1.3"
   },
   "engines": {
-    "node": "^20.4.0"
+    "node": "^18.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/appmonitoring/validation-helm/test-apps/dotnet-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/dotnet-charts/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         instrumentation.opentelemetry.io/private-preview-inject-dotnet: "true"
       {{- end }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 15000
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/dotnet-instrumented/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/dotnet-instrumented/chart.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-configuration: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 9000
       containers:
       - name: dotnet-instrumented-test-app
         image: appmonitoring.azurecr.io/demoaks-dotnet-instrumented-app:latest

--- a/appmonitoring/validation-helm/test-apps/dotnet/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/dotnet/chart.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/private-preview-inject-dotnet: "true" # private-preview is enabled via an annotation only
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 8000
       containers:
       - name: dotnet-test-app
         image: appmonitoring.azurecr.io/demoaks-dotnet-app:latest

--- a/appmonitoring/validation-helm/test-apps/go-instrumented-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/go-instrumented-charts/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-configuration: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 16000
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/go-instrumented/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/go-instrumented/chart.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         #instrumentation.opentelemetry.io/inject-configuration: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
       containers:
       - name: go-instrumented-test-app
         image: appmonitoring.azurecr.io/demoaks-go-instrumented-app:latest

--- a/appmonitoring/validation-helm/test-apps/java-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/java-charts/templates/deployment.yaml
@@ -15,8 +15,7 @@ spec:
         app: {{ .Values.appName }}
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 12000
+        runAsUser: 0
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/java-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/java-charts/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ .Values.appName }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 12000
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/java-instrumented-agent/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/java-instrumented-agent/chart.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-configuration: "false"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: java-instrumented-agent-app
         image: appmonitoring.azurecr.io/demoaks-java-instrumented-agent-app:latest

--- a/appmonitoring/validation-helm/test-apps/java-instrumented/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/java-instrumented/chart.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         #instrumentation.opentelemetry.io/inject-configuration: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 4000
       containers:
       - name: java-instrumented-test-app
         image: appmonitoring.azurecr.io/demoaks-java-instrumented-app:latest

--- a/appmonitoring/validation-helm/test-apps/java/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/java/chart.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: java-test-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 3000
       containers:
       - name: java-test-app
         image: appmonitoring.azurecr.io/demoaks-java-app:latest

--- a/appmonitoring/validation-helm/test-apps/nodejs-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/nodejs-charts/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ .Values.appName }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 13000
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/nodejs-instrumented/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/nodejs-instrumented/chart.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         #instrumentation.opentelemetry.io/inject-configuration: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 6000
       containers:
       - name: nodejs-instrumented-test-app
         image: appmonitoring.azurecr.io/demoaks-nodejs-instrumented-app:latest

--- a/appmonitoring/validation-helm/test-apps/nodejs/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/nodejs/chart.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: nodejs-test-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 5000
       containers:
       - name: nodejs-test-app
         image: appmonitoring.azurecr.io/demoaks-nodejs-app:latest

--- a/appmonitoring/validation-helm/test-apps/python-charts/templates/deployment.yaml
+++ b/appmonitoring/validation-helm/test-apps/python-charts/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/private-preview-inject-python: "true" # private-preview is enabled via an annotation only
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 14000
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.image }}"

--- a/appmonitoring/validation-helm/test-apps/python/chart.yaml
+++ b/appmonitoring/validation-helm/test-apps/python/chart.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/private-preview-inject-python: "true" # private-preview is enabled via an annotation only
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 7000
       containers:
       - name: python-test-app
         image: appmonitoring.azurecr.io/demoaks-python-app:latest


### PR DESCRIPTION
Switching the initcontainer to be run under a non-root user. This is required by certain customers who have policies prohibiting any containers from running under root user.