### PR TITLE
Longw/3.1.35 address vulnerabilties

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -15,7 +15,7 @@ sudo update-ca-trust
 # arm64 build breaks intermittently when installing ruby from global packages, so installing it from mariner packages
 # the mariner package version is behind the global packages so we are using different versions for arm64 and x86_64
 if [ "$ARCH" == "arm64" ]; then
-    sudo tdnf install ruby-3.3.5-1.azl3.aarch64 -y
+    sudo tdnf install ruby-3.3.5-7.azl3.aarch64 -y
 else
     tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
     wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20250409.tar.gz -O ruby-build.tar.gz

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -39,6 +39,7 @@ gem uninstall net-imap --force
 
 # remove rexml gem as it has a known CVE (CVE-2025-58767) and is not used by the agent
 gem uninstall rexml --force
+gem update uri --no-document
 
 sudo tdnf install -y azure-mdsd-1.37.0
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -18,10 +18,10 @@ if [ "$ARCH" == "arm64" ]; then
     sudo tdnf install ruby-3.3.5-7.azl3.aarch64 -y
 else
     tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
-    wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20250409.tar.gz -O ruby-build.tar.gz
+    wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20251023.tar.gz -O ruby-build.tar.gz
     tar -xzf ruby-build.tar.gz
     PREFIX=/usr/local ./ruby-build-*/install.sh
-    ruby-build 3.3.8 /usr -v
+    ruby-build 3.3.10 /usr -v
 
     rm ruby-build.tar.gz
 fi
@@ -39,7 +39,6 @@ gem uninstall net-imap --force
 
 # remove rexml gem as it has a known CVE (CVE-2025-58767) and is not used by the agent
 gem uninstall rexml --force
-gem install uri -v 0.13.3 --force --no-document
 
 sudo tdnf install -y azure-mdsd-1.37.0
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -39,7 +39,7 @@ gem uninstall net-imap --force
 
 # remove rexml gem as it has a known CVE (CVE-2025-58767) and is not used by the agent
 gem uninstall rexml --force
-gem update uri --no-document
+gem install uri -v 0.13.3 --force --no-document
 
 sudo tdnf install -y azure-mdsd-1.37.0
 cp -f $TMPDIR/mdsd.xml /etc/mdsd.d
@@ -63,7 +63,9 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-sudo tdnf install telegraf-agent-1.37.0 -y
+# sudo tdnf install telegraf-agent-1.37.0 -y
+sudo curl -L -O https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.37.1/azl3/x86_64/telegraf-agent-1.37.1-1.azl3.x86_64.rpm
+sudo tdnf install -y --nogpgcheck telegraf-agent-1.37.1-1.azl3.x86_64.rpm
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -62,9 +62,7 @@ sudo tdnf install jq-1.7.1-1.azl3 -y
 #used to setcaps for ruby process to read /proc/env
 sudo tdnf install libcap -y
 
-# sudo tdnf install telegraf-agent-1.37.0 -y
-sudo curl -L -O https://kubernetesreleases.blob.core.windows.net/dalec-packages/telegraf-agent/1.37.1/azl3/x86_64/telegraf-agent-1.37.1-1.azl3.x86_64.rpm
-sudo tdnf install -y --nogpgcheck telegraf-agent-1.37.1-1.azl3.x86_64.rpm
+sudo tdnf install telegraf-agent-1.37.1 -y
 telegraf_version=$(sudo tdnf list installed | grep telegraf | awk '{print $2}')
 echo "telegraf $telegraf_version" >> packages_version.txt
 mv /usr/bin/telegraf-agent /opt/telegraf

--- a/source/plugins/go/input/go.mod
+++ b/source/plugins/go/input/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/input
 
-go 1.24.10
+go 1.26.0
 
 require github.com/calyptia/plugin v1.0.2
 

--- a/source/plugins/go/input/go.mod
+++ b/source/plugins/go/input/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/input
 
-go 1.26.0
+go 1.25.7
 
 require github.com/calyptia/plugin v1.0.2
 

--- a/source/plugins/go/src/go.mod
+++ b/source/plugins/go/src/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/src
 
-go 1.26.0
+go 1.25.7
 
 require (
 	github.com/Microsoft/go-winio v0.6.1

--- a/source/plugins/go/src/go.mod
+++ b/source/plugins/go/src/go.mod
@@ -1,6 +1,6 @@
 module Docker-Provider/source/plugins/go/src
 
-go 1.24.10
+go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.1

--- a/test/ginkgo-e2e/containerstatus/go.mod
+++ b/test/ginkgo-e2e/containerstatus/go.mod
@@ -1,8 +1,6 @@
 module docker-provider/test/containerstatus
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.26.0
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/containerstatus/go.mod
+++ b/test/ginkgo-e2e/containerstatus/go.mod
@@ -1,6 +1,6 @@
 module docker-provider/test/containerstatus
 
-go 1.26.0
+go 1.25.7
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/livenessprobe/go.mod
+++ b/test/ginkgo-e2e/livenessprobe/go.mod
@@ -1,6 +1,6 @@
 module docker-provider/test/livenessprobe
 
-go 1.26.0
+go 1.25.7
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/livenessprobe/go.mod
+++ b/test/ginkgo-e2e/livenessprobe/go.mod
@@ -1,8 +1,6 @@
 module docker-provider/test/livenessprobe
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.26.0
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/querylogs/go.mod
+++ b/test/ginkgo-e2e/querylogs/go.mod
@@ -1,6 +1,6 @@
 module docker-provider/test/querylogs
 
-go 1.26.0
+go 1.25.7
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/querylogs/go.mod
+++ b/test/ginkgo-e2e/querylogs/go.mod
@@ -1,6 +1,6 @@
 module docker-provider/test/querylogs
 
-go 1.23.6
+go 1.26.0
 
 replace docker-provider/test/utils => ../utils
 

--- a/test/ginkgo-e2e/utils/go.mod
+++ b/test/ginkgo-e2e/utils/go.mod
@@ -1,6 +1,6 @@
 module docker-provider/test/utils
 
-go 1.26.0
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0

--- a/test/ginkgo-e2e/utils/go.mod
+++ b/test/ginkgo-e2e/utils/go.mod
@@ -1,8 +1,6 @@
 module docker-provider/test/utils
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
This PR updates several build/test dependencies to address reported 3.1.34-related vulnerabilities and keep the toolchain current: it refreshes the Kubernetes Linux setup script to install a newer Mariner Ruby package on arm64, upgrades ruby-build and the Ruby version used on x86_64, bumps telegraf-agent from 1.37.0 to 1.37.1, and updates Go module toolchain versions across the plugin and Ginkgo e2e test modules to Go 1.25.7 (removing older toolchain go1.23.6 pins where present).