### PR TITLE
fix: bleu cloud name is azurebleucloud

### DIFF
--- a/charts/azuremonitor-containers/templates/ama-logs-arc-k8s-crd.yaml
+++ b/charts/azuremonitor-containers/templates/ama-logs-arc-k8s-crd.yaml
@@ -23,7 +23,7 @@ spec:
   audience: https://monitor.azure.com/
   {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "azurechinacloud" }}
   audience: https://monitor.azure.cn/
-  {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "bleu" }}
+  {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "azurebleucloud" }}
   audience: https://monitor.sovcloud-api.fr/
   {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "azureusgovernmentcloud" }}
   audience: https://monitor.azure.us/

--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -6,7 +6,7 @@ startTime=$(date +%s)
 echo "startup script start @ $(date +'%Y-%m-%dT%H:%M:%S')"
 
 # Supported cloud environments
-SUPPORTED_CLOUDS=("azurepubliccloud" "azurechinacloud" "azureusgovernmentcloud" "usnat" "ussec" "bleu")
+SUPPORTED_CLOUDS=("azurepubliccloud" "azurechinacloud" "azureusgovernmentcloud" "usnat" "ussec" "azurebleucloud")
 
 getDomainFromSecret() {
       # Read the domain from the AMA logs secret and convert to lowercase
@@ -51,7 +51,7 @@ getClusterCloudEnvironment() {
                   echo "ussec"
                   ;;
             "opinsights.sovcloud-api.fr")
-                  echo "bleu"
+                  echo "azurebleucloud"
                   ;;
             ""|*)
                   echo "unknown"
@@ -147,9 +147,9 @@ setCloudSpecificApplicationInsightsConfig() {
             echo "export APPLICATIONINSIGHTS_ENDPOINT=$APPLICATIONINSIGHTS_ENDPOINT" >>~/.bashrc
             source ~/.bashrc
             ;;
-         "bleu")
-            # TODO: Bleu cloud is a new cloud environment, we don't have AI in this cloud yet so using Public cloud for now.
-            # Update this once we have AI in Bleu cloud.
+         "azurebleucloud")
+            # TODO: azurebleucloud is a new cloud environment; we don't have AI in this cloud yet so using Public cloud for now.
+            # Update this once we have AI in azurebleucloud.
             APPLICATIONINSIGHTS_AUTH="NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi"
             APPLICATIONINSIGHTS_ENDPOINT="https://dc.applicationinsights.azure.com/v2/track"
             echo "export APPLICATIONINSIGHTS_AUTH=$APPLICATIONINSIGHTS_AUTH" >>~/.bashrc

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -275,7 +275,7 @@ function Get-McsAzureResourceEndpoint {
             "azureusgovernmentcloud"  { $mcs_azure_resource_endpoint = "https://monitor.azure.us/" }
             "usnat"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.eaglex.ic.gov/" }
             "ussec"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.microsoft.scloud/" }
-            "azurebleucloud"                    { $mcs_azure_resource_endpoint = "https://monitor.sovcloud-api.fr/" }
+            "azurebleucloud"          { $mcs_azure_resource_endpoint = "https://monitor.sovcloud-api.fr/" }
         }
     }
     return $mcs_azure_resource_endpoint
@@ -293,7 +293,7 @@ function Get-McsEndpoint {
             "azureusgovernmentcloud"  { $mcs_endpoint = "monitor.azure.us" }
             "usnat"                   { $mcs_endpoint = "monitor.azure.eaglex.ic.gov" }
             "ussec"                   { $mcs_endpoint = "monitor.azure.microsoft.scloud" }
-            "azurebleucloud"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
+            "azurebleucloud"          { $mcs_endpoint = "monitor.sovcloud-api.fr" }
         }
     }
     return $mcs_endpoint

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -327,7 +327,7 @@ function Get-McsGlobalEndpoint{
                 "azureusgovernmentcloud"  { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us" }
                 "usnat"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov" }
                 "ussec"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud" }
-                "azurebleucloud"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
+                "azurebleucloud"          { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
             }
         }
     }

--- a/kubernetes/windows/main.ps1
+++ b/kubernetes/windows/main.ps1
@@ -103,10 +103,10 @@ function Set-CloudSpecificApplicationInsightsConfig {
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "NTc5ZDRiZjUtMTA1Mi0wODQzLThhNTYtMjU5YzEyZmJhZTkyCg=="
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.microsoft.scloud/v2/track"
         }
