### PR TITLE
Fix image parser issue and update unit test for Kubernetes Metadata

### DIFF
--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1311,13 +1311,29 @@ func extractImageID(hash string) string {
 }
 
 func parseImageDetails(image string) (repo, name, tag string) {
-	slashLocation := strings.Index(image, "/")
-	colonLocation := strings.Index(image, ":")
+	if len(image) == 0 {
+		return "", "", ""
+	}
+
 	atLocation := strings.Index(image, "@")
 
 	// Exclude the digest part for imageRepo/image/tag parsing, if present
 	if atLocation != -1 {
 		image = image[:atLocation]
+	}
+
+	// Handle case where image becomes empty after removing digest
+	if len(image) == 0 {
+		return "", "", ""
+	}
+
+	// Use LastIndex for slash to handle nested paths like registry.io/org/repo
+	slashLocation := strings.LastIndex(image, "/")
+	colonLocation := strings.LastIndex(image, ":")
+
+	// Handle registry with port (e.g., localhost:5000/image or registry.svc:5000/org/image)
+	if colonLocation != -1 && slashLocation != -1 && colonLocation < slashLocation {
+		colonLocation = -1
 	}
 
 	// If colonLocation is -1 (not found), set it to the length of the image string

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"testing"
 	"fmt"
 	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,20 +42,20 @@ func toInterfaceMap(m map[string]interface{}) map[interface{}]interface{} {
 // Test PostDataHelper KuberneteMetadata
 func TestPostDataHelperKuberneteMetadata(t *testing.T) {
 	var intermediateMap map[string]interface{}
-    // Unmarshal JSON data into a map
-    err := json.Unmarshal([]byte(kubernetesJSON), &intermediateMap)
-    if err != nil {
-        fmt.Println("Error unmarshalling JSON:", err)
-        return
-    }
+	// Unmarshal JSON data into a map
+	err := json.Unmarshal([]byte(kubernetesJSON), &intermediateMap)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return
+	}
 	kubernetesMetadata := toInterfaceMap(intermediateMap)
 
 	record := map[interface{}]interface{}{
-		"filepath": "/var/log/containers/pod_xyz.log",
-		"stream": "stdout",
+		"filepath":   "/var/log/containers/pod_xyz.log",
+		"stream":     "stdout",
 		"kubernetes": kubernetesMetadata,
 	}
-	
+
 	KubernetesMetadataIncludeList = []string{
 		"podlabels", "podannotations", "poduid", "image", "imageid", "imagerepo", "imagetag",
 	}
@@ -82,50 +83,50 @@ func TestPostDataHelperMultiple(t *testing.T) {
 			"filepath": "/var/log/containers/pod_xyz.log",
 			"stream":   "stdout",
 			"kubernetes": map[interface{}]interface{}{
-				"pod_name":        "test-publisher-ds-bssg6",
-				"namespace_name":  "kube-system",
-				"pod_id":          "93bf47d2-5c1a-42bc-test-481939a93a66",
+				"pod_name":       "test-publisher-ds-bssg6",
+				"namespace_name": "kube-system",
+				"pod_id":         "93bf47d2-5c1a-42bc-test-481939a93a66",
 				"labels": map[interface{}]interface{}{
-					"app":                          "test",
-					"controller-revision-hash":     "f48799794",
-					"dsName":                       "defender-publisher-ds",
+					"app":                            "test",
+					"controller-revision-hash":       "f48799794",
+					"dsName":                         "defender-publisher-ds",
 					"kubernetes.azure.com/managedby": "aks",
-					"pod-template-generation":       "2",
+					"pod-template-generation":        "2",
 				},
 				"annotations": map[interface{}]interface{}{
 					"kubernetes.io/config.seen":   "2023-10-02T08:21:49.954540360Z",
 					"kubernetes.io/config.source": "api",
 				},
-				"host":             "test-agentpool-test-test000001",
-				"container_name":   "test-publisher",
-				"docker_id":        "test1234567890123213213123213213213213",
-				"container_hash":   "publisher@sha256:test1234567890123213213123213213213213",
-				"container_image":  "test-publisher:1.0.67",
+				"host":            "test-agentpool-test-test000001",
+				"container_name":  "test-publisher",
+				"docker_id":       "test1234567890123213213123213213213213",
+				"container_hash":  "publisher@sha256:test1234567890123213213123213213213213",
+				"container_image": "test-publisher:1.0.67",
 			},
 		},
 		{
 			"filepath": "/var/log/containers/pod_abc.log",
 			"stream":   "stderr",
 			"kubernetes": map[interface{}]interface{}{
-				"pod_name":        "test-consumer-ds-abcde",
-				"namespace_name":  "default",
-				"pod_id":          "a1b2c3d4e5f6",
+				"pod_name":       "test-consumer-ds-abcde",
+				"namespace_name": "default",
+				"pod_id":         "a1b2c3d4e5f6",
 				"labels": map[interface{}]interface{}{
-					"app":                          "test",
-					"controller-revision-hash":     "f48799794",
-					"dsName":                       "defender-consumer-ds",
+					"app":                            "test",
+					"controller-revision-hash":       "f48799794",
+					"dsName":                         "defender-consumer-ds",
 					"kubernetes.azure.com/managedby": "aks",
-					"pod-template-generation":       "1",
+					"pod-template-generation":        "1",
 				},
 				"annotations": map[interface{}]interface{}{
 					"kubernetes.io/config.seen":   "2023-10-02T08:21:49.954540360Z",
 					"kubernetes.io/config.source": "api",
 				},
-				"host":             "test-agentpool-test-test000002",
-				"container_name":   "test-consumer",
-				"docker_id":        "abcde12345",
-				"container_hash":   "consumer@sha256:abcde12345",
-				"container_image":  "test-consumer:2.0.12",
+				"host":            "test-agentpool-test-test000002",
+				"container_name":  "test-consumer",
+				"docker_id":       "abcde12345",
+				"container_hash":  "consumer@sha256:abcde12345",
+				"container_image": "test-consumer:2.0.12",
 			},
 		},
 	}
@@ -169,26 +170,67 @@ func TestConvertKubernetesMetadata(t *testing.T) {
 	}
 }
 
