### PR TITLE
let ginkgo-e2e decide gotoolchain version

### DIFF
--- a/test/testkube/install-and-execute-testkube-tests.sh
+++ b/test/testkube/install-and-execute-testkube-tests.sh
@@ -90,7 +90,7 @@ for wf in "${workflows[@]}"; do
         --config GENEVA_INTEGRATION="$GENEVA_INTEGRATION" \
         --config AZURE_TENANT_ID="$AZURE_TENANT_ID" \
         --config AZURE_CLIENT_ID="$AZURE_CLIENT_ID" \
-        --config GOTOOLCHAIN="go1.23.6" \
+        --config GOTOOLCHAIN="auto" \
         --verbose
 
     echo "Waiting for execution to be created..."


### PR DESCRIPTION
go version upgrade in ginkgo-e2e will break testkube if we pin toolchain to a fixed version. set to auto so toochain version will match ginkgo-e2e.

fail: see "20260225.1 • add back nodes/proxy (#1607)" in test pipeline
fix: see "20260225.2 • test testframe work fix" in test pipeline