-        "bleu" {
-            # TODO: Bleu cloud is a new cloud environment, we don't have AI in this cloud yet so using Public cloud for now.
-            # Update this once we have AI in Bleu cloud.
-            Write-Host "Set-CloudSpecificApplicationInsightsConfig: Setting Application Insights configuration for Bleu Cloud"
+        "azurebleucloud" {
+            # TODO: azurebleucloud is a new cloud environment; we don't have AI in this cloud yet so using Public cloud for now.
+            # Update this once we have AI in azurebleucloud.
+            Write-Host "Set-CloudSpecificApplicationInsightsConfig: Setting Application Insights configuration for azurebleucloud"
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_AUTH" "NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi"
             Set-ProcessAndMachineEnvVariables "APPLICATIONINSIGHTS_ENDPOINT" "https://dc.applicationinsights.azure.com/v2/track"
         }
@@ -204,7 +204,7 @@ function Is-SupportedCloudEnvironment {
     param (
         [string]$cloudEnvironment
     )
-    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "bleu")
+    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "azurebleucloud")
     if ($supportedCloudEnvironments -contains $cloudEnvironment) {
         return $true
     }
@@ -228,7 +228,7 @@ function Get-ClusterCloudEnvironment{
                 "opinsights.azure.us"                 { $cloud_environment = "azureusgovernmentcloud" }
                 "opinsights.azure.eaglex.ic.gov"      { $cloud_environment = "usnat" }
                 "opinsights.azure.microsoft.scloud"   { $cloud_environment = "ussec" }
-                "opinsights.sovcloud-api.fr"          { $cloud_environment = "bleu" }
+                "opinsights.sovcloud-api.fr"          { $cloud_environment = "azurebleucloud" }
             }
         } else {
             Write-Host "Domain name either null or empty. Defaulting to azurepubliccloud."
@@ -275,7 +275,7 @@ function Get-McsAzureResourceEndpoint {
             "azureusgovernmentcloud"  { $mcs_azure_resource_endpoint = "https://monitor.azure.us/" }
             "usnat"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.eaglex.ic.gov/" }
             "ussec"                   { $mcs_azure_resource_endpoint = "https://monitor.azure.microsoft.scloud/" }
-            "bleu"                    { $mcs_azure_resource_endpoint = "https://monitor.sovcloud-api.fr/" }
+            "azurebleucloud"                    { $mcs_azure_resource_endpoint = "https://monitor.sovcloud-api.fr/" }
         }
     }
     return $mcs_azure_resource_endpoint
@@ -293,7 +293,7 @@ function Get-McsEndpoint {
             "azureusgovernmentcloud"  { $mcs_endpoint = "monitor.azure.us" }
             "usnat"                   { $mcs_endpoint = "monitor.azure.eaglex.ic.gov" }
             "ussec"                   { $mcs_endpoint = "monitor.azure.microsoft.scloud" }
-            "bleu"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
+            "azurebleucloud"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
         }
     }
     return $mcs_endpoint
@@ -327,7 +327,7 @@ function Get-McsGlobalEndpoint{
                 "azureusgovernmentcloud"  { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us" }
                 "usnat"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov" }
                 "ussec"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud" }
-                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
+                "azurebleucloud"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
             }
         }
     }

--- a/source/plugins/go/input/lib/applicationinsights.go
+++ b/source/plugins/go/input/lib/applicationinsights.go
@@ -284,7 +284,7 @@ func getWorkspaceCloud() string {
 	case "opinsights.azure.microsoft.scloud":
 		workspaceCloud = "ussec"
 	case "opinsights.sovcloud-api.fr":
-		workspaceCloud = "bleu"
+		workspaceCloud = "azurebleucloud"
 	default:
 		workspaceCloud = "Unknown"
 	}

--- a/source/plugins/ruby/ApplicationInsightsUtility.rb
+++ b/source/plugins/ruby/ApplicationInsightsUtility.rb
@@ -308,7 +308,7 @@ class ApplicationInsightsUtility
         elsif workspaceDomain.casecmp("opinsights.azure.microsoft.scloud") == 0
           workspaceCloud = "ussec"
         elsif workspaceDomain.casecmp("opinsights.sovcloud-api.fr") == 0