+func TestParseImageDetails(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        string
+		expectedRepo string
+		expectedName string
+		expectedTag  string
+	}{
+		{
+			name:         "ACR image with tag",
+			image:        "cradhahgwnpddc301containerimgregistry.azurecr.io/adha-b2b-clamav-container:1.13.0",
+			expectedRepo: "cradhahgwnpddc301containerimgregistry.azurecr.io",
+			expectedName: "adha-b2b-clamav-container",
+			expectedTag:  "1.13.0",
+		},
+		{
+			name:         "OpenShift registry with port and digest",
+			image:        "image-registry.openshift-image-registry.svc:5000/openshift/nginx@sha256:994f124566a0b6e8e1feeef40c6e9aa075185cfafde9b657afd06c38711d10fa",
+			expectedRepo: "image-registry.openshift-image-registry.svc:5000/openshift",
+			expectedName: "nginx",
+			expectedTag:  "latest",
+		},
+		{
+			name:         "Docker.io image with digest",
+			image:        "docker.io/library/redis@sha256:bfb12425ee0f266763621d49b44d07a50c387c3d2e24feca982193ceb1abfbe4",
+			expectedRepo: "docker.io/library",
+			expectedName: "redis",
+			expectedTag:  "latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, name, tag := parseImageDetails(tt.image)
+			assert.Equal(t, tt.expectedRepo, repo, "repo mismatch")
+			assert.Equal(t, tt.expectedName, name, "name mismatch")
+			assert.Equal(t, tt.expectedTag, tag, "tag mismatch")
+		})
+	}
+}
+
 func TestProcessIncludes(t *testing.T) {
 	kubernetesMetadataMap := map[string]interface{}{
-		"pod_name":"test-publisher-ds-bssg6",
-		"namespace_name":"kube-system",
-		"pod_id":"93bf47d2-5c1a-42bc-test-481939a93a66",
+		"pod_name":       "test-publisher-ds-bssg6",
+		"namespace_name": "kube-system",
+		"pod_id":         "93bf47d2-5c1a-42bc-test-481939a93a66",
 		"labels": map[string]interface{}{
-			"app":"test",
-			"controller-revision-hash":"f48799794",
-			"dsName":"defender-publisher-ds",
-			"kubernetes.azure.com/managedby":"aks",
-			"pod-template-generation":"2",
+			"app":                            "test",
+			"controller-revision-hash":       "f48799794",
+			"dsName":                         "defender-publisher-ds",
+			"kubernetes.azure.com/managedby": "aks",
+			"pod-template-generation":        "2",
 		},
 		"annotations": map[string]interface{}{
-			"test":"2023-10-02T08:21:49.954540360Z",
+			"test": "2023-10-02T08:21:49.954540360Z",
 		},
-		"host":"test-agentpool-test-test000001",
-		"container_name":"test-publisher",
-		"docker_id":"test1234567890123213213123213213213213",
-		"container_hash":"publisher@sha256:test1234567890123213213123213213213213",
-		"container_image":"docker.io/test-publisher:1.0.67",
+		"host":            "test-agentpool-test-test000001",
+		"container_name":  "test-publisher",
+		"docker_id":       "test1234567890123213213123213213213213",
+		"container_hash":  "publisher@sha256:test1234567890123213213123213213213213",
+		"container_image": "docker.io/test-publisher:1.0.67",
 	}
 
 	includesList := []string{
@@ -197,18 +239,18 @@ func TestProcessIncludes(t *testing.T) {
 
 	expectedResult := map[string]interface{}{
 		//"image": "test-publisher",
-		"imageID": "sha256:test1234567890123213213123213213213213",
+		"imageID":   "sha256:test1234567890123213213123213213213213",
 		"imageRepo": "docker.io",
 		//"imageTag": "1.0.67",
 		"podAnnotations": map[string]interface{}{
 			"test": "2023-10-02T08:21:49.954540360Z",
 		},
 		"podLabels": map[string]interface{}{
-			"app": "test",
-			"controller-revision-hash": "f48799794",
-			"dsName": "defender-publisher-ds",
+			"app":                            "test",
+			"controller-revision-hash":       "f48799794",
+			"dsName":                         "defender-publisher-ds",
 			"kubernetes.azure.com/managedby": "aks",
-			"pod-template-generation": "2",
+			"pod-template-generation":        "2",
 		},
 		"podUid": "93bf47d2-5c1a-42bc-test-481939a93a66",
 	}


### PR DESCRIPTION
parseImageDetails() in source/plugins/go/src/oms.go assumed image strings always matched certain patterns and used fragile index arithmetic. Some valid Kubernetes image formats (especially with digests, nested repository paths, and registries with ports) could cause invalid slicing and trigger a panic, which then leads to downstream socket writer errors and pod restarts.

1. Hardens parseImageDetails() to avoid panics and correctly handle more image formats
File changed: source/plugins/go/src/oms.go
Key improvements:
Adds guards for empty input and for the case where the image becomes empty after stripping a digest (@sha256:...).
Uses strings.LastIndex instead of strings.Index for / and : so it correctly handles nested repo paths like registry.io/org/repo:tag.
Adds logic to distinguish registry port vs tag separator (if : occurs before the last /, treat it as part of host:port, not a tag delimiter).
This prevents slice-out-of-range panics and makes parsing robust for real-world image strings.

2. Updates and expands unit tests
File changed: source/plugins/go/src/oms_test.go
Key updates:
Reformats/cleans up existing test code (indentation, small structural cleanup).
Adds a new test: TestParseImageDetails, covering representative formats including:
ACR image with tag
OpenShift internal registry with port + digest
docker.io image with digest
Ensures expected outputs for imageRepo, imageName, and defaulting tag to "latest" where appropriate.
