### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,79 @@
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Azure Monitor for Containers (Docker-Provider) repository. Review pull requests for correctness, style, security, telemetry coverage, and adherence to project conventions. This repo has Go Fluent Bit plugins, Ruby Fluentd plugins, Shell/PowerShell scripts, and Kubernetes infrastructure.
+
+## Review Philosophy
+1. **Vulnerability management** — CVE fixes and dependency updates are the most common PR type. Verify Trivy scan passes and no new CRITICAL/HIGH CVEs introduced.
+2. **Telemetry coverage** — Missing Application Insights telemetry on error paths and entry points is a frequent gap.
+3. **Cross-platform correctness** — Changes must work on both Linux (Azure Linux/Mariner) and Windows where applicable.
+4. **Container image security** — Dockerfile changes must maintain non-root execution, minimal packages, and pinned base images.
+5. **Test coverage** — PRs adding features or fixing bugs should include corresponding unit tests.
+
+## Scope
+- **Review**: `source/plugins/go/`, `source/plugins/ruby/`, `build/`, `kubernetes/`, `scripts/`, `charts/`, `test/`
+- **Skip**: Auto-generated files, `.pipelines/` (unless security-relevant), `Documentation/` (defer to @DocumentWriter)
+
+## PR Diff Method
+Use `gh pr diff <number>` to get the accurate diff. Do NOT use `git diff origin/ci_prod...HEAD`.
+
+## Review Checklist
+- [ ] Code follows Go/Ruby/Shell/PowerShell conventions (see `.github/instructions/`)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded instrumentation keys
+- [ ] Error handling follows repo patterns (Go: `if err != nil`, Ruby: `begin/rescue`)
+- [ ] Telemetry uses existing `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go)
+- [ ] Container changes maintain Azure Linux 3.0 base, non-root user, minimal packages
+- [ ] Helm chart `Chart.yaml` version bumped if chart content changed
+- [ ] CI checks would pass (Trivy, CodeQL, DevSkim, unit tests)
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Auth tokens validated, not just checked for presence; mTLS for service-to-service
+- [ ] **Tampering** — Input from Kubernetes API validated; config files have restrictive permissions
+- [ ] **Repudiation** — Security-relevant actions logged via Application Insights
+- [ ] **Information Disclosure** — No secrets in logs/errors; env vars for credentials; debug endpoints disabled
+- [ ] **Denial of Service** — Resource limits in k8s manifests; timeouts on HTTP clients; bounded goroutines
+- [ ] **Elevation of Privilege** — Containers run as non-root; RBAC follows least-privilege; no privileged containers
+- [ ] **Credential Leak** — No API keys, tokens, passwords, private keys, or connection strings in changed files
+- [ ] **Weak Patterns** — No disabled TLS, weak crypto, shell injection, or unsafe deserialization
+
+### Telemetry Review Checklist
+- [ ] New error paths emit telemetry via `ApplicationInsightsUtility.sendExceptionTelemetry` (Ruby) or `TelemetryClient.Track*` (Go)
+- [ ] New entry points track operation name, duration, and success/failure
+- [ ] Telemetry follows existing naming conventions (`HeartBeatEvent`, `ExceptionEvent`, etc.)
+- [ ] No sensitive data in telemetry dimensions (no PII, no request bodies)
+- [ ] Telemetry gated for unit tests (`GOUNITTEST`/`ISTEST` env vars)
+
+## Language-Specific Best Practices
+
+### Go
+- **Enforced by CI**: CodeQL static analysis
+- **Reviewer focus**: Error handling completeness, goroutine lifecycle, `sync.Mutex` usage for shared state
+- **Idiomatic patterns**: Table-driven tests, `defer` for cleanup, context propagation
+- **Common issues**: Unchecked errors from HTTP calls, missing `defer resp.Body.Close()`
+
+### Ruby
+- **Reviewer focus**: `frozen_string_literal` pragma, `begin/rescue` with telemetry, `require_relative` usage
+- **Idiomatic patterns**: Dependency injection via constructor defaults, class variable singletons
+- **Common issues**: Missing error telemetry in rescue blocks, hardcoded paths
+
+### Shell
+- **Reviewer focus**: Variable quoting, `set -e` in critical scripts, portability across Ubuntu and Azure Linux
+- **Common issues**: Unquoted variables, missing error handling, distro-specific commands
+
+### PowerShell
+- **Enforced by CI**: PSScriptAnalyzer
+- **Reviewer focus**: Pester test coverage, error handling with try/catch
+
+## Security Checks
+### CI Security Tool Coverage
+- **SAST**: CodeQL (Go, Python, Ruby), DevSkim
+- **Container scanning**: Trivy (CRITICAL, HIGH severity, exit-code 1)
+- **Secret scanning**: Not detected — recommend adding Gitleaks or detect-secrets
+
+## Common Issues to Flag
+- Dependency updates that don't run `go mod tidy` after `go get`
+- Dockerfile changes that add packages without justification
+- Missing Helm chart version bump when chart templates change
+- Ruby plugins without `frozen_string_literal: true`
+- Go code with unguarded concurrent access to shared variables

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,54 @@
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Azure Monitor for Containers (Docker-Provider) repository. Create and maintain documentation that is accurate, consistent with existing docs, and useful for developers working on the container monitoring agent.
+
+## Audience & Tone
+- Primary audience: Infrastructure/platform engineers working on Azure Monitor container agent
+- Secondary audience: Customers using Helm charts for onboarding
+- Tone: Technical, concise, action-oriented
+- Assumed knowledge: Kubernetes, Docker, Azure Monitor basics
+
+## Documentation Structure
+- `README.md` — Repository overview, prerequisites, repo structure
+- `Documentation/` — Detailed guides (agent settings, DCR, Grafana, multi-tenancy, network flow)
+- `ReleaseNotes.md` — Per-version release notes
+- `ReleaseProcess.md` — Release procedures
+- `Dev Guide.md` — Developer onboarding guide
+- `MARINER.md` — Azure Linux (Mariner) specific notes
+- `test/README.md` — Test framework documentation
+- `test/unit-tests/README.md` — Unit test guide
+
+## Writing Conventions
+- ATX-style headings (`#`, `##`, `###`)
+- Fenced code blocks with language annotation (```bash, ```go, ```yaml)
+- Inline code for file paths, commands, and variable names
+- Tables for structured data (settings, parameters)
+- Bullet lists for steps and features
+- No trailing whitespace, LF line endings
+
+## Documentation Types
+- **READMEs**: Overview + quickstart per directory
+- **Operational guides**: Step-by-step procedures in `Documentation/`
+- **Release notes**: Chronological entries in `ReleaseNotes.md`
+- **Onboarding scripts**: Documented in `scripts/onboarding/`
+
+## Templates
+
+### Release Notes Entry
+```markdown
+## Release <version>
+- <Change description> ([#PR_NUMBER](link))
+- <Change description> ([#PR_NUMBER](link))
+```
+
+### Code Comment Conventions
+- Go: Standard godoc comments for exported functions
+- Ruby: Minimal inline comments for complex logic
+- Shell: Comment blocks at top of script explaining purpose and usage
+
+## Validation
+- All file paths referenced must exist in the repository
+- All commands must be verified against actual build/test scripts
+- Code examples must be syntactically valid
+- Release notes must reference actual PR numbers

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,63 @@
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Azure Monitor for Containers (Docker-Provider) repository. You perform deep security assessments that go beyond routine code review. You are invoked explicitly for thorough threat modeling, attack surface analysis, and security architecture review of this container monitoring agent.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist applied to every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR modifies authentication/authorization logic (MSI, FIC, certificate-based auth)
+- New network endpoints or API interactions are added
+- Dockerfile or Kubernetes manifest security contexts change
+- Preparing for a security audit or compliance review
+- After a security incident to assess exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- **Network**: Kubernetes API server connections, MDSD communication, Azure Monitor ingestion endpoints, Application Insights endpoints
+- **Data flows**: Container logs → Fluent Bit → MDSD → Azure Monitor; Kubernetes API → Ruby plugins → MDSD
+- **Trust boundaries**: Host node → container, container → Kubernetes API, container → Azure endpoints
+- **Secrets**: `APPLICATIONINSIGHTS_AUTH`, MSI tokens, certificates, proxy credentials
+
+### 2. STRIDE Deep Analysis
+
+**Spoofing**: Authentication to Kubernetes API (service account tokens, managed identity), Azure Monitor endpoints (MSI/FIC auth), Application Insights (instrumentation key)
+
+**Tampering**: Config file integrity (`container-azm-ms-agentconfig.yaml`), Fluent Bit config manipulation, log injection via container stdout
+
+**Repudiation**: Agent telemetry logging via Application Insights, Kubernetes audit logs for API access
+
+**Information Disclosure**: Secrets in environment variables (proper), secrets in logs (forbidden), verbose error messages, telemetry dimension leakage
+
+**Denial of Service**: Resource limits in DaemonSet/ReplicaSet specs, Fluent Bit buffer limits, API server rate limiting, container OOM protection
+
+**Elevation of Privilege**: Container security context (non-root, read-only filesystem), RBAC permissions (ClusterRole), host mount access (`/var/log`, `/var/lib/docker`)
+
+### 3. Dependency Security Assessment
+- Go modules: Check `go.mod` / `go.sum` across all module directories
+- Ruby gems: Bundled via fluentd; check for known vulnerable gems
+- Container base image: Azure Linux 3.0 packages via `tdnf`
+- CI scanning: Trivy (container + library), CodeQL (SAST), DevSkim (pattern matching)
+
+### 4. Infrastructure Security Review
+- **Container images**: Azure Linux 3.0 distroless final stage, multi-stage builds
+- **Kubernetes**: DaemonSet with hostPath mounts, RBAC ClusterRole permissions
+- **Secret management**: Environment variables from Kubernetes secrets
+- **TLS**: HTTPS for all Azure endpoint communication
+- **Scanning gaps**: No secret scanner (Gitleaks/detect-secrets) in CI — recommend adding
+
+## Output Format
+
+### Findings Summary
+| # | Severity | STRIDE | Finding | Location | Recommendation |
+|---|----------|--------|---------|----------|----------------|
+
+### Positive Security Patterns
+- Multi-stage Docker builds with distroless final image
+- Trivy scanning on every PR with CRITICAL/HIGH exit-code enforcement
+- CodeQL SAST for Go, Python, Ruby
+- DevSkim security pattern scanning
+- MSI-based authentication support (reducing secret exposure)

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,57 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or changes to the Azure Monitor for Containers agent."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider repository. You tailor content to this project's container monitoring architecture, multi-language codebase, and deployment model.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring/observability gap does this solve?
+- Success criteria: how do we know this is working?
+
+### 2. Requirements
+- Functional requirements (what the feature must do)
+- Non-functional requirements (performance impact on agent, resource consumption, security)
+- Out of scope (explicitly state what this does NOT include)
+
+### 3. Architecture
+- Which components are affected? (Go plugins, Ruby plugins, MDSD config, Kubernetes manifests)
+- Data flow: how does data move through Fluent Bit → MDSD → Azure Monitor?
+- API changes: new environment variables, ConfigMap settings, or Helm values
+- Dependencies: Azure services, Kubernetes APIs, external packages
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change (reference actual paths in the repo)
+- Backward compatibility: does this affect existing deployments?
+- Multi-platform: Linux and Windows considerations
+
+### 5. Testing Strategy
+- Unit tests: Go (`go test`), Ruby (minitest), Bash, PowerShell (Pester)
+- E2E tests: Ginkgo suites in `test/ginkgo-e2e/`
+- Integration: TestKube workflows, conformance tests
+- Container image validation: Trivy scan, build verification
+
+### 6. Monitoring & Observability
+- New Application Insights telemetry to add (metrics, events, exceptions)
+- Use existing `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go)
+- Alerting rules or dashboards needed
+- Rollback indicators: what signals mean we should revert?
+
+### 7. Deployment
+- Helm chart changes: `values.yaml`, `Chart.yaml` version bump
+- Kubernetes manifest changes: `ama-logs.yaml`
+- Azure Arc extension impact
+- Rollout: canary → prod via Azure Pipelines (`.pipelines/`)
+- Rollback: revert Helm chart or image tag
+
+## Adaptation Rules
+- Reference the actual paths: `source/plugins/go/`, `source/plugins/ruby/`, `kubernetes/`, `charts/`
+- Architecture section must map to Fluent Bit → MDSD → Azure Monitor pipeline
+- Testing strategy must include Go, Ruby, Bash, and PowerShell test suites
+- Deployment must consider both AKS and Azure Arc scenarios

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+# Repository Instructions
+
+## Summary
+Azure Monitor for Containers (Docker-Provider) agent for Linux and Windows Kubernetes clusters. Primary languages: Ruby (~28%), YAML (~25%), Shell (~16%), Go (~13%), PowerShell (~9%), Python (~8%). Built as Fluent Bit plugins (Go shared objects + Ruby fluentd plugins) packaged into multi-arch Docker images running on Azure Linux (Mariner). Deployed via Helm charts, Kubernetes DaemonSets/ReplicaSets, and Azure Arc extensions.
+
+## General Guidelines
+
+1. Follow existing code patterns — sample 3-5 neighboring files before writing new code.
+2. Never hardcode secrets, instrumentation keys, or connection strings — use environment variables.
+3. All Go code must pass `go vet` and `go test` with `GOUNITTEST=true ISTEST=true`.
+4. Ruby plugins must follow the existing `frozen_string_literal: true` convention and use `require_relative`.
+5. Shell scripts must work on both Ubuntu and Azure Linux (Mariner); avoid distro-specific commands.
+6. PowerShell scripts target Windows Server 2019+ and must pass PSScriptAnalyzer.
+7. Telemetry must use the existing `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go) — never introduce new telemetry SDKs.
+8. Container images use Azure Linux 3.0 (Mariner) as the base — do NOT switch base images without team approval.
+
+## Build Instructions
+
+### Prerequisites
+- Go 1.23.8+, Ruby with fluentd 1.14.2, Docker, Helm 3, build-essential, Python 3
+
+### Linux Build
+```bash
+cd build/linux && make          # Builds Go plugins + installer packages
+```
+
+### Windows Build
+```powershell
+cd build/windows && .\Makefile.ps1
+```
+
+### Docker Image (Linux)
+```bash
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag> --build-arg IMAGE_TAG=<telemetry-tag>
+```
+
+### Tests
+```bash
+# Bash unit tests
+./test/unit-tests/test_main.sh
+
+# Go unit tests
+cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+
+# Ruby unit tests
+./test/unit-tests/run_ruby_tests.sh
+
+# PowerShell unit tests (Windows)
+./test/unit-tests/test_main.ps1
+
+# Ginkgo E2E tests (requires cluster)
+cd test/ginkgo-e2e/<suite> && go test -v ./...
+```
+
+## Known Patterns & Gotchas
+
+- The default branch is `ci_prod`, not `main`.
+- PR targets are `ci_dev` (development) or `ci_prod` (production).
+- Trivy scans run on every PR with `CRITICAL,HIGH` severity and `exit-code: 1` — fix vulnerabilities before merging.
+- Go plugins compile as C shared objects (`.so` files) for Fluent Bit — use `CGO_ENABLED=1`.
+- The `build/version` file controls build versioning — update it for releases.
+- Ruby plugins live under `source/plugins/ruby/` and Go plugins under `source/plugins/go/`.
+- Helm charts in `charts/` must have `Chart.yaml` version bumped for each release.
+- Azure Pipelines (`.pipelines/`) handle production CI/CD; GitHub Actions handle PR checks and security scans.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.go"
+description: Go coding conventions for Fluent Bit plugins and test utilities in this repository.
+---
+
+# Go Conventions
+
+- Use `gofmt` formatting — no manual style overrides.
+- Check every error return: `if err != nil { ... }`. Never discard errors silently.
+- Use the existing `TelemetryClient` (from `appinsights` package) for telemetry — never create new clients.
+- Guard test-only code with `os.Getenv("GOUNITTEST") == "true"` or `os.Getenv("ISTEST") == "true"`.
+- Constants use PascalCase: `ContainerLogDataType`, `InsightsMetricsDataType`.
+- Group imports: stdlib, then external (`github.com/...`), then internal (`Docker-Provider/...`).
+- Shared state uses `sync.Mutex` — protect concurrent access to global variables.
+- Log using the Fluent Bit logger or `log.Printf` — avoid `fmt.Println` in production paths.
+- Go plugins compile as C shared objects — always use `CGO_ENABLED=1` and test with `go test .`.
+- For input plugins under `source/plugins/go/input/`, follow the `calyptia/plugin` pattern.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**/*.ps1,**/*.psm1"
+description: PowerShell conventions for Windows agent build and test scripts.
+---
+
+# PowerShell Conventions
+
+- Use PascalCase for function names and parameters.
+- Use Pester 5.3.3 for unit tests — test files use `*.Tests.ps1` suffix.
+- Run PSScriptAnalyzer for linting before committing.
+- Use `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force` in CI contexts.
+- Use `$env:VARIABLE_NAME` for environment variables.
+- Error handling: use `try/catch/finally` blocks with appropriate logging.
+- Windows container paths use forward slashes or `Join-Path` for portability.
+- Scripts target Windows Server 2019+ (LTSC2019 container images).

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.rb"
+description: Ruby coding conventions for Fluentd plugins in this repository.
+---
+
+# Ruby Conventions
+
+- Always include `# frozen_string_literal: true` as the second line (after shebang).
+- Use `#!/usr/local/bin/ruby` as the shebang line.
+- Use `require_relative` for local imports within `source/plugins/ruby/`.
+- Class variables (`@@`) are the standard pattern for singleton state in Fluentd plugins.
+- Error handling: wrap operations in `begin/rescue/end` and send telemetry in `rescue` blocks using `ApplicationInsightsUtility.sendExceptionTelemetry`.
+- Follow the Fluentd plugin pattern: inherit from `Fluent::Plugin::Input`, `Output`, or `Filter`.
+- Use dependency injection in constructors for testability (pass `nil` defaults for production, mock objects for tests).
+- Use `ENV["VAR_NAME"]` for configuration — never hardcode keys or endpoints.
+- snake_case for methods and variables, PascalCase for class names.
+- Test files use `_test.rb` suffix and live alongside source in `source/plugins/ruby/`.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**/*.sh"
+description: Shell script conventions for build, setup, and operational scripts in this repository.
+---
+
+# Shell Conventions
+
+- Use `#!/bin/bash` shebang for all scripts.
+- Use `set -e` in critical scripts to fail on errors.
+- Quote all variable expansions: `"$VAR"` not `$VAR`.
+- Use uppercase for environment variables, lowercase for local variables.
+- Scripts must work on both Ubuntu and Azure Linux (Mariner) — avoid distro-specific package managers where possible.
+- Use `tdnf` for Azure Linux package management in Dockerfiles, `apt-get` for Ubuntu build machines.
+- For path portability, use `$(dirname "$0")` or `$SCRIPTPATH` patterns (see existing test scripts).
+- Log output with `echo` — prefix informational messages with `#` for test scripts.
+- Exit with explicit codes: `exit 0` for success, `exit 1` for failure.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,56 @@
+# Bug Fix
+
+## Description
+Fix bugs in the container monitoring agent following the repo's patterns for diagnosis, fix, and validation.
+
+USE FOR: fix bug, resolve issue, patch, hotfix, debug, error fix, liveness probe fix
+DO NOT USE FOR: feature development, refactoring, performance optimization, CVE dependency updates
+
+## Instructions
+
+### When to Apply
+When a bug is reported or discovered in agent behavior — log collection issues, liveness probe failures, telemetry gaps, configuration parsing errors, or container startup failures.
+
+### Step-by-Step Procedure
+1. **Reproduce the issue** — Identify the affected component:
+   - Go plugins: `source/plugins/go/src/` or `source/plugins/go/input/`
+   - Ruby plugins: `source/plugins/ruby/`
+   - Container setup: `kubernetes/linux/main.sh`, `kubernetes/linux/setup.sh`
+   - Windows agent: `kubernetes/windows/main.ps1`
+
+2. **Implement the fix** following existing patterns in the affected file.
+
+3. **Add or update tests** — Bug fixes should include a regression test:
+   - Go: Add test case in `source/plugins/go/src/*_test.go`
+   - Ruby: Add test in `source/plugins/ruby/*_test.rb` or `test/unit-tests/test_driver.rb`
+   - Bash: Add test in `test/unit-tests/test_cases/`
+   - PowerShell: Add test in `test/unit-tests/test_cases/*.Tests.ps1`
+
+4. **Run unit tests:**
+   ```bash
+   cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+   ./test/unit-tests/run_ruby_tests.sh
+   ./test/unit-tests/test_main.sh
+   ```
+
+5. **Build and verify:**
+   ```bash
+   cd build/linux && make
+   ```
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` — Go plugin fixes
+- `source/plugins/ruby/*.rb` — Ruby plugin fixes
+- `kubernetes/linux/main.sh` — Container entrypoint fixes
+- `kubernetes/linux/setup.sh` — Setup/install fixes
+
+### Validation
+- All unit tests pass (Go, Ruby, Bash, PowerShell)
+- Linux build succeeds: `cd build/linux && make`
+- Regression test added covering the bug scenario
+
+## Examples from This Repo
+- `fix amaca liveness probe issue in high scale mode (#1530)`
+- `bug fix (#1593)`
+- `fix bug (#1577)`
+- `Fix FIC Auth support issues (#1547)`

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,47 @@
+# CI/CD Pipeline
+
+## Description
+Modify CI/CD pipeline configurations for build, test, release, or deployment workflows.
+
+USE FOR: update pipeline, fix pipeline, modify CI, update workflow, release pipeline, governed pipeline
+DO NOT USE FOR: application code changes, documentation updates, Helm chart changes without pipeline impact
+
+## Instructions
+
+### When to Apply
+When modifying GitHub Actions workflows (`.github/workflows/`) or Azure Pipelines (`.pipelines/`).
+
+### Step-by-Step Procedure
+1. **Identify the pipeline type:**
+   - GitHub Actions: `.github/workflows/` — PR checks (build, scan, unit tests)
+   - Azure Pipelines: `.pipelines/` — Production builds, releases, canary/prod deployments
+
+2. **Make changes** following existing pipeline patterns:
+   - GitHub Actions use `ubuntu-latest` / `windows-2019` runners
+   - Azure Pipelines use governed release YAML templates
+
+3. **Validate YAML syntax** — Ensure valid YAML structure.
+
+4. **Check for security implications:**
+   - No secrets in plain text — use `${{ secrets.NAME }}`
+   - No `--force` flags in deployment commands
+   - Trivy scan settings maintain `CRITICAL,HIGH` severity with `exit-code: 1`
+
+### Files Typically Involved
+- `.github/workflows/pr-checker.yml` — PR build and Trivy scan
+- `.github/workflows/run_unit_tests.yml` — Unit test execution
+- `.github/workflows/codeql-analysis.yml` — CodeQL SAST
+- `.pipelines/azure_pipeline_mergedbranches.yaml` — Production build pipeline
+- `.pipelines/ci-aks-prod-release.yaml` — AKS production release
+- `.pipelines/ci-arc-k8s-extension-prod-release.yaml` — Arc extension release
+
+### Validation
+- YAML syntax is valid
+- No new secrets exposed in plain text
+- Pipeline logic is consistent with existing patterns
+
+## Examples from This Repo
+- `Governed release yamls migration (#1448)`
+- `Migrate all release pipelines to governed release yaml (#1443)`
+- `TAF pipeline fix (#1541)`
+- `Longw/fix pipeline nodepool (#1522)`

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,58 @@
+# Dependency Update
+
+## Description
+Update Go modules, Ruby gems, or system packages to fix vulnerabilities or stay current.
+
+USE FOR: update dependency, bump package, upgrade library, update go.mod, update gems, CVE dependency fix
+DO NOT USE FOR: adding a brand new dependency, major version migration, removing a dependency
+
+## Instructions
+
+### When to Apply
+When a dependency needs updating for security (CVE fix), compatibility, or currency reasons. This is the most common PR type in this repo.
+
+### Step-by-Step Procedure
+1. **Identify the dependency file(s)** to update:
+   - Go: `source/plugins/go/src/go.mod`, `source/plugins/go/input/go.mod`, `test/ginkgo-e2e/*/go.mod`
+   - Ruby: gems installed in `kubernetes/linux/setup.sh`
+   - System packages: `kubernetes/linux/Dockerfile.multiarch` (tdnf), `kubernetes/windows/Dockerfile`
+
+2. **Update Go dependencies:**
+   ```bash
+   cd source/plugins/go/src && go get <package>@<version> && go mod tidy
+   cd source/plugins/go/input && go get <package>@<version> && go mod tidy
+   ```
+
+3. **Update test Go dependencies (if affected):**
+   ```bash
+   cd test/ginkgo-e2e/utils && go get <package>@<version> && go mod tidy
+   ```
+
+4. **Run unit tests:**
+   ```bash
+   cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+   ./test/unit-tests/run_ruby_tests.sh
+   ```
+
+5. **Build and scan:**
+   ```bash
+   cd build/linux && make
+   # Then build Docker image and run Trivy
+   ```
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/linux/setup.sh`
+
+### Validation
+- `go mod tidy` runs without errors for all Go modules
+- Unit tests pass: `GOUNITTEST=true ISTEST=true go test .`
+- Docker image builds successfully
+- Trivy scan shows no new CRITICAL/HIGH vulnerabilities
+
+## Examples from This Repo
+- `3.1.32 CVE fixes (#1596)` — Go module and system package updates
+- `3.1.31 CVEs fixes (#1572)` — Multi-module dependency updates
+- `Longw/Fix CVEs though updating go packages and ruby gem (#1414)` — Cross-language dependency update

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,46 @@
+# Documentation
+
+## Description
+Update documentation, release notes, and README files.
+
+USE FOR: update docs, write README, release notes, changelog, add documentation, chart documentation
+DO NOT USE FOR: code comments only, inline code documentation, API spec generation
+
+## Instructions
+
+### When to Apply
+When creating or updating project documentation, release notes, or onboarding guides.
+
+### Step-by-Step Procedure
+1. **Identify documentation type:**
+   - Release notes: `ReleaseNotes.md`
+   - Project overview: `README.md`
+   - Operational guides: `Documentation/`
+   - Helm chart docs: `charts/azuremonitor-containers/`
+   - Test documentation: `test/README.md`, `test/unit-tests/README.md`
+
+2. **Follow existing formatting conventions:**
+   - ATX-style headings, fenced code blocks with language annotations
+   - Tables for structured data
+   - PR number references in parentheses: `(#1234)`
+
+3. **For release notes:**
+   - Add new entry at the top of `ReleaseNotes.md`
+   - Include version number, date, and change list with PR references
+   - Update `charts/azuremonitor-containers/Chart.yaml` version if applicable
+
+### Files Typically Involved
+- `ReleaseNotes.md`
+- `README.md`
+- `Documentation/` subdirectories
+- `charts/azuremonitor-containers/Chart.yaml`
+
+### Validation
+- All referenced file paths exist
+- All PR number links are valid
+- Markdown renders correctly
+
+## Examples from This Repo
+- `release notes for 3.1.35 (#1608)`
+- `3.1.34 release notes and chart update (#1603)`
+- `add deprecation note for helm chart (#1546)`

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,51 @@
+# Feature Development
+
+## Description
+Add new features to the container monitoring agent — new data streams, authentication methods, cloud support, or telemetry capabilities.
+
+USE FOR: add feature, implement, new stream, new auth, enable support, add cloud support, networkflow, OTLP
+DO NOT USE FOR: bug fixes, refactoring, documentation only, dependency updates
+
+## Instructions
+
+### When to Apply
+When implementing new monitoring capabilities, authentication methods, data streams, or cloud support.
+
+### Step-by-Step Procedure
+1. **Identify affected layers:**
+   - Go plugin changes: `source/plugins/go/src/` or `source/plugins/go/input/`
+   - Ruby plugin changes: `source/plugins/ruby/`
+   - Configuration: `build/common/installer/conf/`, `kubernetes/linux/defaultpromenvvariables*`
+   - Kubernetes manifests: `kubernetes/ama-logs.yaml`
+   - Helm charts: `charts/azuremonitor-containers/`
+
+2. **Implement the feature** following existing plugin patterns:
+   - Go input plugins: Follow `containerinventory` or `perf` plugin pattern in `source/plugins/go/input/`
+   - Go output plugins: Follow `out_oms.go` pattern in `source/plugins/go/src/`
+   - Ruby plugins: Follow Fluentd plugin pattern with `Fluent::Plugin.register_*`
+
+3. **Add telemetry** for the new feature using `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go).
+
+4. **Add unit tests** for new code paths.
+
+5. **Update configuration** if new environment variables or ConfigMap settings are needed.
+
+6. **Update Helm chart** if new values or templates are required.
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` or `source/plugins/go/input/*/`
+- `source/plugins/ruby/*.rb`
+- `kubernetes/ama-logs.yaml`
+- `charts/azuremonitor-containers/values.yaml`
+
+### Validation
+- Unit tests pass for new and existing code
+- Docker image builds successfully
+- Trivy scan passes
+- Feature works in both DaemonSet and ReplicaSet modes
+
+## Examples from This Repo
+- `Added FIC auth support (#1539)`
+- `Enabled OTel logs and traces support (#1527)`
+- `Adding change for networkflow logs new stream (#1551)`
+- `Add high logs scale support for ARC (#1491)`

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,102 @@
+# Fix Critical Vulnerabilities
+
+## Description
+Identify and fix critical/high vulnerabilities using the repo's own scanning tools (Trivy, CodeQL, DevSkim).
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure, dependency vulnerability fix, container image vulnerability
+DO NOT USE FOR: general dependency updates without security motivation, adding new security tools, threat modeling (use security-review), low/medium severity unless explicitly requested
+
+## Instructions
+
+### When to Apply
+When Trivy, CodeQL, or DevSkim reports CRITICAL or HIGH severity findings that must be resolved before merging.
+
+### Step-by-Step Procedure
+
+#### 1. Vulnerability Discovery
+This repo uses the following scanning tools (from CI):
+
+- **Trivy** (container + library): Runs in `.github/workflows/pr-checker.yml` with `severity: CRITICAL,HIGH`, `exit-code: 1`, `ignore-unfixed: true`
+- **CodeQL**: Runs in `.github/workflows/codeql-analysis.yml` for Go, Python, Ruby
+- **DevSkim**: Runs in `.github/workflows/devskim.yml` for security pattern matching
+
+Run locally:
+```bash
+# Build the container image first
+cd build/linux && make
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t test:latest
+
+# Scan container image
+trivy image --severity CRITICAL,HIGH --ignore-unfixed test:latest
+
+# Scan Go dependencies
+trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/
+
+# Scan all Go modules
+for mod in source/plugins/go/src source/plugins/go/input test/ginkgo-e2e/utils; do
+  echo "=== Scanning $mod ==="
+  trivy fs --severity CRITICAL,HIGH --scanners vuln "$mod/"
+done
+```
+
+#### 2. Vulnerability Triage
+- **Direct Go dependencies**: Listed in `go.mod` `require` block — directly fixable
+- **Transitive Go dependencies**: `// indirect` entries — bump parent dependency
+- **OS/base image packages**: Azure Linux 3.0 packages in `setup.sh` / Dockerfile
+- **Ruby gems**: Installed in `setup.sh` — check for newer gem versions
+
+#### 3. Fix Implementation
+
+**Go module vulnerabilities:**
+```bash
+cd source/plugins/go/src && go get <package>@<fixed-version> && go mod tidy
+cd source/plugins/go/input && go get <package>@<fixed-version> && go mod tidy
+# Update test modules if affected
+cd test/ginkgo-e2e/utils && go get <package>@<fixed-version> && go mod tidy
+```
+
+**Container base image vulnerabilities:**
+- Check for newer Azure Linux base image tags in `Dockerfile.multiarch`
+- Update `FROM` line if newer tag available
+
+**OS package vulnerabilities:**
+- Update package versions in `kubernetes/linux/setup.sh` (tdnf install)
+- For unfixed upstream packages, document and accept risk
+
+**Ruby gem vulnerabilities:**
+- Update gem version in `kubernetes/linux/setup.sh` install commands
+- Example: `CVE 202543857: uninstall net-imap gem (#1480)`
+
+#### 4. Build and Test
+```bash
+# Build
+cd build/linux && make
+
+# Run unit tests
+cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+./test/unit-tests/run_ruby_tests.sh
+./test/unit-tests/test_main.sh
+
+# Rebuild and re-scan
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t test:latest
+trivy image --severity CRITICAL,HIGH --ignore-unfixed test:latest
+```
+
+#### 5. Commit
+Follow the repo's commit pattern:
+- Single CVE: `fix CVE-YYYY-NNNNN in <package> (#PR)`
+- Batch: `CVE fixes (#PR)` or `address vulnerabilities (#PR)`
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/linux/setup.sh`
+- `.github/workflows/pr-checker.yml` (to understand scan flags)
+
+### Validation
+- Build succeeds for Linux: `cd build/linux && make`
+- All unit tests pass
+- Re-scan shows targeted CVEs resolved
+- No new CRITICAL/HIGH vulnerabilities introduced

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,57 @@
+# Infrastructure
+
+## Description
+Modify container images, Kubernetes manifests, Helm charts, or build infrastructure.
+
+USE FOR: update Dockerfile, modify Helm chart, change Kubernetes manifest, upgrade base image, update Fluent Bit, upgrade Telegraf, Mariner upgrade
+DO NOT USE FOR: application logic changes, unit test changes, documentation-only updates
+
+## Instructions
+
+### When to Apply
+When changing container build infrastructure, base images, system packages, Kubernetes deployment manifests, or Helm charts.
+
+### Step-by-Step Procedure
+1. **Identify the infrastructure component:**
+   - Dockerfiles: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+   - Helm charts: `charts/azuremonitor-containers/`, `charts/azuremonitor-containers-geneva/`
+   - K8s manifests: `kubernetes/ama-logs.yaml`
+   - Build system: `build/linux/Makefile`, `build/windows/Makefile.ps1`
+
+2. **For Dockerfile changes:**
+   - Maintain Azure Linux 3.0 (Mariner) as base image
+   - Use multi-stage builds (golang-builder → builder → distroless)
+   - Minimize installed packages — document justification for new packages
+   - Ensure final image uses distroless base
+
+3. **For Helm chart changes:**
+   - Bump version in `Chart.yaml`
+   - Update `values.yaml` if new configuration added
+   - Update templates if manifest structure changes
+
+4. **Build and scan:**
+   ```bash
+   cd build/linux && make
+   cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t test:latest
+   trivy image --severity CRITICAL,HIGH test:latest
+   ```
+
+### Files Typically Involved
+- `kubernetes/linux/Dockerfile.multiarch` — Linux container image
+- `kubernetes/linux/setup.sh` — Package installation and configuration
+- `kubernetes/linux/main.sh` — Container entrypoint
+- `charts/azuremonitor-containers/Chart.yaml` — Chart version
+- `charts/azuremonitor-containers/values.yaml` — Default values
+- `kubernetes/ama-logs.yaml` — Kubernetes deployment manifest
+
+### Validation
+- Docker image builds for both amd64 and arm64
+- Trivy scan passes with no new CRITICAL/HIGH vulnerabilities
+- Helm chart lints: `helm lint charts/azuremonitor-containers/`
+- Unit tests still pass after infrastructure changes
+
+## Examples from This Repo
+- `Mariner 3 upgrade (#1439)`
+- `Upgrade Fluent Bit to 4.0.9 (#1535)`
+- `Upgrade Telegraf 1.34.3 (#1434)`
+- `Fluent bit 4.0.14 (#1601)`

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,88 @@
+# Security Review
+
+## Description
+Perform a STRIDE-based security review of code changes in the Docker-Provider repository.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit, hardening review
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## Instructions
+
+### When to Apply
+Apply to every PR that modifies authentication/authorization logic, network-facing code, data handling, infrastructure (Dockerfiles, Helm charts, Kubernetes manifests), or dependency changes.
+
+### Step-by-Step Procedure
+
+#### 1. STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Authentication checks present at Kubernetes API access points (service account tokens)
+- MSI/FIC tokens validated before use in Azure Monitor communication
+- Certificates validated for agent-to-MDSD communication
+
+**Tampering (Data Integrity)**
+- Input from Kubernetes API validated before processing
+- ConfigMap settings validated before application
+- File permissions restrictive in container (check `setup.sh`, Dockerfile `chmod`)
+
+**Repudiation (Auditability)**
+- Security-relevant actions logged via Application Insights telemetry
+- Agent startup/shutdown events tracked
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets (check for `APPLICATIONINSIGHTS_AUTH`, proxy passwords, certificates)
+- No secrets in log output or error messages
+- Environment variables used for all sensitive configuration
+- `.gitignore` excludes `*.so`, `*.pyc`, intermediate build artifacts
+
+**Denial of Service (Availability)**
+- Resource limits set in Kubernetes manifests (`ama-logs.yaml`)
+- HTTP client timeouts configured for API calls
+- Fluent Bit buffer limits configured
+- Goroutines bounded (no goroutine leaks in Go plugins)
+
+**Elevation of Privilege (Authorization)**
+- Containers run with minimal RBAC (check ClusterRole in `ama-logs.yaml`)
+- Dockerfile uses non-root USER where possible
+- No privileged containers or hostNetwork unless justified
+- Security contexts set (readOnlyRootFilesystem where applicable)
+
+#### 2. Credential & Secret Leak Detection
+- Scan for hardcoded strings matching secret patterns (API keys, tokens, connection strings)
+- Check for Base64-encoded instrumentation keys
+- Verify `.gitignore` excludes secret file patterns
+- Check test fixtures for real credentials
+
+#### 3. Weak Security Patterns
+
+**Go:**
+- `#nosec` annotations must have justification comments
+- No unchecked `err` from crypto/auth/TLS functions
+- No `fmt.Sprintf` for SQL queries or command construction
+- No `exec.Command` with unsanitized input
+
+**Ruby:**
+- No `eval`, `send` with user-controlled input
+- No `YAML.load` (use `YAML.safe_load`)
+- No `system()` with unsanitized input
+
+**Shell:**
+- No unquoted variables in commands
+- No `chmod 777`
+- No secrets as command-line arguments
+- `set -e` in security-critical scripts
+
+**Infrastructure (Dockerfiles, k8s):**
+- No `latest` tags in FROM instructions
+- No secrets in ENV instructions
+- Non-root USER directive
+- Missing security contexts flagged
+
+#### 4. CI Security Integration
+- **Active**: CodeQL (Go, Python, Ruby), DevSkim, Trivy (container + library scanning)
+- **Gap**: No secret scanner (Gitleaks/detect-secrets) — recommend adding
+
+### Validation
+- Trivy scan passes: `trivy image --severity CRITICAL,HIGH <image>`
+- `.gitignore` excludes sensitive file patterns
+- `SECURITY.md` exists with responsible disclosure process

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,71 @@
+# Telemetry Authoring
+
+## Description
+Add Application Insights telemetry following the existing patterns in this repository.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add logging, add Application Insights, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+When adding telemetry instrumentation to new or existing code paths in Go plugins or Ruby plugins.
+
+### Step-by-Step Procedure
+
+#### 1. Telemetry Pattern Discovery
+Before adding ANY telemetry, identify the existing pattern:
+
+**Go plugins** (`source/plugins/go/src/`):
+- SDK: `github.com/microsoft/ApplicationInsights-Go/appinsights`
+- Client: `TelemetryClient` (global singleton initialized in `telemetry.go`)
+- Init: `appinsights.NewTelemetryClient(ikey)` with proxy support
+- Events: `TelemetryClient.TrackEvent(name, properties)` / `TelemetryClient.TrackMetric(name, value)`
+- Properties: `CommonProperties` map includes `Computer`, `AgentVersion`, `ControllerType`, `ContainerRuntime`
+- Env guards: Check `GOUNITTEST` / `ISTEST` before initializing telemetry
+
+**Ruby plugins** (`source/plugins/ruby/`):
+- Utility: `ApplicationInsightsUtility` class in `ApplicationInsightsUtility.rb`
+- Methods: `sendExceptionTelemetry(error)`, `sendCustomEvent(eventName, properties)`, `sendMetricTelemetry(name, value, properties)`
+- Properties: `@@CustomProperties` includes cluster type, region, agent version, controller type
+- Env guards: Telemetry skipped when `APPLICATIONINSIGHTS_AUTH` env var is empty
+
+#### 2. What to Instrument (priority order)
+
+a. **Error paths** — Every `rescue`/`if err != nil` block for unexpected failures:
+   - Ruby: `ApplicationInsightsUtility.sendExceptionTelemetry(error)`
+   - Go: `TelemetryClient.TrackException(err)` with context properties
+
+b. **Entry points** — HTTP handlers, Fluent Bit plugin callbacks, timer-based collection:
+   - Track operation name, duration, success/failure
+
+c. **External calls** — Kubernetes API calls, Azure Monitor ingestion, MDSD communication:
+   - Track target, duration, response status/error
+
+d. **Custom events** — State transitions, configuration changes, feature flag activation:
+   - Ruby: `ApplicationInsightsUtility.sendCustomEvent("EventName", {"key" => "value"})`
+   - Go: `TelemetryClient.TrackEvent("EventName")` with properties
+
+#### 3. Naming Conventions
+- Events: PascalCase descriptive names (e.g., `HeartBeatEvent`, `ExceptionEvent`, `ContainerLogFlush`)
+- Metrics: Descriptive names with component prefix (e.g., `FlushedRecordsCount`, `FlushedRecordsSize`)
+- Properties: PascalCase keys matching `CommonProperties` pattern (`Computer`, `ControllerType`, `ContainerRuntime`)
+
+#### 4. Anti-Patterns to Avoid
+- Do NOT log sensitive data (credentials, tokens, PII)
+- Do NOT add telemetry inside tight loops
+- Do NOT create new `TelemetryClient` instances — use the existing singleton
+- Do NOT emit telemetry in unit test code paths (respect `GOUNITTEST`/`ISTEST` guards)
+- Do NOT hardcode instrumentation keys — use `APPLICATIONINSIGHTS_AUTH` env var
+
+#### 5. Validation
+- Verify import matches existing files (`ApplicationInsightsUtility` for Ruby, `appinsights` for Go)
+- Verify event/metric names follow PascalCase convention
+- Run unit tests to ensure telemetry additions don't break test isolation
+- Check that telemetry is gated for unit test environments
+
+### Files Typically Involved
+- `source/plugins/go/src/telemetry.go` — Go telemetry setup and helpers
+- `source/plugins/go/input/lib/applicationinsights.go` — Input plugin telemetry
+- `source/plugins/ruby/ApplicationInsightsUtility.rb` — Ruby telemetry utility
+- Any plugin file that handles data collection or error paths

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,62 @@
+# Test Authoring
+
+## Description
+Add tests for new or existing code following the repo's multi-language test patterns.
+
+USE FOR: add test, write test, test coverage, add unit test, add e2e test, add integration test
+DO NOT USE FOR: fixing flaky tests, test infrastructure changes, CI pipeline changes
+
+## Instructions
+
+### When to Apply
+When new code needs test coverage or existing code lacks sufficient tests.
+
+### Step-by-Step Procedure
+1. **Determine test type and framework:**
+   - Go unit tests: `go test` with `_test.go` files
+   - Ruby unit tests: minitest via `test_driver.rb`
+   - Bash unit tests: Custom framework in `test/unit-tests/test_framework.sh`
+   - PowerShell unit tests: Pester 5.3.3 with `*.Tests.ps1` files
+   - E2E tests: Ginkgo (Go) in `test/ginkgo-e2e/`
+
+2. **Place test files correctly:**
+   - Go: `source/plugins/go/src/*_test.go` (alongside source)
+   - Ruby: `source/plugins/ruby/*_test.rb` or `test/unit-tests/test_driver.rb`
+   - Bash: `test/unit-tests/test_cases/test_*.sh`
+   - PowerShell: `test/unit-tests/test_cases/*.Tests.ps1`
+   - Ginkgo E2E: `test/ginkgo-e2e/<suite-name>/`
+
+3. **Follow existing test patterns:**
+   - Go: Use `GOUNITTEST=true ISTEST=true` environment guards; use `go generate` for mocks
+   - Ruby: Dependency injection via constructor for testability
+   - Bash: Source `test_framework.sh`, use `assert_*` functions
+   - PowerShell: `Describe`/`It`/`Should` Pester blocks
+
+4. **Run tests:**
+   ```bash
+   # Go
+   cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+   # Ruby
+   ./test/unit-tests/run_ruby_tests.sh
+   # Bash
+   ./test/unit-tests/test_main.sh
+   # PowerShell (Windows)
+   ./test/unit-tests/test_main.ps1
+   ```
+
+### Files Typically Involved
+- `source/plugins/go/src/*_test.go`
+- `source/plugins/ruby/*_test.rb`
+- `test/unit-tests/test_cases/test_*.sh`
+- `test/unit-tests/test_cases/*.Tests.ps1`
+- `test/ginkgo-e2e/*/`
+
+### Validation
+- New tests pass in isolation
+- All existing tests continue to pass
+- Tests cover the target behavior (happy path + error cases)
+
+## Examples from This Repo
+- `Test Automation Framework improvements (#1449)`
+- `Update conformnace test (#1452)`
+- `Testkube workflow migration (#1589)`

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Prerequisites: Go 1.23.8+, Ruby, fluentd 1.14.2, Docker, Helm 3, build-essential, Python 3
+
+# Install Ruby dependencies (for unit tests)
+sudo gem install fluentd -v "1.14.2" --no-document
+sudo gem install ipaddress --no-document
+
+# Build Linux agent (Go plugins + installer)
+cd build/linux && make
+
+# Build Windows agent (requires Windows)
+cd build/windows && .\Makefile.ps1
+```
+
+## Code Style
+
+### Go (source/plugins/go/)
+- Standard Go formatting (`gofmt`)
+- PascalCase for exported identifiers, camelCase for local variables
+- Constants use PascalCase with descriptive names (e.g., `ContainerLogDataType`)
+- Imports grouped: stdlib, external packages, internal packages
+- Error handling: check every error return, log with `Log(message)` or `FLBPluginLogMessage`
+- Use `sync.Mutex` for shared state; avoid global mutable state where possible
+- Test files use `_test.go` suffix; run with `GOUNITTEST=true ISTEST=true`
+
+### Ruby (source/plugins/ruby/)
+- `frozen_string_literal: true` on every file
+- Class variables (`@@`) for singleton state (following fluentd plugin pattern)
+- `require_relative` for local imports
+- PascalCase for class names, snake_case for methods and variables
+- `begin/rescue/end` blocks for error handling with telemetry in rescue
+- Fluentd plugin pattern: inherit from `Fluent::Plugin::Input` / `Output` / `Filter`
+
+### Shell (scripts/, build/, kubernetes/)
+- Bash with `#!/bin/bash` shebang
+- Use `set -e` for error-on-failure in critical scripts
+- Quote all variables: `"$VAR"` not `$VAR`
+- Uppercase for environment variables, lowercase for local variables
+
+### PowerShell (build/windows/, kubernetes/windows/)
+- `.ps1` extension, PascalCase function names
+- Uses Pester 5.3.3 for testing
+- PSScriptAnalyzer for linting
+
+## Testing Instructions
+
+### Unit Tests (CI runs on every PR)
+```bash
+# Bash unit tests
+chmod +x test/unit-tests/test_main.sh
+./test/unit-tests/test_main.sh
+
+# Go unit tests
+cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .
+
+# Ruby unit tests
+./test/unit-tests/run_ruby_tests.sh
+
+# PowerShell unit tests (Windows only)
+./test/unit-tests/test_main.ps1
+```
+
+### E2E Tests
+- Ginkgo-based tests in `test/ginkgo-e2e/` (querylogs, containerstatus, livenessprobe)
+- TestKube-based tests in `test/testkube/`
+- Conformance tests in `test/e2e/`
+
+### Test file locations
+- Bash: `test/unit-tests/test_cases/test_*.sh`
+- Go: `source/plugins/go/src/*_test.go`
+- Ruby: `source/plugins/ruby/*_test.rb`, `test/unit-tests/test_driver.rb`
+- PowerShell: `test/unit-tests/test_cases/*.Tests.ps1`
+
+## Dev Environment Tips
+
+- Default branch is `ci_prod` — PRs target `ci_dev` or `ci_prod`
+- Go plugins need `CGO_ENABLED=1` and cmetrics library installed
+- For arm64 cross-compilation: install `gcc-aarch64-linux-gnu`
+- Container base image: `mcr.microsoft.com/azurelinux/base/core:3.0`
+- Telemetry uses Application Insights — key via `APPLICATIONINSIGHTS_AUTH` env var
+- Log paths: Linux `/var/opt/microsoft/docker-cimprov/log/`, Windows `/etc/amalogswindows/`
+
+## PR Instructions
+
+- **Commit messages**: Freeform with PR number suffix (e.g., `Fix liveness probe issue (#1530)`)
+- **Branch naming**: Feature branches use `<alias>/<description>` pattern
+- **Required checks**: Linux build + Trivy scan, Windows build, unit tests (Bash, Go, Ruby, PowerShell)
+- **Security**: CodeQL (Go, Python, Ruby) and DevSkim run on `ci_prod`
+- **Merge**: Squash merge is standard; PR titles become commit messages
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    A[Kubernetes Cluster] --> B[DaemonSet: ama-logs]
+    A --> C[ReplicaSet: ama-logs-rs]
+    B --> D[Fluent Bit + Go Plugins]
+    B --> E[Ruby Fluentd Plugins]
+    D --> F[MDSD / Azure Monitor Agent]
+    E --> F
+    F --> G[Azure Monitor / Log Analytics]
+    F --> H[Azure Monitor Metrics]
+    C --> I[KubernetesApiClient]
+    I --> J[Kubernetes API Server]
+    B --> K[Application Insights Telemetry]
+    C --> K
+    L[Helm Charts] --> A
+    M[Azure Arc Extension] --> A
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,73 @@
+# Docker-Provider (Azure Monitor for Containers)
+
+Azure Monitor for Containers agent — collects container logs, metrics, inventory, and events from Kubernetes clusters (AKS, Arc-enabled, hybrid) and forwards them to Azure Monitor / Log Analytics.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log pipeline | Fluent Bit (output/input Go plugins) + Fluentd (Ruby plugins) |
+| Telemetry SDK | Application Insights (Go + Ruby) |
+| Agent framework | Azure Monitor Agent (MDSD) |
+| Container runtime | Azure Linux 3.0 (Mariner) distroless base |
+| Build system | Make (Linux), PowerShell (Windows) |
+| CI/CD | GitHub Actions (PR checks), Azure Pipelines (releases) |
+| Package format | RPM + DEB (Linux), Docker images (multi-arch) |
+| Deployment | Helm charts, Kubernetes DaemonSet/ReplicaSet, Azure Arc extensions |
+| E2E testing | Ginkgo (Go), TestKube, conformance YAML |
+| Unit testing | Go test, Ruby minitest, Bash test framework, Pester (PowerShell) |
+| Languages | Ruby, Go, Shell, PowerShell, Python, YAML |
+
+## Architecture Overview
+
+The agent runs as a DaemonSet (per-node) and ReplicaSet (cluster-level) in Kubernetes. Fluent Bit collects container logs and metrics via Go input/output plugins. Ruby Fluentd plugins handle Kubernetes API inventory (nodes, pods, events) and MDM metric filtering. Data flows through MDSD (Azure Monitor Agent) to Azure Monitor / Log Analytics workspaces.
+
+## Functional Requirements
+### 1) Container log collection via Fluent Bit with configurable schemas (ContainerLogV2)
+### 2) Kubernetes inventory collection (nodes, pods, containers, events) via API server
+### 3) Performance metrics (CPU, memory, network) via cAdvisor and Telegraf
+### 4) MDM/Azure Monitor Metrics forwarding for alerting
+### 5) Multi-arch support (amd64 + arm64) for Linux and Windows
+### 6) Azure Arc extension support for non-AKS clusters
+
+## Non-Functional Requirements
+- Trivy vulnerability scanning on every PR (CRITICAL/HIGH must pass)
+- CodeQL SAST for Go, Python, Ruby
+- DevSkim security pattern scanning
+- Container runs as non-root where possible
+- Secrets via environment variables only (APPLICATIONINSIGHTS_AUTH, etc.)
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/go/src/` | Go Fluent Bit output plugin (out_oms) |
+| `source/plugins/go/input/` | Go Fluent Bit input plugins (containerinventory, perf) |
+| `source/plugins/ruby/` | Ruby Fluentd plugins (inventory, metrics, filters) |
+| `build/linux/Makefile` | Linux build system |
+| `build/windows/Makefile.ps1` | Windows build system |
+| `kubernetes/linux/Dockerfile.multiarch` | Linux container image |
+| `kubernetes/windows/Dockerfile` | Windows container image |
+| `charts/azuremonitor-containers/` | Public Helm chart |
+| `test/unit-tests/` | Unit tests (Bash, Go, Ruby, PowerShell) |
+| `test/ginkgo-e2e/` | Ginkgo E2E test suites |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `APPLICATIONINSIGHTS_AUTH` | Application Insights instrumentation key (base64) |
+| `APPLICATIONINSIGHTS_ENDPOINT` | AI ingestion endpoint |
+| `AKS_RESOURCE_ID` | AKS cluster resource ID |
+| `ACS_RESOURCE_NAME` | Non-AKS resource name |
+| `CONTROLLER_TYPE` | DaemonSet or ReplicaSet |
+| `CONTAINER_RUNTIME` | Container runtime (docker/containerd) |
+| `OS_TYPE` | Operating system (linux/windows) |
+| `AAD_MSI_AUTH_MODE` | AAD MSI authentication mode |
+
+## Acceptance Criteria
+- Linux and Windows Docker images build successfully
+- Trivy scan passes with no CRITICAL/HIGH vulnerabilities (unfixed excluded)
+- All unit tests pass (Bash, Go, Ruby, PowerShell)
+- CodeQL and DevSkim scans produce no new findings
+- Helm chart version bumped for releases

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,144 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Docker-Provider repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand this codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `copilot-instructions.md` on every session — no action needed.
+3. When you open a file matching a language pattern, the corresponding `.instructions.md` file auto-activates.
+4. Invoke skills by typing their trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them in chat (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically every session | Root router — general rules, build commands, conventions |
+| `AGENTS.md` | Root | Automatically (supported tools) | Setup commands, code style, testing instructions, architecture |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match (`applyTo` glob) | Language-specific coding rules (Go, Ruby, Shell, PowerShell) |
+| `Prompt.md` | Root | On demand | Reusable task-spec template for new work |
+| Skill files (`SKILL.md`) | `.github/skills/` | On keyword trigger | Step-by-step guides for recurring tasks |
+| `CodeReviewer.agent.md` | `.github/agents/` | On @-mention | Structured code review with STRIDE security |
+| `SecurityReviewer.agent.md` | `.github/agents/` | On @-mention | Deep security analysis and threat modeling |
+| `DocumentWriter.agent.md` | `.github/agents/` | On @-mention | Documentation authoring following repo standards |
+| `prd.agent.md` | `.github/agents/` | On @-mention | PRD generation tailored to this project |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically by VS Code | MCP server configuration (GitHub, Microsoft Docs) |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: copilot-instructions.md (always loaded)
+  ├── General rules, build commands, conventions
+  ├── Routes to →
+  │
+Layer 2: .instructions.md files (auto-loaded when you open matching files)
+  ├── go.instructions.md → activates for *.go files
+  ├── ruby.instructions.md → activates for *.rb files
+  ├── shell.instructions.md → activates for *.sh files
+  ├── powershell.instructions.md → activates for *.ps1 files
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Reviews PRs for correctness, style, STRIDE security, telemetry gaps, and project conventions.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review my changes for telemetry gaps`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates and maintains documentation following repo doc conventions.
+- **Example prompts:**
+  - `@DocumentWriter write release notes for version 3.1.36`
+  - `@DocumentWriter update the README`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Deep security analysis including threat modeling, STRIDE deep-dive, and dependency auditing.
+- **Example prompts:**
+  - `@SecurityReviewer perform a threat model for the new auth changes`
+  - `@SecurityReviewer audit our container security configuration`
+- **When to use:** For dedicated security analysis beyond routine code review — before releases or after architecture changes.
+
+### @prd (PRD Generator)
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **What it does:** Generates structured PRDs tailored to this project's container monitoring architecture.
+- **Example prompts:**
+  - `@prd create a PRD for adding OpenTelemetry metrics support`
+  - `@prd write requirements for Windows ARM64 support`
+
+## Using Skills
+
+Skills activate when you use their trigger phrases in chat. Just describe what you want to do naturally.
+
+### Always-Available Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "threat model", "STRIDE analysis" | STRIDE-based security review and credential scanning |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Guides adding Application Insights telemetry |
+| `fix-critical-vulnerabilities` | "fix critical vulnerability", "CVE fix", "trivy fix" | Identifies and fixes CRITICAL/HIGH CVEs |
+
+### Commit-History-Driven Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `dependency-update` | "update dependency", "bump package", "update go.mod" | Safe dependency updates across Go modules |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix workflow with regression tests |
+| `ci-cd-pipeline` | "update pipeline", "fix pipeline", "modify CI" | CI/CD pipeline modifications |
+| `infrastructure` | "update Dockerfile", "modify Helm chart", "upgrade base image" | Container and infrastructure changes |
+| `feature-development` | "add feature", "implement", "new stream" | New feature scaffolding |
+| `test-authoring` | "add test", "write test" | Test creation following repo patterns |
+| `documentation` | "update docs", "release notes", "write README" | Documentation updates |
+
+**Example usage:**
+```
+# In Copilot Chat, just describe the task:
+"Fix the critical CVE in our Go dependencies"
+"Add telemetry to the new network flow log handler"
+"Update the Dockerfile to Fluent Bit 4.1"
+"Add a unit test for the container inventory plugin"
+```
+
+## Using Prompt.md for New Work
+
+`Prompt.md` is a reusable template for describing new tasks or features. Copy it and fill in sections when starting complex work.
+
+## MCP Server Integration
+
+The `.vscode/mcp.json` configures:
+- **GitHub MCP:** PR management, issues, and branch operations from chat.
+- **Microsoft Docs MCP:** Azure documentation search for validating patterns against official docs.
+
+## Tips for Maximum Productivity
+
+1. **Let auto-loading work** — Just open the file. Language-specific rules activate automatically.
+2. **Use natural language** — Don't invoke skills by name. Just describe: "add a test", "fix the CVE".
+3. **Start reviews with @CodeReviewer** — It knows the team's patterns, linter rules, and security requirements.
+4. **Use @prd before big features** — A structured PRD helps scope the work before writing code.
+5. **Check AGENTS.md for setup** — If the AI struggles with build commands, verify they match your environment.
+
+## Customizing These Artifacts
+
+These files evolve with the project:
+- **Add rules** to `.instructions.md` when new conventions are established.
+- **Add skills** when you identify recurring workflows.
+- **Update `copilot-instructions.md`** when build commands or project structure change.
+- **Re-run generation** periodically to refresh skills from commit patterns.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow Go conventions | Check `.github/instructions/go.instructions.md` `applyTo` matches `**/*.go` |
+| Skill not activating | Use exact trigger phrases from the skill table above |
+| Agent not available | Ensure `.github/agents/*.agent.md` files exist |
+| Build commands fail | Update Setup Commands in `AGENTS.md` to match current environment |
+| Trivy scan fails | Run `trivy image --severity CRITICAL,HIGH --ignore-unfixed <image>` locally |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,53 @@
+# Test Framework Guide
+
+## Test Decision Tree
+When adding tests, use this decision tree:
+
+1. **Pure Go plugin logic with no external dependencies?** → Go unit test (`go test` with `_test.go`)
+2. **Ruby plugin logic with mock Kubernetes API?** → Ruby unit test (minitest via `test_driver.rb`)
+3. **Bash script behavior (installer, setup, entrypoint)?** → Bash unit test (`test_framework.sh`)
+4. **PowerShell script behavior (Windows agent)?** → Pester test (`*.Tests.ps1`)
+5. **Agent behavior on a real cluster?** → Ginkgo E2E test (`test/ginkgo-e2e/`)
+6. **Full deployment validation?** → TestKube or conformance test (`test/testkube/`, `test/e2e/`)
+
+## Test Patterns in This Repo
+
+### Go Unit Tests
+- Framework: `go test` (stdlib)
+- Mocking: `go generate` with `github.com/golang/mock`
+- Location: `source/plugins/go/src/*_test.go`
+- Environment: Set `GOUNITTEST=true ISTEST=true` to guard test code paths
+- Command: `cd source/plugins/go/src && GOUNITTEST=true ISTEST=true go test .`
+
+### Ruby Unit Tests
+- Framework: minitest (via fluentd test infrastructure)
+- Location: `source/plugins/ruby/*_test.rb`, invoked via `test/unit-tests/test_driver.rb`
+- Pattern: Dependency injection in constructors enables mock objects in tests
+- Command: `./test/unit-tests/run_ruby_tests.sh`
+
+### Bash Unit Tests
+- Framework: Custom (`test/unit-tests/test_framework.sh`)
+- Location: `test/unit-tests/test_cases/test_*.sh`
+- Functions: `test/unit-tests/test_functions/*.sh`
+- Command: `./test/unit-tests/test_main.sh`
+
+### PowerShell Unit Tests
+- Framework: Pester 5.3.3
+- Location: `test/unit-tests/test_cases/*.Tests.ps1`
+- Command: `./test/unit-tests/test_main.ps1`
+
+### Ginkgo E2E Tests
+- Framework: Ginkgo v2 + Gomega
+- Suites: `test/ginkgo-e2e/querylogs/`, `containerstatus/`, `livenessprobe/`
+- Shared utilities: `test/ginkgo-e2e/utils/`
+- Requires: Running Kubernetes cluster with agent deployed
+
+### Conformance / TestKube Tests
+- Config: `test/e2e/conformance.yaml`, `test/testkube/`
+- Purpose: Validate end-to-end agent deployment and data collection
+
+## Common Test Utilities
+- `test/unit-tests/test_framework.sh` — Bash test runner with assertions
+- `test/unit-tests/test_driver.rb` — Ruby test runner
+- `test/unit-tests/canned-api-responses/` — Mock Kubernetes API responses
+- `test/ginkgo-e2e/utils/` — Shared Go E2E utilities (Azure SDK, K8s API helpers)


### PR DESCRIPTION
## Summary

Auto-generated AI agent artifacts for coding assistants.

### What's included
- `copilot-instructions.md` — root instructions for AI agents
- `AGENTS.md` — setup, style, and testing instructions
- `Prompt.md` — structured prompt template
- `.instructions.md` files — language-specific conventions (Go, Ruby, Shell, PowerShell)
- `SKILL.md` files — task-specific skills derived from commit history (dependency-update, bug-fix, ci-cd-pipeline, infrastructure, feature-development, test-authoring, documentation, security-review, telemetry-authoring, fix-critical-vulnerabilities)
- Agent definitions: CodeReviewer, SecurityReviewer, DocumentWriter, prd
- `.vscode/mcp.json` — MCP server configuration (GitHub, Microsoft Docs)
- `test/AGENTS.md` — test framework guide
- `coding-agent-instructions.md` — user guide for all artifacts

### How to verify
1. Open the repo in VS Code / GitHub Codespaces
2. Start a Copilot Chat session
3. Verify agents respond correctly: `@CodeReviewer`, `@SecurityReviewer`, `@DocumentWriter`, `@prd`
4. Check that `.instructions.md` files activate for matching file types

> Auto-generated by the agentify prompt. Review before merging.