-          workspaceCloud = "bleu"
+          workspaceCloud = "azurebleucloud"
         else
           workspaceCloud = "Unknown"
         end

--- a/test/unit-tests/test_cases/Test-GetClusterCloudEnvironment.ps1
+++ b/test/unit-tests/test_cases/Test-GetClusterCloudEnvironment.ps1
@@ -11,7 +11,7 @@ function Test-ValidEnvironmentVariables {
         "azureusgovernmentcloud",
         "usnat",
         "ussec",
-        "bleu"
+        "azurebleucloud"
     )
 
     foreach ($cloud in $testCases) {
@@ -38,7 +38,7 @@ function Test-DomainFileFallback {
         @{domain="opinsights.azure.us"; expected="azureusgovernmentcloud"},
         @{domain="opinsights.azure.eaglex.ic.gov"; expected="usnat"},
         @{domain="opinsights.azure.microsoft.scloud"; expected="ussec"},
-        @{domain="opinsights.sovcloud-api.fr"; expected="bleu"}
+        @{domain="opinsights.sovcloud-api.fr"; expected="azurebleucloud"}
     )
 
     foreach ($testCase in $testCases) {

--- a/test/unit-tests/test_cases/Test-GetMcsEndpoint.ps1
+++ b/test/unit-tests/test_cases/Test-GetMcsEndpoint.ps1
@@ -27,7 +27,7 @@ function Test-CloudEnvironments {
             expected = "monitor.azure.microsoft.scloud"
         },
         @{
-            cloud = "bleu"
+            cloud = "azurebleucloud"
             expected = "monitor.sovcloud-api.fr"
         }
     )

--- a/test/unit-tests/test_cases/Test-GetMcsGlobalEndpoint.ps1
+++ b/test/unit-tests/test_cases/Test-GetMcsGlobalEndpoint.ps1
@@ -42,7 +42,7 @@ function Test-CloudEnvironments {
             expected = "https://global.handler.control.monitor.azure.microsoft.scloud"
         },
         @{
-            cloud = "bleu"
+            cloud = "azurebleucloud"
             expected = "https://global.handler.control.monitor.sovcloud-api.fr"
         }
     )

--- a/test/unit-tests/test_cases/Test-IsSupportedCloudEnvironment.ps1
+++ b/test/unit-tests/test_cases/Test-IsSupportedCloudEnvironment.ps1
@@ -11,7 +11,7 @@ function Test-ValidCloudEnvironments {
         "azureusgovernmentcloud",
         "usnat",
         "ussec",
-        "bleu"
+        "azurebleucloud"
     )
 
     foreach ($cloud in $testCases) {

--- a/test/unit-tests/test_cases/test_getClusterCloudEnvironment.sh
+++ b/test/unit-tests/test_cases/test_getClusterCloudEnvironment.sh
@@ -14,7 +14,7 @@ test_valid_environment_variables() {
         "azureusgovernmentcloud"
         "usnat"
         "ussec"
-        "bleu"
+        "azurebleucloud"
     )
 
     for cloud in "${test_cases[@]}"; do
@@ -45,7 +45,7 @@ test_domain_file_fallback() {
         "opinsights.azure.us:azureusgovernmentcloud"
         "opinsights.azure.eaglex.ic.gov:usnat"
         "opinsights.azure.microsoft.scloud:ussec"
-        "opinsights.sovcloud-api.fr:bleu"
+        "opinsights.sovcloud-api.fr:azurebleucloud"
     )
 
     for test_case in "${test_cases[@]}"; do

--- a/test/unit-tests/test_functions/Get-ClusterCloudEnvironment.ps1
+++ b/test/unit-tests/test_functions/Get-ClusterCloudEnvironment.ps1
@@ -2,7 +2,7 @@ function Is-SupportedCloudEnvironment {
     param (
         [string]$cloudEnvironment
     )
-    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "bleu")
+    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "azurebleucloud")
     if ($supportedCloudEnvironments -contains $cloudEnvironment) {
         return $true
     }
@@ -26,7 +26,7 @@ function Get-ClusterCloudEnvironment{
                 "opinsights.azure.us"                 { $cloud_environment = "azureusgovernmentcloud" }
                 "opinsights.azure.eaglex.ic.gov"      { $cloud_environment = "usnat" }
                 "opinsights.azure.microsoft.scloud"   { $cloud_environment = "ussec" }
-                "opinsights.sovcloud-api.fr"          { $cloud_environment = "bleu" }
+                "opinsights.sovcloud-api.fr"          { $cloud_environment = "azurebleucloud" }
             }
         } else {
             Write-Host "Domain name either null or empty. Defaulting to azurepubliccloud."

--- a/test/unit-tests/test_functions/Get-McsEndpoint.ps1
+++ b/test/unit-tests/test_functions/Get-McsEndpoint.ps1
@@ -10,7 +10,7 @@ function Get-McsEndpoint {
             "azureusgovernmentcloud"  { $mcs_endpoint = "monitor.azure.us" }
             "usnat"                   { $mcs_endpoint = "monitor.azure.eaglex.ic.gov" }
             "ussec"                   { $mcs_endpoint = "monitor.azure.microsoft.scloud" }
-            "bleu"                    { $mcs_endpoint = "monitor.sovcloud-api.fr" }
+            "azurebleucloud"          { $mcs_endpoint = "monitor.sovcloud-api.fr" }
         }
     }
     return $mcs_endpoint

--- a/test/unit-tests/test_functions/Get-McsGlobalEndpoint.ps1
+++ b/test/unit-tests/test_functions/Get-McsGlobalEndpoint.ps1
@@ -25,7 +25,7 @@ function Get-McsGlobalEndpoint{
                 "azureusgovernmentcloud"  { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.us" }
                 "usnat"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.eaglex.ic.gov" }
                 "ussec"                   { $mcs_globalendpoint = "https://global.handler.control.monitor.azure.microsoft.scloud" }
-                "bleu"                    { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
+                "azurebleucloud"          { $mcs_globalendpoint = "https://global.handler.control.monitor.sovcloud-api.fr" }
             }
         }
     }

--- a/test/unit-tests/test_functions/Is-SupportedCloudEnvironment.ps1
+++ b/test/unit-tests/test_functions/Is-SupportedCloudEnvironment.ps1
@@ -5,7 +5,7 @@ function Is-SupportedCloudEnvironment {
     param (
         [string]$cloudEnvironment
     )
-    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "bleu")
+    $supportedCloudEnvironments = @("azurepubliccloud", "azurechinacloud", "azureusgovernmentcloud", "usnat", "ussec", "azurebleucloud")
     if ($supportedCloudEnvironments -contains $cloudEnvironment) {
         return $true
     }

--- a/test/unit-tests/test_functions/getClusterCloudEnvironment.sh
+++ b/test/unit-tests/test_functions/getClusterCloudEnvironment.sh
@@ -4,7 +4,7 @@
 # Original source: kubernetes/linux/main.sh
 
 # Required variables
-SUPPORTED_CLOUDS=("azurepubliccloud" "azurechinacloud" "azureusgovernmentcloud" "usnat" "ussec" "bleu")
+SUPPORTED_CLOUDS=("azurepubliccloud" "azurechinacloud" "azureusgovernmentcloud" "usnat" "ussec" "azurebleucloud")
 
 getDomainFromSecret() {
       # Read the domain from the AMA logs secret and convert to lowercase
@@ -55,7 +55,7 @@ getClusterCloudEnvironment() {
                   echo "ussec"
                   ;;
             "opinsights.sovcloud-api.fr")
-                  echo "bleu"
+                  echo "azurebleucloud"
                   ;;
             ""|*)
                   echo "unknown"


### PR DESCRIPTION
The cloud environment coming from AKS is `azurebleucloud` and is also the name mdsd expects. Contract with AKS and mdsd for the name changed at some point. The endpoints are correct however, just the customEnvironment name wasn't valid to mdsd.

```
2026-01-21T07:19:30.2315920Z: Skipped IMDS metadata lookup, will use configured region "bleufrancecentral", environment "bleu"
...
2026-01-21T07:19:30.2326740Z: Error: mdsd is terminated with exception: Unknown cloud environment "bleu", cannot construct MCS or MSI token resource endpoints
2026-01-21T07:19:30.2329030Z: FATAL: mdsd killed by direct call, no signal involved
```

mdsd codebase:
```
const std::string BLEU_CLOUD_NAME = "azurebleucloud";
```
