### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,100 @@
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Docker-Provider (Azure Monitor Container Insights) repository. Your job is to review pull requests and code changes for correctness, style, security, and adherence to project conventions. This repo contains Ruby Fluentd plugins, Go Fluent Bit plugins, Shell/PowerShell scripts, and Kubernetes infrastructure.
+
+## Review Philosophy
+1. **CVE/vulnerability management** — Most PRs involve dependency updates and Trivy fixes. Verify vulnerable packages are actually updated and scans pass.
+2. **Telemetry consistency** — Verify new code follows existing Application Insights patterns (Ruby: `ApplicationInsightsUtility`, Go: `appinsights` SDK).
+3. **Multi-arch compatibility** — Changes must work on both amd64 and arm64. Check for architecture-specific code paths.
+4. **Test coverage** — Bug fixes should include regression tests. New features need unit tests.
+5. **Container security** — Dockerfile changes should maintain non-root user, minimal packages, and pinned base images.
+
+## Review Checklist
+
+### General
+- [ ] Code follows naming conventions (Ruby: snake_case, Go: camelCase/PascalCase, Shell: UPPER_CASE env vars)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded instrumentation keys
+- [ ] Error handling follows repo patterns (Ruby: begin/rescue, Go: `if err != nil`)
+- [ ] Logging uses project conventions (Ruby: `@log`/`omslog`, Go: telemetry client)
+- [ ] CI checks would pass (CodeQL, DevSkim, Trivy, unit tests)
+- [ ] No TODO/FIXME comments introduced without a linked issue
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Authentication present at entry points; tokens validated
+- [ ] **Tampering** — Input validated; file permissions restrictive
+- [ ] **Repudiation** — Security-relevant actions logged
+- [ ] **Information Disclosure** — No hardcoded secrets; secrets not in logs/errors
+- [ ] **Denial of Service** — Resource limits set; no unbounded loops
+- [ ] **Elevation of Privilege** — Containers non-root; RBAC least-privilege
+- [ ] **Credential Leak Scan** — No API keys, tokens, passwords in changed files
+- [ ] **Weak Pattern Scan** — No disabled TLS verification, weak crypto, or shell injection
+
+### Telemetry Review Checklist
+- [ ] **New error paths have telemetry** — Every new error handling block emits telemetry
+- [ ] **Telemetry follows existing patterns** — Uses `ApplicationInsightsUtility` (Ruby) or `appinsights` (Go)
+- [ ] **No sensitive data in telemetry** — Metric dimensions don't contain PII or secrets
+- [ ] **Test isolation preserved** — Telemetry gated for test environments (`$in_unit_test`, `GOUNITTEST`)
+
+## Language-Specific Best Practices
+
+### Ruby
+- **Enforced:** `frozen_string_literal: true` required in every file
+- **Reviewer-focus:** Proper use of `require_relative` vs `require`; class variable thread safety
+- **Common mistakes:** Missing nil checks on environment variables; using `puts` instead of `@log`
+- **Patterns:** Fluent plugin lifecycle (`configure` → `start` → `emit`/`filter` → `shutdown`)
+
+### Go
+- **Enforced:** `gofmt` formatting; race condition detection in tests (`-race` flag)
+- **Reviewer-focus:** Mutex usage for shared counters; proper error propagation
+- **Common mistakes:** Goroutine leaks; unchecked errors from telemetry calls
+- **Patterns:** Package-level variables for metrics; `sync.Mutex` for thread safety
+
+### Shell/Bash
+- **Enforced:** `set -e` and `set -o pipefail` in build scripts
+- **Reviewer-focus:** Quoted variables; proper error handling in CI scripts
+- **Common mistakes:** Unquoted variables causing word splitting; missing error checks
+
+### PowerShell
+- **Enforced:** Pester 5.x test structure
+- **Reviewer-focus:** `$ErrorActionPreference` settings; parameter validation
+- **Common mistakes:** Missing `-Force` on module installations; incorrect execution policy
+
+## Security Checks
+
+### Credential & Secret Detection
+- Scan for hardcoded `APPLICATIONINSIGHTS_AUTH` values (should be env vars only)
+- Check `.trivyignore` entries have justification comments
+- Verify no certificates or private keys committed
+
+### CI Security Tool Coverage
+- SAST: CodeQL (`.github/workflows/codeql-analysis.yml`)
+- Security patterns: DevSkim (`.github/workflows/devskim.yml`)
+- Container scanning: Trivy (`.github/workflows/pr-checker.yml`)
+
+## Telemetry Gap Detection
+
+### Existing Telemetry Baseline
+- **Ruby SDK:** `ApplicationInsightsUtility` class in `source/plugins/ruby/ApplicationInsightsUtility.rb`
+- **Go SDK:** `appinsights` package, `TelemetryClient` in `source/plugins/go/src/telemetry.go`
+- **Standard properties:** ID (resource ID), Region, AgentVersion, ControllerType, Computer
+- **Event types:** HeartBeat, Exception, custom metrics (flush counts, sizes, latency)
+
+### Gap Detection Rules
+1. New Ruby plugins without `ApplicationInsightsUtility` calls for error paths → flag
+2. New Go code without error telemetry in `if err != nil` blocks → flag
+3. Telemetry removal without justification → flag
+4. Missing standard dimensions (Computer, ControllerType) → flag
+
+## Testing Expectations
+- Bug fixes must include a regression test
+- New Ruby plugins need `*_test.rb` file
+- New Go packages need `*_test.go` file
+- Dockerfile changes should be validated with Trivy scan
+
+## Common Issues to Flag
+- Hardcoded cloud-specific values (should use environment-driven configuration)
+- Missing ARM64 cross-compilation support in Go changes
+- Helm chart version not bumped for manifest changes
+- Release notes not updated for version changes

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,71 @@
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Docker-Provider (Azure Monitor Container Insights) repository. Your job is to create and maintain documentation that is accurate, consistent, and follows the project's documentation conventions.
+
+## Audience & Tone
+- Primary audience: Azure platform engineers, SREs, and Kubernetes operators
+- Secondary audience: AI coding assistants working on this codebase
+- Tone: Technical and direct, with clear step-by-step instructions
+- Assumed knowledge: Familiarity with Kubernetes, Docker, and Azure Monitor concepts
+
+## Documentation Structure
+- `README.md` — Project overview and quick links
+- `ReleaseNotes.md` — Version-by-version release notes
+- `Documentation/` — Detailed guides organized by topic:
+  - `AgentSettings/` — Agent configuration documentation
+  - `DCR/` — Data Collection Rules documentation
+  - `External/` — External-facing guides (Grafana dashboards)
+  - `Internal/` — Internal implementation details
+  - `MultiTenancyLogging/` — Multi-tenancy setup guides
+  - `NetworkFlowLogging/` — Network flow logging docs
+- `Dev Guide.md` — Developer setup and contribution guide
+- `MARINER.md` — Mariner OS-specific build notes
+
+## Writing Conventions
+- Heading style: ATX (`#`, `##`, `###`)
+- Code blocks: Always specify language (```bash, ```yaml, ```go, etc.)
+- Links: Inline style `[text](url)`
+- Lists: Use `-` for unordered lists
+- File references: Use backtick-wrapped paths (`` `source/plugins/ruby/` ``)
+- Version format: `X.Y.Z` (e.g., `3.1.35`)
+
+## Documentation Types
+
+### Release Notes (`ReleaseNotes.md`)
+- Each version gets a section with date and changes
+- List bug fixes, new features, CVE patches, and dependency updates
+- Reference PR numbers in parentheses
+
+### README Pattern
+- Start with project name and one-line description
+- Include badges if applicable
+- Quick start / getting started section
+- Link to detailed documentation
+
+### Code Comment Conventions
+- Ruby: Use `#` comments; avoid excessive inline comments
+- Go: Use `//` comments; document exported functions
+- Shell: Comment complex logic; explain non-obvious environment variables
+
+## Templates
+
+### Release Notes Entry
+```markdown
+## Release <version> (<MM-DD-YYYY>)
+- Fix: <description> (#<PR>)
+- Feature: <description> (#<PR>)
+- Security: <CVE fixes description> (#<PR>)
+- Dependency: <update description> (#<PR>)
+```
+
+## Cross-References
+- Reference Helm chart versions when documenting deployment changes
+- Link to Azure Monitor documentation for external concepts
+- Reference specific file paths when documenting code behavior
+
+## Validation
+- All file paths referenced in documentation must exist
+- All code examples must be syntactically valid
+- Version numbers must match `build/version` file
+- Release notes entries must reference valid PR numbers

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,85 @@
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Docker-Provider (Azure Monitor Container Insights) repository. You perform deep security assessments that go beyond routine code review. You are invoked explicitly when a thorough security analysis is needed — for example, before major releases, after architecture changes, or when introducing new external attack surfaces.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist applied to every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR introduces or modifies authentication/authorization logic
+- New external-facing APIs or network endpoints are added
+- Infrastructure changes modify security boundaries (Dockerfile, Helm, RBAC)
+- Preparing for a security audit or compliance review
+- After a security incident to assess exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- Identify all entry points: Fluent Bit plugin interfaces, HTTP endpoints, Kubernetes API calls
+- Map trust boundaries: cluster network → agent pod → Azure backend
+- Enumerate data flows: container logs → Fluent Bit → Go plugin → Log Analytics
+- Identify secrets: `APPLICATIONINSIGHTS_AUTH`, mounted K8s secrets, MSI tokens
+
+### 2. STRIDE Deep Analysis
+
+**Spoofing:** Can an attacker impersonate a legitimate agent or data source?
+- Verify MSI/FIC authentication for Azure backend calls
+- Check certificate validation in TLS connections
+- Verify Kubernetes service account permissions are scoped correctly
+
+**Tampering:** Can an attacker modify log data, config, or agent code?
+- Input validation on log data before forwarding
+- ConfigMap integrity for agent configuration
+- Helm chart value validation
+
+**Repudiation:** Can actions be performed without accountability?
+- Agent telemetry audit trail via Application Insights
+- Kubernetes audit logging for agent operations
+
+**Information Disclosure:** Can sensitive data leak?
+- No secrets in container logs or agent telemetry
+- No PII in metric dimensions
+- Debug endpoints disabled in production
+- Environment variable handling (no logging of `APPLICATIONINSIGHTS_AUTH`)
+
+**Denial of Service:** Can the agent be made unavailable?
+- Resource limits in Kubernetes manifests (CPU/memory)
+- Log volume handling and backpressure
+- Liveness/readiness probe configuration
+
+**Elevation of Privilege:** Can an attacker gain unauthorized access?
+- Container runs as non-root user
+- Kubernetes RBAC roles follow least-privilege
+- No privileged containers or host mounts unless justified
+
+### 3. Dependency Security Assessment
+- Audit Go modules (`go.mod`) and Ruby gems for known vulnerabilities
+- Check for pinned versions vs floating ranges
+- Verify Trivy scan is configured for container images in CI
+- Review `.trivyignore` entries for validity and expiration
+
+### 4. Infrastructure Security Review
+- **Dockerfiles:** Non-root USER, minimal base image, no secrets in ENV
+- **Helm charts:** SecurityContext, resource limits, network policies
+- **Kubernetes manifests:** RBAC roles, service accounts, pod security
+- **Build scripts:** No secrets in build arguments, secure artifact handling
+
+## Output Format
+
+### Findings Summary
+| # | Severity | STRIDE | Finding | Location | Recommendation |
+|---|----------|--------|---------|----------|----------------|
+
+### Detailed Findings
+For each finding: Description, Impact, Exploitation scenario, Recommendation, References.
+
+### Positive Security Patterns
+Note security practices the repo does well to reinforce good patterns.
+
+## CI Security Tools Reference
+- **CodeQL:** `.github/workflows/codeql-analysis.yml` — SAST for Go, Ruby, Python
+- **DevSkim:** `.github/workflows/devskim.yml` — Security pattern matching
+- **Trivy:** `.github/workflows/pr-checker.yml` — Container vulnerability scanning
+- For the procedural STRIDE checklist, invoke the `security-review` skill.

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,62 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or larger projects."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider (Azure Monitor Container Insights) repository. You follow a consistent template and tailor the content to this project's architecture, tech stack, and conventions.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring/observability gap does this solve?
+- Success criteria: how do we know this is working?
+
+### 2. Requirements
+- Functional requirements (what the feature must do)
+- Non-functional requirements (performance, security, multi-arch support)
+- Out of scope (explicitly state what this does NOT include)
+
+### 3. Architecture
+- High-level design: which components are affected?
+  - Ruby plugins (`source/plugins/ruby/`)
+  - Go plugins (`source/plugins/go/`)
+  - Container build (`kubernetes/linux/`, `kubernetes/windows/`)
+  - Helm charts (`charts/`)
+  - Configuration (`kubernetes/container-azm-ms-agentconfig.yaml`)
+- Data flow: how does data move through Fluent Bit → plugins → Azure backends?
+- API changes: new telemetry tables, metrics, or configuration options
+- Dependencies: Azure SDK changes, Fluent Bit version requirements
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change
+- Linux and Windows compatibility considerations
+- ARM64 architecture support requirements
+
+### 5. Testing Strategy
+- Unit tests: Ruby `*_test.rb`, Go `*_test.go`, Shell test cases, PowerShell Pester tests
+- E2E tests: Ginkgo tests in `test/ginkgo-e2e/`
+- Container scan: Trivy validation
+- Performance testing considerations for high-scale clusters
+
+### 6. Monitoring & Observability
+- New Application Insights telemetry to add (using `ApplicationInsightsUtility` for Ruby, `appinsights` for Go)
+- Standard dimensions to include: Computer, ControllerType, AgentVersion
+- Error telemetry for new failure paths
+- Rollback indicators: what signals mean we should revert?
+
+### 7. Deployment
+- Helm chart version bump in `charts/*/Chart.yaml`
+- Kubernetes manifest updates in `kubernetes/`
+- Azure Pipelines release process via `.pipelines/`
+- Multi-cloud support: Azure Public, China, Government, Bleu
+- Release notes entry in `ReleaseNotes.md`
+
+## Adaptation Rules
+- Architecture section must map to actual `source/plugins/`, `kubernetes/`, and `charts/` directories
+- Testing strategy must include all four test frameworks (Bash, Go, Ruby, PowerShell)
+- Deployment must account for both Linux and Windows container images
+- Monitoring section must reference the actual telemetry helpers in this repo

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,74 @@
+# Repository Instructions
+
+## Summary
+Docker-Provider (aka Container Insights agent / ama-logs) is the Azure Monitor agent for Kubernetes container monitoring. It collects container logs, metrics, and inventory from AKS and Arc-enabled clusters. Primary languages are Ruby (~24%), Go (~11%), Shell (~13%), and PowerShell (~8%), running as Fluent Bit/Fluentd plugins inside a containerized agent deployed via DaemonSet and ReplicaSet on Linux and Windows nodes.
+
+## General Guidelines
+
+1. All code changes must pass CI: CodeQL, DevSkim, Trivy container scan, and unit tests (Bash, Go, Ruby, PowerShell).
+2. Never hardcode secrets or instrumentation keys — use environment variables (`APPLICATIONINSIGHTS_AUTH`, `APPLICATIONINSIGHTS_ENDPOINT`).
+3. Ruby plugins live in `source/plugins/ruby/`, Go plugins in `source/plugins/go/`. Follow existing patterns in each directory.
+4. Gate telemetry calls behind `$in_unit_test` (Ruby) or `GOUNITTEST` (Go) checks to avoid telemetry in tests.
+5. Container images are built from `kubernetes/linux/Dockerfile.multiarch` (Linux) and `kubernetes/windows/Dockerfile` (Windows).
+6. Helm charts in `charts/` must be kept in sync with Kubernetes manifest changes in `kubernetes/`.
+7. If newer commits make prior changes unnecessary, revert them.
+
+## Custom Agents
+
+| Agent | Triggers | Description |
+|-------|----------|-------------|
+| @CodeReviewer | review code, review PR | Review code for correctness, style, security, and telemetry |
+| @SecurityReviewer | security review, threat model | Deep STRIDE security analysis and attack surface review |
+| @DocumentWriter | write docs, update README | Create and maintain documentation |
+| @prd | create PRD, write requirements | Generate Product Requirements Documents |
+
+## Task-Specific Skills
+
+| Skill | Triggers | Description |
+|-------|----------|-------------|
+| `security-review` | security review, STRIDE analysis, credential leak check | STRIDE-based security review |
+| `telemetry-authoring` | add telemetry, add metrics, instrument code | Add telemetry following existing patterns |
+| `fix-critical-vulnerabilities` | fix CVE, trivy fix, patch vulnerability | Fix critical/high vulnerabilities |
+| `dependency-update` | update dependency, bump package | Update Go modules and Ruby gems |
+| `bug-fix` | fix bug, resolve issue, hotfix | Structured bug fix workflow |
+| `feature-development` | add feature, implement, new plugin | New feature development |
+| `test-authoring` | add test, write test | Create tests following repo conventions |
+| `ci-cd-pipeline` | update pipeline, modify workflow | CI/CD pipeline changes |
+| `infrastructure` | update Dockerfile, modify Helm chart | Infrastructure and deployment changes |
+| `code-refactoring` | refactor, restructure, rename | Code refactoring workflow |
+| `security-patch` | security fix, CVE patch | Security-related fixes |
+| `documentation` | update docs, write release notes | Documentation updates |
+
+## Build Instructions
+
+```bash
+# Prerequisites: Go 1.23+, Ruby 3.3+, make, Docker
+
+# Build Go Fluent Bit output plugin
+cd source/plugins/go/src && make fbplugin
+
+# Build Go Fluent Bit input plugins
+cd source/plugins/go/input/containerinventory && make containerinventory
+cd source/plugins/go/input/perf && make perf
+
+# Build full Linux package (requires dpkg/rpm tools)
+cd build/linux && make all
+
+# Run unit tests
+./test/unit-tests/test_main.sh           # Bash tests
+./test/unit-tests/run_go_tests.sh        # Go tests
+./test/unit-tests/run_ruby_tests.sh      # Ruby tests (requires fluentd gem)
+./test/unit-tests/test_main.ps1          # PowerShell tests (Windows)
+
+# Build Docker image
+cd kubernetes/linux && docker build -f Dockerfile.multiarch .
+```
+
+## Known Patterns & Gotchas
+
+- The `ci_prod` branch is the default integration branch (HEAD). PRs target `ci_dev` or `ci_prod`.
+- Ruby gems must be installed before running Ruby tests: `gem install fluentd -v "1.14.2" && gem install ipaddress`.
+- Go plugins are built as C-shared libraries (`.so` files) for Fluent Bit.
+- ARM64 builds use cross-compilation with `aarch64-linux-gnu-gcc`.
+- The `.trivyignore` file contains temporarily ignored CVEs — always check before adding new entries.
+- Azure Pipelines in `.pipelines/` handle production builds and deployments; GitHub Actions handle PR checks.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.go"
+description: Go code style and Fluent Bit plugin conventions for this repository.
+---
+
+# Go / Fluent Bit Plugin Conventions
+
+- Build output plugins as C-shared libraries: `go build -buildmode=c-shared -o out_oms.so .`
+- Always check `err != nil` and log errors via the telemetry client or `Log()` function.
+- Use `appinsights` SDK (`github.com/microsoft/ApplicationInsights-Go/appinsights`) for telemetry.
+- Use package-level variables for telemetry counters (e.g., `FlushedRecordsCount`, `FlushedRecordsSize`).
+- Use `sync.Mutex` or `sync.RWMutex` for thread-safe access to shared state.
+- Do not use `fmt.Println` for production logging — use structured telemetry or the Fluent Bit log API.
+- CGO is required for Fluent Bit plugin interface; ARM64 cross-compilation uses `aarch64-linux-gnu-gcc`.
+- Run tests with `go test -cover -race -coverprofile=coverage.txt -covermode=atomic`.
+- E2E tests use Ginkgo/Gomega framework in `test/ginkgo-e2e/`.
+- Environment variables drive configuration — never hardcode connection strings or keys.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**/*.ps1,**/*.psm1"
+description: PowerShell conventions for Windows agent scripts and tests.
+---
+
+# PowerShell Conventions
+
+- Use PascalCase for function names, script names, and parameters.
+- Use Pester 5.x (`Describe`/`Context`/`It`) for all test files (`Test-*.ps1`).
+- Functions under test live in `test/unit-tests/test_functions/` with matching test cases in `test_cases/`.
+- Use `$ErrorActionPreference = 'Stop'` for strict error handling in production scripts.
+- Use `param()` blocks at the top of scripts for parameter declaration.
+- Environment variables accessed via `$env:VARIABLE_NAME`.
+- Import modules explicitly: `Import-Module Pester -RequiredVersion 5.3.3`.
+- Windows agent entry point: `kubernetes/windows/main.ps1`.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.rb"
+description: Ruby code style and Fluentd plugin conventions for this repository.
+---
+
+# Ruby / Fluentd Plugin Conventions
+
+- Always include `frozen_string_literal: true` at the top of every Ruby file.
+- Use `require_relative` for files in the same plugin directory, `require` for gems.
+- Register Fluent plugins with `Fluent::Plugin.register_filter/input/output('name', self)`.
+- Use class variables (`@@`) for shared module-level state (e.g., `@@isWindows`, `@@os_type`).
+- Use `ApplicationInsightsUtility` for telemetry — never instantiate a new telemetry client.
+- Gate telemetry calls with `$in_unit_test` to prevent telemetry during tests.
+- Use `OMS::Common` for shared utility methods (hostname, proxy configuration).
+- Log errors via `@log.warn`/`@log.error` from `omslog.rb`, not `puts` or `STDOUT`.
+- Handle environment variables defensively: check `.nil?` and `.empty?` before use.
+- JSON is the standard data interchange format between plugins.
+- Test files follow the pattern `*_test.rb` alongside source in `source/plugins/ruby/`.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**/*.sh,**/*.bash"
+description: Shell script conventions for build, setup, and operational scripts.
+---
+
+# Shell Script Conventions
+
+- Start scripts with `#!/bin/bash` and use `set -e` and `set -o pipefail` for safety.
+- Quote all variable references to prevent word splitting: `"$VAR"` not `$VAR`.
+- Use uppercase with underscores for environment variables (e.g., `IMAGE_TAG_NAME`, `ACR_REGISTRY`).
+- Use `parse_args()` function pattern for CLI argument handling in build scripts.
+- Log operations with `echo` prefixed by context (e.g., `echo "========================= Building ..."`).
+- Check for required tools before use: `which <tool> >/dev/null 2>&1 || { echo "Error: ..."; exit 1; }`.
+- Use `chmod +x` on test scripts before execution in CI.
+- Do not hardcode secrets — use environment variables or mounted secrets.
+- For conditional OS logic, check `$ARCH` or `$OS_TYPE` environment variables.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,67 @@
+# Bug Fix
+
+## Purpose
+Diagnoses and fixes defects in the Container Insights agent, covering Fluent Bit Go plugins (input/output), Fluentd Ruby plugins, shell-based configuration scripts, and PowerShell Windows agent scripts. Ensures telemetry collection, log forwarding, and metric emission continue to function correctly on AKS and Arc-enabled Kubernetes clusters.
+
+USE FOR: "fix bug", "resolve issue", "patch error", "crash fix", "data gap", "missing metrics", "log loss", "nil pointer", "exception in plugin", "OOMKill", "agent restart loop"
+DO NOT USE FOR: Adding new telemetry sources (use feature-development), updating dependencies without a bug (use dependency-update), security vulnerability remediation (use security-patch)
+
+## When to Use
+- A GitHub issue reports incorrect, missing, or duplicated telemetry data
+- Agent pods are crash-looping or OOM-killed in customer clusters
+- Log Analytics workspace shows data gaps for Container Insights tables (Perf, ContainerLog, KubeEvents, etc.)
+- An exception or error pattern is found in agent logs (fluent-bit, fluentd, or mdsd)
+- A regression is detected after a recent release
+
+## Inputs
+- Bug report or issue number with reproduction steps
+- Affected component: Go plugin (`source/plugins/go/src/` or `source/plugins/go/input/`), Ruby plugin (`source/plugins/ruby/`), shell script (`scripts/`), or PowerShell (`kubernetes/windows/`)
+- Cluster environment: AKS, Arc-enabled K8s, Windows node pool, Linux node pool
+- Agent version exhibiting the bug (from `ReleaseNotes.md`)
+
+## Outputs
+- Code fix in the affected source files
+- Unit test covering the bug scenario (regression test)
+- Passing CI pipeline (pr-checker.yml, run_unit_tests.yml, codeql-analysis.yml)
+- Updated `ReleaseNotes.md` entry documenting the fix (if shipping in next release)
+
+## Steps
+1. Reproduce the issue locally or identify the root cause from logs and stack traces
+2. Locate the affected source file(s):
+   - Go output plugins: `source/plugins/go/src/` (e.g., OMI, ADX, MDSD output)
+   - Go input plugins: `source/plugins/go/input/` (e.g., container log input)
+   - Ruby Fluentd plugins: `source/plugins/ruby/` (e.g., `in_kube_events.rb`, `in_kube_podinventory.rb`, `KubernetesApiClient.rb`, `out_mdm.rb`)
+   - Configuration/startup scripts: `scripts/`, `kubernetes/linux/`, `kubernetes/windows/`
+3. Implement the fix with minimal blast radius — change only what is necessary
+4. Add or update unit tests:
+   - Go tests: add test cases alongside the fixed code, run with `test/unit-tests/run_go_tests.sh`
+   - Ruby tests: add test cases in `test/unit-tests/`, run with `test/unit-tests/run_ruby_tests.sh`
+   - Shell tests: use `test/unit-tests/test_main.sh`
+   - PowerShell tests: use `test/unit-tests/test_main.ps1`
+5. Build the agent image: `make` in `build/linux/Makefile` for Linux, verify `kubernetes/windows/Dockerfile` for Windows
+6. Run the full unit test suite to check for regressions
+7. If the fix affects Helm-deployed configuration, validate chart templates in `charts/azuremonitor-containers/` render correctly
+8. Update `ReleaseNotes.md` with a concise description of the fix
+
+## Validation
+- Regression test fails before the fix and passes after
+- `bash test/unit-tests/run_go_tests.sh` passes
+- `bash test/unit-tests/run_ruby_tests.sh` passes
+- `bash test/unit-tests/test_main.sh` passes
+- `pwsh test/unit-tests/test_main.ps1` passes (if Windows code changed)
+- PR checks green: pr-checker.yml, run_unit_tests.yml, codeql-analysis.yml, devskim.yml
+- No new Trivy findings introduced
+
+## Risks and Guardrails
+- **Blast radius**: Bug fixes should be surgical; avoid refactoring unrelated code in the same PR
+- **Cross-platform impact**: A fix in shared Ruby/Go code may affect both Linux and Windows agents — test both paths
+- **Data loss prevention**: Changes to log forwarding or metric emission plugins must not silently drop data; add error handling that logs failures
+- **Helm chart consistency**: If default values change in `charts/*/values.yaml`, ensure existing deployments are not broken by the update
+- **Backward compatibility**: Fixes must work with the Kubernetes API versions supported by the current agent (check `KubernetesApiClient.rb`)
+- **Constants and configuration**: Changes to `source/plugins/ruby/constants.rb` affect many plugins; review all dependents before modifying
+
+## Examples from This Repo
+- Ruby plugin fixes often involve nil-check guards in Kubernetes API response parsing (`KubernetesApiClient.rb`)
+- Go plugin fixes frequently address panic recovery, connection retry logic, or data serialization issues
+- Shell script fixes typically handle edge cases in environment variable parsing or missing configuration files
+- Bug fix commits usually include both the fix and a corresponding unit test addition

--- a/.github/skills/bug-fix/assets/README.md
+++ b/.github/skills/bug-fix/assets/README.md
@@ -1,0 +1,6 @@
+# Bug Fix — Assets
+
+Static assets supporting the bug fix skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/bug-fix/references/README.md
+++ b/.github/skills/bug-fix/references/README.md
@@ -1,0 +1,6 @@
+# Bug Fix — References
+
+Reference materials for the bug fix skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/bug-fix/scripts/README.md
+++ b/.github/skills/bug-fix/scripts/README.md
@@ -1,0 +1,6 @@
+# Bug Fix — Scripts
+
+Automation scripts supporting the bug fix skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,78 @@
+# CI/CD Pipeline
+
+## Purpose
+Maintains and improves the continuous integration and continuous deployment pipelines for the Container Insights agent. Covers GitHub Actions workflows (PR validation, unit tests, CodeQL, DevSkim), Azure Pipelines (build, release, deployment), and associated build scripts.
+
+USE FOR: "update workflow", "fix CI", "add pipeline step", "update build", "GitHub Actions", "Azure Pipelines", "pr-checker", "unit test workflow", "CodeQL", "DevSkim", "pipeline failure", "build script"
+DO NOT USE FOR: Application code changes that happen to be tested by CI (use bug-fix or feature-development), Helm chart changes (use infrastructure), dependency updates (use dependency-update)
+
+## When to Use
+- A CI workflow is failing and needs repair
+- Adding a new validation step to the PR check pipeline
+- Updating GitHub Actions versions or runner images
+- Modifying Azure Pipelines build/release definitions in `.pipelines/`
+- Changing the build process in `build/linux/Makefile` or `source/plugins/go/src/Makefile`
+- Updating Trivy scanning configuration in pr-checker.yml
+- Adding or modifying the stale issue bot configuration
+- Changing how unit tests are orchestrated in CI
+
+## Inputs
+- Description of the CI/CD change needed
+- Which pipeline is affected: GitHub Actions (`.github/workflows/`) or Azure Pipelines (`.pipelines/`)
+- Target workflow file(s) and the specific job/step to modify
+- Any new secrets, environment variables, or service connections required
+
+## Outputs
+- Updated workflow YAML files (`.github/workflows/*.yml` or `.pipelines/*.yaml`)
+- Updated build scripts if the build process changes
+- Passing CI on the PR that introduces the change
+- No regressions in existing pipeline behavior
+
+## Steps
+1. Identify the target pipeline file(s):
+   - **GitHub Actions workflows:**
+     - `.github/workflows/pr-checker.yml` — PR validation, Trivy scanning, build verification
+     - `.github/workflows/run_unit_tests.yml` — Go, Ruby, Shell, PowerShell unit test execution
+     - `.github/workflows/codeql-analysis.yml` — CodeQL static analysis for Go and Ruby
+     - `.github/workflows/devskim.yml` — DevSkim security linting
+     - `.github/workflows/stale.yml` — Stale issue/PR management
+   - **Azure Pipelines:**
+     - `.pipelines/` — Build, release, and deployment pipeline definitions
+     - `.pipelines/` contains Helm deployment templates and image build steps
+2. Make the workflow change:
+   - For GitHub Actions: update YAML following the existing workflow structure and naming conventions
+   - For Azure Pipelines: follow the existing template patterns in `.pipelines/`
+   - For build scripts: update `build/linux/Makefile`, `source/plugins/go/src/Makefile`, or shell scripts in `build/`
+3. If modifying test execution:
+   - Ensure `test/unit-tests/run_go_tests.sh` is called for Go test changes
+   - Ensure `test/unit-tests/run_ruby_tests.sh` is called for Ruby test changes
+   - Ensure `test/unit-tests/test_main.sh` and `test/unit-tests/test_main.ps1` are called for shell/PS tests
+4. If modifying Trivy scanning:
+   - Update scan configuration in pr-checker.yml
+   - Update `.trivyignore` only with justified CVE exceptions
+5. Validate workflow syntax locally if possible (e.g., `actionlint` for GitHub Actions)
+6. Push the change and verify the pipeline runs successfully on the PR
+
+## Validation
+- The modified workflow runs successfully on the PR
+- Existing parallel workflows continue to pass (no cross-workflow interference)
+- Build artifacts are produced correctly (Docker images, Helm packages)
+- Unit test results are reported correctly in PR checks
+- Trivy scan results appear in PR comments/checks as expected
+- No secrets or sensitive values are exposed in workflow logs
+
+## Risks and Guardrails
+- **Secret exposure**: Never echo or log secrets; use GitHub Actions secrets or Azure DevOps variable groups exclusively
+- **Workflow permissions**: Use minimum required permissions in GitHub Actions (`permissions:` block); avoid `write-all`
+- **Runner compatibility**: Verify changes work on the runner OS specified in the workflow (ubuntu-latest, windows-latest)
+- **Pipeline dependencies**: Azure Pipelines in `.pipelines/` may reference shared templates; changing one file can affect multiple pipelines
+- **Trivy ignore discipline**: Each `.trivyignore` entry must reference a specific CVE with a comment explaining why it is safe to ignore
+- **Build cache invalidation**: Changes to Makefiles or Dockerfiles may invalidate build caches; verify build times remain acceptable
+- **Branch protection**: PR-checker.yml is a required check; changes must not break the check or it blocks all PRs
+
+## Examples from This Repo
+- pr-checker.yml runs Trivy container scanning on the built Docker image as part of PR validation
+- run_unit_tests.yml orchestrates separate Go, Ruby, and shell test runners from `test/unit-tests/`
+- codeql-analysis.yml runs CodeQL for Go and has custom query configurations
+- Azure Pipelines in `.pipelines/` handle the full build-test-release cycle including multi-arch image builds
+- Makefile targets in `build/linux/Makefile` produce the agent bundle installed in the container image

--- a/.github/skills/ci-cd-pipeline/assets/README.md
+++ b/.github/skills/ci-cd-pipeline/assets/README.md
@@ -1,0 +1,6 @@
+# CI/CD Pipeline — Assets
+
+Static assets supporting the ci/cd pipeline skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/ci-cd-pipeline/references/README.md
+++ b/.github/skills/ci-cd-pipeline/references/README.md
@@ -1,0 +1,6 @@
+# CI/CD Pipeline — References
+
+Reference materials for the ci/cd pipeline skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/ci-cd-pipeline/scripts/README.md
+++ b/.github/skills/ci-cd-pipeline/scripts/README.md
@@ -1,0 +1,6 @@
+# CI/CD Pipeline — Scripts
+
+Automation scripts supporting the ci/cd pipeline skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/code-refactoring/SKILL.md
+++ b/.github/skills/code-refactoring/SKILL.md
@@ -1,0 +1,76 @@
+# Code Refactoring
+
+## Purpose
+Restructures and improves existing Container Insights agent code without changing external behavior. Targets code clarity, maintainability, performance, and reduction of technical debt in Go plugins, Ruby plugins, shell scripts, and build infrastructure.
+
+USE FOR: "refactor", "clean up code", "reduce duplication", "extract method", "simplify", "improve readability", "consolidate", "rename", "restructure", "tech debt"
+DO NOT USE FOR: Fixing bugs that change behavior (use bug-fix), adding new functionality (use feature-development), dependency updates (use dependency-update)
+
+## When to Use
+- Duplicated logic exists across multiple plugins that should be consolidated
+- A function or method has grown too complex (high cyclomatic complexity)
+- Variable or function names are misleading or inconsistent
+- Dead code or unused imports need removal
+- Constants are hardcoded in multiple places instead of using `constants.rb` or Go constants
+- Error handling patterns are inconsistent across similar plugins
+- Go code needs to be restructured to follow idiomatic patterns
+
+## Inputs
+- Source file(s) or module to refactor
+- Specific code smell or improvement goal
+- Confirmation that existing tests provide adequate coverage for the refactored code (add tests first if not)
+
+## Outputs
+- Refactored source code with improved structure
+- All existing tests continue to pass (behavior is preserved)
+- No changes to external interfaces, APIs, or output formats
+
+## Steps
+1. Identify the scope of the refactoring:
+   - Go plugins: `source/plugins/go/src/`, `source/plugins/go/input/`
+   - Ruby plugins: `source/plugins/ruby/`
+   - Shared constants: `source/plugins/ruby/constants.rb`
+   - Build scripts: `build/linux/`, `scripts/`
+   - Kubernetes scripts: `kubernetes/linux/`, `kubernetes/windows/`
+2. Verify existing test coverage for the code being refactored:
+   - Run `test/unit-tests/run_go_tests.sh` for Go code
+   - Run `test/unit-tests/run_ruby_tests.sh` for Ruby code
+   - If coverage is insufficient, add tests BEFORE refactoring (use test-authoring skill)
+3. Perform the refactoring in small, reviewable increments:
+   - Extract shared logic into helper functions or utility modules
+   - Replace magic numbers/strings with named constants
+   - Simplify complex conditionals
+   - Remove dead code and unused imports
+   - Standardize error handling patterns
+   - Improve variable and function naming
+4. After each incremental change, run the relevant test suite to verify behavior is preserved
+5. Build the agent to verify compilation:
+   - `make` in `source/plugins/go/src/Makefile`
+   - `make` in `build/linux/Makefile`
+6. Run all test suites for a final validation pass
+
+## Validation
+- All existing tests pass without modification (behavior is preserved)
+- `bash test/unit-tests/run_go_tests.sh` passes
+- `bash test/unit-tests/run_ruby_tests.sh` passes
+- `bash test/unit-tests/test_main.sh` passes
+- Code compiles successfully (`go build ./...`, `make`)
+- No new warnings from CodeQL (`codeql-analysis.yml`) or DevSkim (`devskim.yml`)
+- PR CI checks pass: pr-checker.yml, run_unit_tests.yml
+- Refactored code is easier to understand (smaller functions, clearer names, less duplication)
+
+## Risks and Guardrails
+- **Test coverage prerequisite**: Never refactor code without adequate test coverage; add tests first if needed
+- **Behavioral preservation**: Refactoring must not change output formats, log levels, metric names, or API call patterns
+- **Small PRs**: Break large refactors into small, incremental PRs that are easy to review and revert
+- **Ruby dynamic dispatch**: Ruby plugins use metaprogramming and dynamic method calls; ensure renames don't break runtime dispatch
+- **Go interface compliance**: Refactored Go code must still satisfy Fluent Bit plugin interfaces
+- **Cross-file impact**: Renaming constants in `constants.rb` affects all Ruby plugins that import it; grep for all usages
+- **Configuration compatibility**: Refactoring ConfigMap parsing must preserve all existing configuration key names
+
+## Examples from This Repo
+- Consolidating duplicated Kubernetes API call patterns from individual `in_kube_*.rb` plugins into `KubernetesApiClient.rb`
+- Extracting common error handling and retry logic into shared Go utility packages
+- Moving hardcoded strings into `source/plugins/ruby/constants.rb`
+- Simplifying conditional logic in configuration parsing scripts under `scripts/`
+- Refactoring commits are less frequent (6 commits in 12 months) and typically paired with test improvements

--- a/.github/skills/code-refactoring/assets/README.md
+++ b/.github/skills/code-refactoring/assets/README.md
@@ -1,0 +1,6 @@
+# Code Refactoring — Assets
+
+Static assets supporting the code refactoring skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/code-refactoring/references/README.md
+++ b/.github/skills/code-refactoring/references/README.md
@@ -1,0 +1,6 @@
+# Code Refactoring — References
+
+Reference materials for the code refactoring skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/code-refactoring/scripts/README.md
+++ b/.github/skills/code-refactoring/scripts/README.md
@@ -1,0 +1,6 @@
+# Code Refactoring — Scripts
+
+Automation scripts supporting the code refactoring skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,65 @@
+# Dependency Update
+
+## Purpose
+Updates Go module dependencies and Ruby gem versions across the Container Insights agent codebase. Keeps Fluent Bit input/output plugins, Fluentd Ruby plugins, and Ginkgo e2e test dependencies current with security patches and upstream releases.
+
+USE FOR: "update go modules", "bump dependency", "upgrade gem", "update go.sum", "refresh dependencies", "renovate", "dependabot PR"
+DO NOT USE FOR: Changing plugin business logic, adding new dependencies for new features, Helm chart version bumps (use infrastructure skill)
+
+## When to Use
+- Dependabot or Renovate opens a PR to bump a Go module or Ruby gem
+- A CVE is published against a transitive dependency (coordinate with security-patch skill)
+- Upstream Fluent Bit, Fluentd, or Azure SDK releases a new version
+- Periodic monthly dependency refresh cycle
+- `go mod tidy` reports stale or unused modules
+
+## Inputs
+- Name and target version of the dependency to update
+- Which module(s) are affected (there are multiple independent go.mod files)
+- Reason for update (security, compatibility, routine maintenance)
+
+## Outputs
+- Updated `go.mod` and `go.sum` files in affected modules
+- Updated Gemfile / gemspec if Ruby gems change
+- Passing unit tests (`test/unit-tests/run_go_tests.sh`, `test/unit-tests/run_ruby_tests.sh`)
+- Passing CI checks (pr-checker.yml, run_unit_tests.yml)
+- Clean Trivy scan with no new HIGH/CRITICAL vulnerabilities
+
+## Steps
+1. Identify all Go modules that depend on the target package:
+   - `source/plugins/go/src/go.mod` — core Fluent Bit output plugins
+   - `source/plugins/go/input/go.mod` — Fluent Bit input plugins
+   - `test/ginkgo-e2e/livenessprobe/go.mod` — liveness probe e2e tests
+   - `test/ginkgo-e2e/utils/go.mod` — e2e test utilities
+   - `test/ginkgo-e2e/containerstatus/go.mod` — container status e2e tests
+   - `test/ginkgo-e2e/querylogs/go.mod` — log query e2e tests
+2. For each affected module, run `go get <package>@<version>` then `go mod tidy`
+3. For Ruby gem updates, update the relevant require/version in `source/plugins/ruby/` and run `bundle update` if a Gemfile is present
+4. Run Go unit tests: `cd test/unit-tests && bash run_go_tests.sh`
+5. Run Ruby unit tests: `cd test/unit-tests && bash run_ruby_tests.sh`
+6. Build the Linux container image using `build/linux/Makefile` to verify compilation
+7. Run Trivy scan against the built image to check for new vulnerabilities; update `.trivyignore` only if the finding is a false positive with documented justification
+8. Update `ReleaseNotes.md` with the dependency version change if it affects a top-level component (Golang, Fluent-bit, Fluentd, Ruby, MDSD, Telegraf)
+
+## Validation
+- `go build ./...` succeeds in `source/plugins/go/src/` and `source/plugins/go/input/`
+- `make` succeeds in `source/plugins/go/src/Makefile`
+- `bash test/unit-tests/run_go_tests.sh` passes
+- `bash test/unit-tests/run_ruby_tests.sh` passes
+- PR checks pass: pr-checker.yml (includes Trivy scan), run_unit_tests.yml
+- No new entries needed in `.trivyignore` (or entries are justified)
+- `go mod tidy` produces no diff (modules are clean)
+
+## Risks and Guardrails
+- **Multiple go.mod files**: Forgetting to update one module can cause version skew; always grep all `go.mod` files for the dependency
+- **Breaking API changes**: Major version bumps in Azure SDK or Fluent Bit Go API may require code changes in `source/plugins/go/`
+- **Ruby compatibility**: Fluentd plugins must remain compatible with the Fluentd version pinned in `kubernetes/linux/Dockerfile.multiarch`
+- **Trivy exceptions**: Never add blanket ignores to `.trivyignore`; each entry must reference a specific CVE with justification
+- **Windows builds**: Go dependency changes can affect the Windows build; verify `kubernetes/windows/Dockerfile` still builds
+- **E2E test modules**: The `test/ginkgo-e2e/*/go.mod` files are independent modules; update them in the same PR to keep versions consistent
+
+## Examples from This Repo
+- Go module bumps typically touch 2-4 `go.mod`/`go.sum` file pairs in a single commit
+- Ruby gem updates are less frequent and usually tied to Fluentd base image upgrades
+- Dependency PRs often pair with Trivy scan result updates in `.trivyignore`
+- Component version changes are recorded in `ReleaseNotes.md` under the next release heading

--- a/.github/skills/dependency-update/assets/README.md
+++ b/.github/skills/dependency-update/assets/README.md
@@ -1,0 +1,6 @@
+# Dependency Update — Assets
+
+Static assets supporting the dependency update skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/dependency-update/references/README.md
+++ b/.github/skills/dependency-update/references/README.md
@@ -1,0 +1,6 @@
+# Dependency Update — References
+
+Reference materials for the dependency update skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/dependency-update/scripts/README.md
+++ b/.github/skills/dependency-update/scripts/README.md
@@ -1,0 +1,6 @@
+# Dependency Update — Scripts
+
+Automation scripts supporting the dependency update skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,76 @@
+# Documentation
+
+## Purpose
+Creates and updates documentation for the Container Insights agent, including release notes, development guides, architecture documentation, Helm chart README files, and operational runbooks. Ensures that contributors, operators, and users have accurate, up-to-date information.
+
+USE FOR: "update docs", "write documentation", "update README", "release notes", "CHANGELOG", "dev guide", "architecture docs", "chart README", "MARINER docs"
+DO NOT USE FOR: Code comments within source files (handle as part of the relevant code skill), CI workflow documentation (use ci-cd-pipeline skill for in-workflow comments)
+
+## When to Use
+- A new release is being prepared and `ReleaseNotes.md` needs updating
+- A new feature or breaking change requires documentation updates
+- Helm chart `README.md` needs to reflect new parameters or changed defaults
+- `Dev Guide.md` needs updates for new build steps or development workflows
+- `MARINER.md` needs updates for base image changes
+- Repository-level documentation (`README.md`, `SECURITY.md`, `CODEOWNERS`) needs updates
+
+## Inputs
+- Description of what changed (feature, fix, configuration, infrastructure)
+- Target document(s) to update
+- Version numbers, dates, and component versions for release notes
+- Any new Helm chart parameters, environment variables, or configuration options to document
+
+## Outputs
+- Updated documentation files with accurate, current content
+- Consistent formatting following existing document conventions
+- No broken links or outdated references
+
+## Steps
+1. Identify the documentation file(s) to update:
+   - `ReleaseNotes.md` — Version history with component versions (Golang, Ruby, MDSD, Telegraf, Fluent-bit, Fluentd), Linux/Windows release dates
+   - `README.md` — Repository overview and getting started
+   - `Dev Guide.md` — Development setup, build instructions, test execution
+   - `MARINER.md` — CBL-Mariner base image details and update procedures
+   - `SECURITY.md` — Security policy and vulnerability reporting
+   - `CODEOWNERS` — Code ownership for PR review routing
+   - `charts/azuremonitor-containers/README.md` — Public Helm chart documentation
+   - `charts/azuremonitor-containers-geneva/README.md` — Geneva chart documentation
+   - `Documentation/` — Additional architecture and operational docs
+2. Follow existing formatting conventions:
+   - `ReleaseNotes.md`: Use the established version heading format with component version table
+   - Helm chart READMEs: Document all `values.yaml` parameters with types and defaults
+   - Use Markdown consistently; match heading levels and list styles of existing content
+3. For release notes specifically:
+   - Add a new version heading at the top of `ReleaseNotes.md`
+   - List all component versions (Golang, Ruby, MDSD, Telegraf, Fluent-bit, Fluentd versions)
+   - Include Linux and Windows release dates
+   - Summarize bug fixes, features, and security patches included in the release
+4. For Helm chart documentation:
+   - Keep the parameter table in `README.md` synchronized with `values.yaml`
+   - Document any new required values or changed defaults
+   - Include upgrade notes if breaking changes are introduced
+5. Review for accuracy: verify version numbers, file paths, and command examples are correct
+6. Check for broken links and outdated references
+
+## Validation
+- Documentation renders correctly in GitHub's Markdown viewer
+- All referenced file paths exist in the repository
+- Version numbers in `ReleaseNotes.md` match actual component versions in Dockerfiles and charts
+- Helm chart parameter documentation matches `values.yaml`
+- No broken relative links between documents
+- Spelling and grammar are correct
+
+## Risks and Guardrails
+- **Accuracy**: Documentation must reflect the actual state of the code; outdated docs are worse than no docs
+- **Release notes completeness**: Every shipped change should be represented in `ReleaseNotes.md`; cross-reference with merged PRs
+- **Sensitive information**: Never include credentials, internal URLs, or customer-specific details in documentation
+- **Chart version alignment**: Helm chart README updates should accompany `Chart.yaml` version bumps
+- **Link stability**: Use relative links for in-repo references; avoid absolute GitHub URLs that break on forks
+- **Multiple chart variants**: Documentation changes may apply to all three chart directories; check for consistency
+
+## Examples from This Repo
+- `ReleaseNotes.md` follows a consistent format with version headings, component version tables, and categorized change lists
+- `Dev Guide.md` documents the local development setup including Docker, Go, and Ruby prerequisites
+- `MARINER.md` specifically documents the CBL-Mariner base image update process
+- Documentation commits are the least frequent category (3 commits in 12 months), typically tied to release preparation
+- Helm chart `values.yaml` files contain inline comments that serve as parameter documentation

--- a/.github/skills/documentation/assets/README.md
+++ b/.github/skills/documentation/assets/README.md
@@ -1,0 +1,6 @@
+# Documentation — Assets
+
+Static assets supporting the documentation skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/documentation/references/README.md
+++ b/.github/skills/documentation/references/README.md
@@ -1,0 +1,6 @@
+# Documentation — References
+
+Reference materials for the documentation skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/documentation/scripts/README.md
+++ b/.github/skills/documentation/scripts/README.md
@@ -1,0 +1,6 @@
+# Documentation — Scripts
+
+Automation scripts supporting the documentation skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,81 @@
+# Feature Development
+
+## Purpose
+Implements new telemetry collection capabilities, monitoring features, and agent functionality for Azure Monitor Container Insights. This includes new Fluent Bit input/output Go plugins, new Fluentd Ruby plugins, new Kubernetes resource inventory collectors, and new metric/log pipelines.
+
+USE FOR: "add new feature", "new telemetry source", "new plugin", "new metric", "new inventory type", "support new resource", "add collection for", "new data table", "new ConfigMap option"
+DO NOT USE FOR: Fixing broken existing features (use bug-fix), updating existing dependency versions (use dependency-update), CI/CD workflow changes (use ci-cd-pipeline)
+
+## When to Use
+- Product requirement to collect a new Kubernetes resource type (e.g., new inventory, new event type)
+- Adding a new output destination for telemetry data (e.g., new ADX table, new LA table)
+- Introducing a new agent configuration option via ConfigMap or Helm values
+- Adding new prometheus scraping targets or metric pipelines
+- Implementing new container log filtering or transformation capabilities
+
+## Inputs
+- Feature specification or GitHub issue describing the new capability
+- Target Kubernetes resource types or data sources
+- Output schema (Log Analytics table schema, ADX schema, or MDM metric dimensions)
+- Configuration surface (ConfigMap keys, Helm values, environment variables)
+- Whether the feature applies to Linux, Windows, or both
+
+## Outputs
+- New or modified plugin source files (Go and/or Ruby)
+- Updated configuration templates and default values
+- Helm chart updates (`charts/azuremonitor-containers/`, `charts/azuremonitor-containers-geneva/`)
+- Unit tests covering the new functionality
+- Updated `ReleaseNotes.md` documenting the new feature
+- Documentation updates if user-facing configuration changes
+
+## Steps
+1. Design the data flow: identify source (Kubernetes API, container runtime, node metrics) → processing (Ruby/Go plugin) → output (Log Analytics, ADX, MDM)
+2. If adding a new Go plugin:
+   - Create source files under `source/plugins/go/src/` (output) or `source/plugins/go/input/` (input)
+   - Register the plugin in the appropriate plugin registry
+   - Update `source/plugins/go/src/Makefile` if new build targets are needed
+   - Add any new Go dependencies with `go get` and `go mod tidy`
+3. If adding a new Ruby plugin:
+   - Create the plugin file in `source/plugins/ruby/` following the `in_*.rb` or `out_*.rb` naming convention
+   - Add constants to `source/plugins/ruby/constants.rb`
+   - Use `KubernetesApiClient.rb` patterns for Kubernetes API interactions
+4. If the feature requires new configuration:
+   - Add ConfigMap keys to the appropriate configuration scripts in `scripts/`
+   - Add Helm values to `charts/azuremonitor-containers/values.yaml` and `charts/azuremonitor-containers-geneva/values.yaml`
+   - Update chart templates if new environment variables or volume mounts are needed
+5. Update container startup scripts:
+   - Linux: scripts referenced in `kubernetes/linux/Dockerfile.multiarch`
+   - Windows: PowerShell scripts in `kubernetes/windows/`
+6. Write unit tests:
+   - Go: test files alongside source in the appropriate module
+   - Ruby: test files in `test/unit-tests/`
+   - Shell/PowerShell: `test/unit-tests/test_main.sh` or `test/unit-tests/test_main.ps1`
+7. Build and verify:
+   - `make` in `source/plugins/go/src/Makefile` and `build/linux/Makefile`
+   - Docker build with `kubernetes/linux/Dockerfile.multiarch`
+8. Update `ReleaseNotes.md` with the new feature description
+9. If the feature introduces a new Helm chart parameter, bump the chart version in `charts/*/Chart.yaml`
+
+## Validation
+- New plugin loads successfully in fluent-bit/fluentd configuration
+- Unit tests pass for all test suites (`run_go_tests.sh`, `run_ruby_tests.sh`, `test_main.sh`)
+- Docker image builds successfully for both Linux (`Dockerfile.multiarch`) and Windows (`Dockerfile`) if applicable
+- Helm template rendering produces valid Kubernetes manifests: `helm template charts/azuremonitor-containers/`
+- PR CI checks pass: pr-checker.yml, run_unit_tests.yml, codeql-analysis.yml
+- No new Trivy HIGH/CRITICAL vulnerabilities from added dependencies
+- Feature can be enabled/disabled via ConfigMap without agent restart issues
+
+## Risks and Guardrails
+- **Resource consumption**: New collection features increase agent CPU/memory footprint; profile resource usage before merging
+- **API rate limiting**: New Kubernetes API calls must respect watch/list patterns and caching to avoid API server throttling
+- **Data volume**: New log or metric sources can significantly increase data ingestion costs; features should be configurable and off by default if high-volume
+- **Schema compatibility**: New fields in output plugins must be backward-compatible with existing Log Analytics table schemas
+- **Multi-platform**: Features must work on both Linux and Windows node pools unless explicitly scoped; test both Dockerfiles
+- **Helm backward compatibility**: New Helm values must have sensible defaults so existing `helm upgrade` commands continue to work
+- **Geneva vs public charts**: Features may need to be added to both `azuremonitor-containers` and `azuremonitor-containers-geneva` chart variants
+
+## Examples from This Repo
+- New inventory collectors follow the pattern of existing `in_kube_podinventory.rb`, `in_kube_events.rb` plugins
+- Go input plugins are registered in the Fluent Bit input plugin framework under `source/plugins/go/input/`
+- Feature flags are typically controlled through ConfigMap values parsed in Ruby via `constants.rb`
+- New Helm chart parameters are added to both `values.yaml` and documented in the chart's `README.md`

--- a/.github/skills/feature-development/assets/README.md
+++ b/.github/skills/feature-development/assets/README.md
@@ -1,0 +1,6 @@
+# Feature Development — Assets
+
+Static assets supporting the feature development skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/feature-development/references/README.md
+++ b/.github/skills/feature-development/references/README.md
@@ -1,0 +1,6 @@
+# Feature Development — References
+
+Reference materials for the feature development skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/feature-development/scripts/README.md
+++ b/.github/skills/feature-development/scripts/README.md
@@ -1,0 +1,6 @@
+# Feature Development — Scripts
+
+Automation scripts supporting the feature development skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,109 @@
+# Fix Critical Vulnerabilities
+
+## Purpose
+Identify and fix critical and high severity vulnerabilities in the Docker-Provider container images and dependencies using the repository's own scanning tools (Trivy, CodeQL, DevSkim).
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure, dependency vulnerability fix, container image vulnerability
+DO NOT USE FOR: general dependency updates without security motivation, adding new security scanning tools, security architecture review (use security-review), low/medium severity unless explicitly requested
+
+## When to Use
+- When Trivy scan in `pr-checker.yml` reports critical/high CVEs
+- When Dependabot or manual review identifies vulnerable dependencies
+- When container base image has known vulnerabilities
+- When Go modules or Ruby gems have published CVEs
+
+## Inputs
+- CVE ID(s) or vulnerability scan report
+- Affected component (Go modules, container base image, OS packages)
+
+## Outputs
+- Updated dependency files (`go.mod`, `go.sum`, Dockerfile base images)
+- Updated `.trivyignore` if CVEs cannot be fixed immediately
+- Passing Trivy scan on rebuilt container image
+
+## Steps
+
+1. **Run vulnerability scan** using the repo's configured tools:
+   ```bash
+   # Scan Go modules
+   cd source/plugins/go/src && go list -m -json all | head -50
+   cd test/ginkgo-e2e/utils && go list -m -json all | head -50
+
+   # Scan container image (if built locally)
+   trivy image --severity CRITICAL,HIGH <image-tag>
+
+   # Scan filesystem for dependency vulnerabilities
+   trivy fs --severity CRITICAL,HIGH --scanners vuln .
+   ```
+
+2. **Triage vulnerabilities** by type:
+   - **Go module vulnerabilities:** Check if package is direct or indirect in `go.mod`
+   - **Container base image:** Check `kubernetes/linux/Dockerfile.multiarch` and `kubernetes/windows/Dockerfile` for base image tags
+   - **OS packages:** Check `kubernetes/linux/setup.sh` for `tdnf install` packages
+   - **Already ignored:** Check `.trivyignore` for existing entries with justification
+
+3. **Fix Go module vulnerabilities:**
+   ```bash
+   # Update specific package
+   cd source/plugins/go/src && go get <package>@<fixed-version> && go mod tidy
+
+   # Update ALL Go modules in the repo
+   for dir in source/plugins/go/src source/plugins/go/input test/ginkgo-e2e/utils test/ginkgo-e2e/querylogs test/ginkgo-e2e/containerstatus test/ginkgo-e2e/livenessprobe; do
+     cd $dir && go get -u ./... && go mod tidy && cd -
+   done
+   ```
+
+4. **Fix container base image vulnerabilities:**
+   - Update base image tag in `kubernetes/linux/Dockerfile.multiarch`
+   - Update base image tag in `kubernetes/windows/Dockerfile`
+   - Check `kubernetes/linux/setup.sh` for package versions that need updating
+
+5. **Fix OS package vulnerabilities:**
+   - Update package versions in `kubernetes/linux/setup.sh` (`tdnf install`)
+   - For Ruby: Update Ruby version in setup.sh if Ruby has CVEs
+
+6. **Handle unfixable vulnerabilities:**
+   - Add to `.trivyignore` with justification:
+     ```
+     # CVE-YYYY-NNNNN: No fix available upstream as of YYYY-MM-DD
+     # Tracked at: <upstream issue URL>
+     CVE-YYYY-NNNNN
+     ```
+
+7. **Build and test:**
+   ```bash
+   # Build Go plugins
+   cd source/plugins/go/src && make fbplugin
+
+   # Run unit tests
+   ./test/unit-tests/run_go_tests.sh
+   ./test/unit-tests/test_main.sh
+
+   # Re-scan to verify fixes
+   trivy fs --severity CRITICAL,HIGH --scanners vuln .
+   ```
+
+## Validation
+- Build succeeds for all affected components
+- All unit tests pass (Go, Bash, Ruby, PowerShell)
+- Re-scan shows targeted CVEs resolved
+- No new critical/high vulnerabilities introduced
+- `.trivyignore` entries have proper justification
+
+## Risks and Guardrails
+- Major version bumps may introduce breaking API changes — check changelogs
+- Go module updates may require updating multiple `go.mod` files across the repo
+- Container base image updates may change available OS packages
+- Always re-run Trivy after fixes to confirm resolution
+
+## Examples from This Repo
+- `3.1.32 CVE fixes (#1596)` — Batch CVE remediation
+- `3.1.31 CVEs fixes (#1572)` — Dependency updates for security
+- `Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)` — Combined CVE fix with test improvements
+- `CVEs Fix (#1526)` — Go module security updates
+
+## References
+- `.trivyignore` — Current CVE ignore list
+- `.github/workflows/pr-checker.yml` — Trivy scan configuration
+- `kubernetes/linux/setup.sh` — OS package installation
+- `kubernetes/linux/Dockerfile.multiarch` — Linux container build

--- a/.github/skills/fix-critical-vulnerabilities/assets/README.md
+++ b/.github/skills/fix-critical-vulnerabilities/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+This directory contains assets for the `fix-critical-vulnerabilities` skill.

--- a/.github/skills/fix-critical-vulnerabilities/references/README.md
+++ b/.github/skills/fix-critical-vulnerabilities/references/README.md
@@ -1,0 +1,3 @@
+# References
+
+This directory contains references for the `fix-critical-vulnerabilities` skill.

--- a/.github/skills/fix-critical-vulnerabilities/scripts/README.md
+++ b/.github/skills/fix-critical-vulnerabilities/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts
+
+This directory contains scripts for the `fix-critical-vulnerabilities` skill.

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,88 @@
+# Infrastructure
+
+## Purpose
+Manages the container image definitions, Helm charts, Kubernetes manifests, and deployment infrastructure for the Container Insights agent. Covers Dockerfiles for Linux and Windows multi-arch builds, Helm chart templates and values, Kubernetes DaemonSet/Deployment specs, and supporting deployment scripts.
+
+USE FOR: "update Dockerfile", "Helm chart change", "chart version bump", "add environment variable", "update container image", "Kubernetes manifest", "DaemonSet change", "add volume mount", "update resource limits", "multi-arch build", "base image update", "chart template"
+DO NOT USE FOR: Application plugin code changes (use bug-fix or feature-development), CI pipeline YAML changes (use ci-cd-pipeline), Go/Ruby dependency updates (use dependency-update)
+
+## When to Use
+- Updating base images in Dockerfiles (e.g., CBL-Mariner, Windows Server Core)
+- Modifying Helm chart templates, values, or Chart.yaml version
+- Adding or changing environment variables, ConfigMap mounts, or volume definitions
+- Updating Kubernetes resource requests/limits for agent pods
+- Adding new container ports, probes, or security contexts
+- Modifying the multi-arch build process for Linux or Windows images
+- Updating deployment scripts in `kubernetes/` or `deployment/`
+- Changing the agent installation or startup process within the container
+
+## Inputs
+- Description of the infrastructure change
+- Target artifact: Dockerfile, Helm chart, Kubernetes manifest, or deployment script
+- Whether the change affects Linux, Windows, or both platforms
+- Any new image tags, registry references, or chart versions
+
+## Outputs
+- Updated Dockerfiles, Helm charts, Kubernetes manifests, or deployment scripts
+- Updated `Chart.yaml` with bumped version if Helm chart content changed
+- Passing container image build
+- Valid Helm template rendering
+- Updated `ReleaseNotes.md` if the change affects a shipped component version
+
+## Steps
+1. Identify the target infrastructure file(s):
+   - **Dockerfiles:**
+     - `kubernetes/linux/Dockerfile.multiarch` — Linux multi-arch agent image (AMD64, ARM64)
+     - `kubernetes/windows/Dockerfile` — Windows agent image
+     - `kubernetes/windows/Dockerfile-dev-image` — Windows dev/test image
+   - **Helm charts:**
+     - `charts/azuremonitor-containers/` — Public Azure Monitor chart
+     - `charts/azuremonitor-containers-geneva/` — Geneva (internal Microsoft) chart
+     - `charts/azuremonitor-containerinsights-for-prod-clusters/` — Production clusters chart
+   - **Kubernetes manifests and scripts:**
+     - `kubernetes/linux/` — Linux-specific K8s resources and scripts
+     - `kubernetes/windows/` — Windows-specific K8s resources and PowerShell scripts
+     - `deployment/` — Deployment templates and ARM/Bicep resources
+2. Make the infrastructure change:
+   - For Dockerfiles: follow multi-stage build patterns; pin base image versions; maintain layer cache efficiency
+   - For Helm charts: update templates in `templates/`, values in `values.yaml`, and metadata in `Chart.yaml`
+   - For Kubernetes manifests: follow existing resource naming and labeling conventions
+3. If modifying Helm charts:
+   - Bump the chart version in `Chart.yaml` (patch for fixes, minor for new features)
+   - Ensure default values in `values.yaml` maintain backward compatibility
+   - Update all chart variants if the change applies broadly (public, geneva, prod-clusters)
+4. Build and verify container images:
+   - Linux: `docker build -f kubernetes/linux/Dockerfile.multiarch .`
+   - Windows: `docker build -f kubernetes/windows/Dockerfile .`
+5. Validate Helm charts:
+   - `helm lint charts/azuremonitor-containers/`
+   - `helm template charts/azuremonitor-containers/` — verify rendered manifests
+6. Run Trivy scan on built images to check for new vulnerabilities
+7. Update `ReleaseNotes.md` if component versions change (base images, MDSD, Telegraf, Fluent-bit)
+
+## Validation
+- Docker images build successfully for all target platforms
+- `helm lint` passes for all modified charts
+- `helm template` produces valid Kubernetes manifests with no rendering errors
+- Trivy scan shows no new HIGH/CRITICAL vulnerabilities (or findings are documented in `.trivyignore`)
+- Existing Helm values continue to work (backward compatibility)
+- Agent pods start successfully with the new image (liveness/readiness probes pass)
+- PR CI checks pass: pr-checker.yml (includes image build and Trivy scan)
+
+## Risks and Guardrails
+- **Base image CVEs**: Always check Trivy results when updating base images; new base versions can introduce vulnerabilities
+- **Multi-arch consistency**: Changes to `Dockerfile.multiarch` must work on both AMD64 and ARM64 architectures
+- **Helm backward compatibility**: Chart changes must not break `helm upgrade` for existing deployments; new values need defaults
+- **Chart version discipline**: Always bump `Chart.yaml` version when chart content changes; follow semver
+- **Resource limits**: Changing CPU/memory limits affects cluster capacity planning; validate with load testing
+- **Windows parity**: If a Linux Dockerfile change adds a new component, evaluate whether the Windows Dockerfile needs the equivalent
+- **Build layer ordering**: Keep frequently-changing layers (source code copy, build steps) at the end of Dockerfiles to maximize cache hits
+- **MARINER.md**: Base image changes for CBL-Mariner should be reflected in `MARINER.md` documentation
+- **Multiple chart variants**: Changes often need to be applied to all three chart directories; missing one causes drift
+
+## Examples from This Repo
+- Dockerfile.multiarch uses multi-stage builds with separate builder and runtime stages for Go plugins
+- Helm charts define DaemonSets for the agent with configurable resource limits, tolerations, and node selectors
+- Chart.yaml versions follow semver; patch bumps for bug fixes, minor bumps for new features
+- Base image updates in Dockerfiles are paired with ReleaseNotes.md updates listing the new component versions
+- Infrastructure changes represent the largest commit category (51 commits in 12 months) due to frequent image and chart updates

--- a/.github/skills/infrastructure/assets/README.md
+++ b/.github/skills/infrastructure/assets/README.md
@@ -1,0 +1,6 @@
+# Infrastructure — Assets
+
+Static assets supporting the infrastructure skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/infrastructure/references/README.md
+++ b/.github/skills/infrastructure/references/README.md
@@ -1,0 +1,6 @@
+# Infrastructure — References
+
+Reference materials for the infrastructure skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/infrastructure/scripts/README.md
+++ b/.github/skills/infrastructure/scripts/README.md
@@ -1,0 +1,6 @@
+# Infrastructure — Scripts
+
+Automation scripts supporting the infrastructure skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/security-patch/SKILL.md
+++ b/.github/skills/security-patch/SKILL.md
@@ -1,0 +1,88 @@
+# Security Patch
+
+## Purpose
+Addresses security vulnerabilities in the Container Insights agent, including CVE remediation in dependencies, fixing insecure code patterns, hardening container security contexts, and resolving findings from CodeQL, DevSkim, and Trivy scanners.
+
+USE FOR: "security fix", "CVE", "vulnerability", "Trivy finding", "CodeQL alert", "DevSkim alert", "harden", "credential exposure", "RBAC", "security context", "secret management"
+DO NOT USE FOR: Routine dependency bumps without a CVE (use dependency-update), general bug fixes without security implications (use bug-fix), CI pipeline changes to scanners (use ci-cd-pipeline)
+
+## When to Use
+- Trivy scan in pr-checker.yml reports a HIGH or CRITICAL vulnerability
+- CodeQL analysis (`codeql-analysis.yml`) flags a security issue in Go or Ruby code
+- DevSkim (`devskim.yml`) identifies an insecure code pattern
+- A CVE is published affecting a direct or transitive dependency
+- Security review identifies hardcoded credentials, insecure defaults, or excessive RBAC permissions
+- Container image needs security context hardening (non-root, read-only filesystem, capabilities)
+
+## Inputs
+- CVE identifier or scanner alert details
+- Affected component and file path(s)
+- Severity level (CRITICAL, HIGH, MEDIUM, LOW)
+- Whether a fix is available upstream (patched dependency version) or requires code change
+
+## Outputs
+- Patched code or updated dependencies addressing the vulnerability
+- Updated `.trivyignore` if the finding is a false positive (with documented justification)
+- Clean scanner results on the PR
+- Updated `ReleaseNotes.md` noting the security fix
+
+## Steps
+1. Triage the vulnerability:
+   - Determine if the vulnerable code path is reachable in the Container Insights agent
+   - Assess severity in context (a CVE in an unused transitive dependency may be low risk)
+   - Check if an upstream fix is available (newer package version)
+2. For dependency CVEs:
+   - Identify all affected `go.mod` files:
+     - `source/plugins/go/src/go.mod`
+     - `source/plugins/go/input/go.mod`
+     - `test/ginkgo-e2e/livenessprobe/go.mod`
+     - `test/ginkgo-e2e/utils/go.mod`
+     - `test/ginkgo-e2e/containerstatus/go.mod`
+     - `test/ginkgo-e2e/querylogs/go.mod`
+   - Update to the patched version: `go get <package>@<patched-version>` then `go mod tidy`
+   - For Ruby gems: update version constraints and run dependency resolution
+3. For code-level vulnerabilities (CodeQL/DevSkim findings):
+   - Fix the insecure pattern in the flagged source file
+   - Common fixes: input validation, proper credential handling, secure defaults, SQL injection prevention
+4. For container hardening:
+   - Update `kubernetes/linux/Dockerfile.multiarch` and/or `kubernetes/windows/Dockerfile`
+   - Update Helm chart security contexts in `charts/*/templates/`
+   - Ensure pods run as non-root where possible
+5. For base image CVEs:
+   - Update the base image version in Dockerfiles
+   - Rebuild and re-scan with Trivy
+6. Run all validation:
+   - Unit tests: `run_go_tests.sh`, `run_ruby_tests.sh`, `test_main.sh`, `test_main.ps1`
+   - Build: `make` in `build/linux/Makefile`
+   - Trivy scan on the rebuilt image
+   - CodeQL/DevSkim re-analysis
+7. If a Trivy finding is a false positive:
+   - Add the CVE to `.trivyignore` with a comment explaining why it is safe to ignore
+   - Include the date and a reference to the analysis
+8. Update `ReleaseNotes.md` with the security fix details
+
+## Validation
+- The specific CVE/alert is resolved in scanner output
+- Trivy scan shows no new HIGH/CRITICAL findings (or false positives are documented in `.trivyignore`)
+- CodeQL analysis passes with no new alerts
+- DevSkim scan passes with no new findings
+- All unit tests pass
+- Container image builds successfully
+- PR CI checks pass: pr-checker.yml, codeql-analysis.yml, devskim.yml
+
+## Risks and Guardrails
+- **Urgency vs. thoroughness**: Security patches may be urgent, but still require tests and review; do not skip CI
+- **False positive documentation**: Every `.trivyignore` entry must include the CVE ID and a clear justification comment
+- **Transitive dependency chains**: Updating one package to fix a CVE may pull in other breaking changes; test thoroughly
+- **RBAC changes**: Modifying ClusterRole/ClusterRoleBinding in Helm charts affects all clusters; minimize permissions
+- **Secret handling**: Never log secrets, tokens, or connection strings; audit any changes to logging code
+- **Base image provenance**: Only use base images from trusted registries (MCR, official Docker Hub images)
+- **Coordinated disclosure**: If the vulnerability is in the agent's own code, coordinate with the security team before public disclosure
+- **Windows parity**: Security fixes in Linux Dockerfiles may need equivalent changes in Windows Dockerfiles
+
+## Examples from This Repo
+- Trivy findings are tracked and resolved through `.trivyignore` entries with CVE-specific comments
+- pr-checker.yml runs Trivy as a required PR check, blocking merges with unaddressed HIGH/CRITICAL findings
+- CodeQL analysis covers Go code in `source/plugins/go/` for common vulnerability patterns
+- Base image updates for CVE remediation are recorded in `ReleaseNotes.md` with specific version changes
+- Security patches are relatively infrequent (7 commits in 12 months) but high priority when they occur

--- a/.github/skills/security-patch/assets/README.md
+++ b/.github/skills/security-patch/assets/README.md
@@ -1,0 +1,6 @@
+# Security Patch — Assets
+
+Static assets supporting the security patch skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/security-patch/references/README.md
+++ b/.github/skills/security-patch/references/README.md
@@ -1,0 +1,6 @@
+# Security Patch — References
+
+Reference materials for the security patch skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/security-patch/scripts/README.md
+++ b/.github/skills/security-patch/scripts/README.md
@@ -1,0 +1,6 @@
+# Security Patch — Scripts
+
+Automation scripts supporting the security patch skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,72 @@
+# Security Review
+
+## Purpose
+Perform a STRIDE-based security review of code changes in the Docker-Provider repository, checking for credential leaks, weak security patterns, and threat model gaps specific to containerized Kubernetes monitoring agents.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## When to Use
+- When reviewing any PR that modifies authentication, network, or data handling code
+- When changes touch Dockerfiles, Helm charts, Kubernetes manifests, or RBAC configurations
+- When dependency changes introduce new packages
+- Before major version releases
+
+## Inputs
+- Files changed in the PR or commit range
+- Target component (Ruby plugins, Go plugins, infrastructure, scripts)
+
+## Outputs
+- STRIDE assessment for each changed component
+- Credential leak scan results
+- Weak security pattern findings
+- Recommended fixes
+
+## Steps
+
+1. **Enumerate changed files** and classify by security impact:
+   - High: Dockerfiles, Helm values, RBAC, auth code, secret handling
+   - Medium: Plugin code with external calls, configuration files
+   - Low: Tests, documentation, internal logic
+
+2. **Apply STRIDE analysis** to high/medium impact files:
+   - **Spoofing:** Check MSI/FIC authentication in Azure SDK calls. Verify certificate validation in Go HTTP clients. Check `InsecureSkipVerify` is not set to `true`.
+   - **Tampering:** Verify ConfigMap inputs are validated. Check file permissions in Dockerfile (`chmod`/`chown`). Verify Helm chart values are sanitized.
+   - **Repudiation:** Ensure security-relevant actions emit Application Insights telemetry. Check that error paths log sufficient context.
+   - **Information Disclosure:** Scan for hardcoded `APPLICATIONINSIGHTS_AUTH` values. Check no secrets in `echo`/`Log()` statements. Verify `.gitignore` excludes `*.pem`, `*.key`, `.env`.
+   - **Denial of Service:** Check Kubernetes resource limits in manifests. Verify log processing has backpressure. Check for unbounded goroutines in Go code.
+   - **Elevation of Privilege:** Verify `USER` directive in Dockerfiles (non-root). Check RBAC roles in Helm chart templates. Verify `securityContext` in pod specs.
+
+3. **Run credential leak scan** on all changed files:
+   - Pattern: base64-encoded strings > 32 chars (potential keys)
+   - Pattern: `APPLICATIONINSIGHTS_AUTH=` followed by literal values
+   - Pattern: connection strings (`Server=...;Password=...`)
+   - Pattern: private keys (`-----BEGIN.*PRIVATE KEY-----`)
+   - Check `.trivyignore` entries have expiration dates and justification
+
+4. **Check language-specific weak patterns:**
+   - Go: `#nosec` annotations, unchecked crypto errors, `exec.Command` with unsanitized input
+   - Ruby: `eval`/`send` with user input, `YAML.load` instead of `YAML.safe_load`
+   - Shell: Unquoted variables, `curl | bash`, `chmod 777`, secrets in CLI arguments
+   - PowerShell: `Invoke-Expression` with user input, disabled execution policies
+
+5. **Verify CI security coverage:**
+   - CodeQL running on PR (`.github/workflows/codeql-analysis.yml`)
+   - DevSkim running on PR (`.github/workflows/devskim.yml`)
+   - Trivy scanning container image (`.github/workflows/pr-checker.yml`)
+
+## Validation
+- All findings categorized by STRIDE category and severity
+- No false positives for patterns explicitly allowed by the team
+- `.trivyignore` entries verified for validity
+
+## Risks and Guardrails
+- Do NOT expose actual secret values in review comments
+- Do NOT modify code — only report findings
+- Flag `.trivyignore` entries older than 90 days for re-evaluation
+
+## References
+- `SECURITY.md` — Microsoft responsible disclosure policy
+- `.github/workflows/codeql-analysis.yml` — CodeQL configuration
+- `.github/workflows/devskim.yml` — DevSkim configuration
+- `.github/workflows/pr-checker.yml` — Trivy scan configuration

--- a/.github/skills/security-review/assets/README.md
+++ b/.github/skills/security-review/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+This directory contains assets for the `security-review` skill.

--- a/.github/skills/security-review/references/README.md
+++ b/.github/skills/security-review/references/README.md
@@ -1,0 +1,3 @@
+# References
+
+This directory contains references for the `security-review` skill.

--- a/.github/skills/security-review/scripts/README.md
+++ b/.github/skills/security-review/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts
+
+This directory contains scripts for the `security-review` skill.

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,77 @@
+# Telemetry Authoring
+
+## Purpose
+Guide adding Application Insights telemetry to new or modified code in the Docker-Provider repository, following the existing telemetry patterns established by the Ruby `ApplicationInsightsUtility` class and Go `appinsights` SDK.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add Application Insights, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring Fluent Bit infrastructure, dashboard creation, alert rule authoring
+
+## When to Use
+- When adding new Ruby Fluentd plugins or Go Fluent Bit plugins
+- When adding new error handling paths that should report exceptions
+- When adding new entry points (HTTP handlers, scheduled tasks, plugin lifecycle methods)
+- When code review identifies telemetry gaps
+
+## Inputs
+- The file(s) being modified and their language (Ruby or Go)
+- The component type (input plugin, output plugin, filter, utility)
+- The specific code paths that need telemetry
+
+## Outputs
+- Telemetry instrumentation code added to the specified files
+- Consistent with existing patterns in neighboring files
+
+## Steps
+
+1. **Identify the telemetry SDK for the language:**
+   - **Ruby:** Use `ApplicationInsightsUtility` class from `source/plugins/ruby/ApplicationInsightsUtility.rb`
+   - **Go:** Use `appinsights` package from `github.com/microsoft/ApplicationInsights-Go/appinsights`
+
+2. **Sample existing telemetry patterns** — Read 3-5 files in the same directory that already have telemetry:
+   - Ruby: Look for `ApplicationInsightsUtility.sendExceptionTelemetry`, `sendCustomEvent`, `sendMetricTelemetry`
+   - Go: Look for `TelemetryClient.TrackMetric`, `TelemetryClient.TrackEvent`, `TelemetryClient.TrackException`
+
+3. **Add error path telemetry** (highest priority):
+   - Ruby: In every `rescue` block that represents an unexpected failure:
+     ```ruby
+     ApplicationInsightsUtility.sendExceptionTelemetry(e)
+     ```
+   - Go: In every `if err != nil` block:
+     ```go
+     SendException(err)
+     ```
+
+4. **Add entry point telemetry:**
+   - Ruby: In `configure`/`start`/`emit`/`filter` lifecycle methods, track operation start and duration
+   - Go: In plugin `FLBPluginFlush*` functions, track flush counts, sizes, and durations
+
+5. **Add standard dimensions to all telemetry:**
+   - Ruby: `Computer` (hostname), `ControllerType` (DaemonSet/ReplicaSet), `AgentVersion`
+   - Go: `CommonProperties` map with Computer, ControllerType, AgentVersion, ClusterId
+
+6. **Gate telemetry for test environments:**
+   - Ruby: Check `$in_unit_test` before sending telemetry
+   - Go: Check `GOUNITTEST` environment variable
+
+7. **Follow naming conventions:**
+   - Metric names: `<component>.<operation>.<measurement>` (e.g., `containerlog.flush.count`)
+   - Event names: `<ComponentAction>` (e.g., `ContainerLogFlushed`, `InventoryCollected`)
+   - Exception events: Use the SDK's exception tracking method, not custom events
+
+## Validation
+- Verify telemetry import/require matches existing files in the same directory
+- Verify metric/event names follow the naming convention used by neighboring files
+- Run unit tests to ensure telemetry additions don't break test isolation
+- Verify `$in_unit_test` / `GOUNITTEST` gating is in place
+
+## Risks and Guardrails
+- Do NOT log sensitive data (credentials, tokens, PII, request bodies)
+- Do NOT add telemetry inside tight loops (will generate excessive volume)
+- Do NOT use `puts`/`fmt.Println` for production telemetry — use the structured SDK
+- Do NOT create new TelemetryClient instances — reuse the existing singleton
+- Do NOT hardcode instrumentation keys — use env vars (`APPLICATIONINSIGHTS_AUTH`)
+
+## References
+- `source/plugins/ruby/ApplicationInsightsUtility.rb` — Ruby telemetry helper
+- `source/plugins/go/src/telemetry.go` — Go telemetry implementation
+- `source/plugins/go/input/lib/applicationinsights.go` — Go input plugin telemetry

--- a/.github/skills/telemetry-authoring/assets/README.md
+++ b/.github/skills/telemetry-authoring/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+This directory contains assets for the `telemetry-authoring` skill.

--- a/.github/skills/telemetry-authoring/references/README.md
+++ b/.github/skills/telemetry-authoring/references/README.md
@@ -1,0 +1,3 @@
+# References
+
+This directory contains references for the `telemetry-authoring` skill.

--- a/.github/skills/telemetry-authoring/scripts/README.md
+++ b/.github/skills/telemetry-authoring/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts
+
+This directory contains scripts for the `telemetry-authoring` skill.

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,84 @@
+# Test Authoring
+
+## Purpose
+Creates and maintains unit tests, integration tests, and end-to-end (e2e) tests for the Container Insights agent. Covers Go tests for Fluent Bit plugins, Ruby tests for Fluentd plugins, Shell script tests for Linux agent components, PowerShell tests for Windows agent components, and Ginkgo-based e2e tests.
+
+USE FOR: "add test", "write unit test", "increase coverage", "test for bug", "regression test", "e2e test", "Ginkgo test", "Ruby test", "Go test", "shell test", "PowerShell test"
+DO NOT USE FOR: Fixing the test infrastructure itself (use ci-cd-pipeline), running tests as part of a bug fix (tests are a step in bug-fix skill, not standalone)
+
+## When to Use
+- New code is added without corresponding tests
+- A bug fix needs a regression test
+- Test coverage needs improvement for a specific plugin or module
+- A new e2e test scenario is needed for Ginkgo test suites
+- Existing tests need to be updated due to code changes
+- Adding test cases for edge conditions (nil responses, API timeouts, malformed data)
+
+## Inputs
+- Source file(s) or feature to be tested
+- Test type: unit (Go, Ruby, Shell, PowerShell) or e2e (Ginkgo)
+- Expected behavior and edge cases to cover
+- Any mock data or fixtures needed
+
+## Outputs
+- New or updated test files in the appropriate test directory
+- All existing and new tests passing
+- Test runner scripts updated if new test files need to be included
+
+## Steps
+1. Determine the test type and framework based on the source code being tested:
+   - **Go unit tests**: Place alongside source code or run via `test/unit-tests/run_go_tests.sh`
+     - Tests for `source/plugins/go/src/` (output plugins)
+     - Tests for `source/plugins/go/input/` (input plugins)
+   - **Ruby unit tests**: Place in `test/unit-tests/` and run via `test/unit-tests/run_ruby_tests.sh`
+     - Uses `test_driver.rb` as the test harness for Fluentd plugins
+   - **Shell tests**: Add to `test/unit-tests/test_main.sh`
+     - Tests for bash scripts in `scripts/`, `build/`, `kubernetes/linux/`
+   - **PowerShell tests**: Add to `test/unit-tests/test_main.ps1`
+     - Tests for PowerShell scripts in `kubernetes/windows/`
+   - **Ginkgo e2e tests**: Add to the appropriate suite under `test/ginkgo-e2e/`
+     - `test/ginkgo-e2e/livenessprobe/` — liveness probe verification
+     - `test/ginkgo-e2e/containerstatus/` — container status checks
+     - `test/ginkgo-e2e/querylogs/` — log query validation
+     - `test/ginkgo-e2e/utils/` — shared e2e test utilities
+2. Write the test following existing patterns in the codebase:
+   - Go: standard `testing` package with table-driven tests
+   - Ruby: follow patterns in `test_driver.rb` and existing test files
+   - Shell: follow assertion patterns in `test_main.sh`
+   - PowerShell: follow Pester-style patterns in `test_main.ps1`
+   - Ginkgo: use `Describe`/`Context`/`It` blocks with Gomega matchers
+3. Add test data fixtures if needed:
+   - Mock Kubernetes API responses for Ruby plugin tests
+   - Sample log lines for Go input plugin tests
+   - Sample ConfigMap values for configuration parsing tests
+4. Run the specific test suite to verify:
+   - `bash test/unit-tests/run_go_tests.sh`
+   - `bash test/unit-tests/run_ruby_tests.sh`
+   - `bash test/unit-tests/test_main.sh`
+   - `pwsh test/unit-tests/test_main.ps1`
+5. Run all test suites to check for regressions
+6. Verify tests are picked up by CI: `run_unit_tests.yml` must execute the new tests
+
+## Validation
+- New tests fail when the feature/fix under test is reverted (tests are meaningful)
+- All test suites pass: `run_go_tests.sh`, `run_ruby_tests.sh`, `test_main.sh`, `test_main.ps1`
+- CI workflow `run_unit_tests.yml` picks up and runs the new tests
+- No flaky behavior: tests pass consistently across multiple runs
+- Test names clearly describe what is being tested
+- Edge cases are covered: nil/empty inputs, API errors, timeout scenarios
+
+## Risks and Guardrails
+- **Test isolation**: Each test must be independent; avoid shared mutable state between test cases
+- **Mock fidelity**: Kubernetes API mocks must reflect real API response structures; outdated mocks cause false positives
+- **Flaky tests**: Avoid time-dependent assertions or network calls in unit tests; use mocks for external dependencies
+- **Test runner registration**: New test files must be discoverable by the respective runner script; verify inclusion
+- **Ginkgo module independence**: Each `test/ginkgo-e2e/*/` directory is its own Go module; manage `go.mod` independently
+- **Windows test compatibility**: PowerShell tests in `test_main.ps1` must work on the Windows runner specified in CI
+- **Large test data**: Avoid committing large fixture files; generate test data programmatically when possible
+
+## Examples from This Repo
+- Go tests use table-driven test patterns with descriptive subtests
+- Ruby tests in `test/unit-tests/` use `test_driver.rb` to simulate Fluentd plugin lifecycle
+- Shell tests in `test_main.sh` validate configuration parsing and environment variable handling
+- Ginkgo e2e tests query Log Analytics workspaces to verify end-to-end data flow
+- Test runner scripts (`run_go_tests.sh`, `run_ruby_tests.sh`) aggregate results and return proper exit codes for CI

--- a/.github/skills/test-authoring/assets/README.md
+++ b/.github/skills/test-authoring/assets/README.md
@@ -1,0 +1,6 @@
+# Test Authoring — Assets
+
+Static assets supporting the test authoring skill.
+
+Place templates, sample configurations, fixture data, and other non-executable
+resources here that are used by the procedures in `../SKILL.md`.

--- a/.github/skills/test-authoring/references/README.md
+++ b/.github/skills/test-authoring/references/README.md
@@ -1,0 +1,6 @@
+# Test Authoring — References
+
+Reference materials for the test authoring skill.
+
+Place links, notes, and reference documents here that provide background context
+for the procedures described in `../SKILL.md`.

--- a/.github/skills/test-authoring/scripts/README.md
+++ b/.github/skills/test-authoring/scripts/README.md
@@ -1,0 +1,6 @@
+# Test Authoring — Scripts
+
+Automation scripts supporting the test authoring skill.
+
+Place executable helper scripts here (Shell, Python, Ruby, Go) that automate
+repetitive steps described in `../SKILL.md`.

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Clone the repository
+git clone https://github.com/microsoft/Docker-Provider.git
+cd Docker-Provider
+
+# Install Go 1.23+ (if not already installed)
+# See https://go.dev/doc/install
+
+# Install Ruby 3.3+ and Fluentd gem for Ruby plugin development
+gem install fluentd -v "1.14.2" --no-document
+gem install ipaddress --no-document
+
+# Build Go output plugin
+cd source/plugins/go/src && make fbplugin && cd -
+
+# Build Go input plugins
+cd source/plugins/go/input/containerinventory && make containerinventory && cd -
+cd source/plugins/go/input/perf && make perf && cd -
+
+# Verify with tests
+./test/unit-tests/test_main.sh
+./test/unit-tests/run_go_tests.sh
+```
+
+## Code Style
+
+### Ruby (Fluentd Plugins — `source/plugins/ruby/`)
+- `frozen_string_literal: true` at top of every file
+- Class variables (`@@`) for module-level state (e.g., `@@isWindows`, `@@os_type`)
+- `require_relative` for local dependencies, `require` for gems
+- Snake_case for methods and variables, PascalCase for classes
+- Fluent plugin registration pattern: `Fluent::Plugin.register_*('name', self)`
+- JSON-based data interchange between plugins
+- Telemetry via `ApplicationInsightsUtility` singleton class
+
+### Go (Fluent Bit Plugins — `source/plugins/go/`)
+- Standard Go formatting (`gofmt`)
+- Package-level variables for telemetry counters and shared state
+- `appinsights` SDK for Application Insights telemetry
+- CGO enabled for Fluent Bit plugin interface (C-shared build mode)
+- Error handling: check `err != nil` and log via telemetry or `Log()` function
+
+### Shell (Build & Operations — `scripts/`, `kubernetes/linux/`)
+- `set -e` and `set -o pipefail` in build scripts
+- Environment variable configuration (uppercase with underscores)
+- `#!/bin/bash` shebang for all shell scripts
+
+### PowerShell (Windows Agent — `kubernetes/windows/`, `build/windows/`)
+- PascalCase for function names, scripts, and parameters
+- Pester 5.x for testing with `Describe`/`Context`/`It` blocks
+
+## Testing Instructions
+
+### Unit Tests (CI runs all on PR to ci_dev/ci_prod)
+
+| Framework | Language | Command | Location |
+|-----------|----------|---------|----------|
+| Custom bash framework | Shell | `./test/unit-tests/test_main.sh` | `test/unit-tests/test_cases/` |
+| `go test` | Go | `./test/unit-tests/run_go_tests.sh` | `source/plugins/go/` |
+| Minitest via `test_driver.rb` | Ruby | `ruby test/unit-tests/test_driver.rb` | `source/plugins/ruby/*_test.rb` |
+| Pester 5.3.3 | PowerShell | `./test/unit-tests/test_main.ps1` | `test/unit-tests/test_cases/` |
+
+### E2E Tests
+| Framework | Command | Location |
+|-----------|---------|----------|
+| Ginkgo/Gomega (Go) | `cd test/ginkgo-e2e/<suite> && go test -v ./...` | `test/ginkgo-e2e/` |
+| Python (legacy) | `python test/e2e/...` | `test/e2e/` |
+
+### Adding Tests
+- Ruby: Create `*_test.rb` alongside source in `source/plugins/ruby/`
+- Go: Create `*_test.go` in the same package directory
+- Shell: Add test case file in `test/unit-tests/test_cases/`
+- PowerShell: Add `Test-*.ps1` in `test/unit-tests/test_cases/`
+
+## Dev Environment Tips
+
+- **Editor:** VS Code recommended. Install Go, Ruby, and PowerShell extensions.
+- **Docker:** Required for building container images (`kubernetes/linux/Dockerfile.multiarch`).
+- **Key env vars:** `OS_TYPE` (linux/windows), `CONTROLLER_TYPE` (DaemonSet/ReplicaSet), `AKS_RESOURCE_ID`, `APPLICATIONINSIGHTS_AUTH`.
+- **Local debugging:** Ruby plugins can be tested with `fluentd -c <config>` using test config files.
+- **Windows development:** Use `kubernetes/windows/` for Windows-specific agent code. PowerShell tests run on Windows only.
+
+## PR Instructions
+
+- **Commit messages:** Freeform style. Include PR number in parentheses, e.g., `fix liveness probe issue (#1530)`.
+- **Branch naming:** Feature branches, no enforced convention. Target `ci_dev` or `ci_prod`.
+- **Required checks:** CodeQL, DevSkim, Trivy scan, unit tests (Bash, Go, Ruby, PowerShell).
+- **Merge strategy:** Squash merge via GitHub PR.
+- **Release notes:** Update `ReleaseNotes.md` for version releases. Update Helm chart versions in `charts/*/Chart.yaml`.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "AKS/Arc Cluster"
+        DS[ama-logs DaemonSet<br/>Linux + Windows] --> FB[Fluent Bit]
+        RS[ama-logs-rs ReplicaSet] --> FB
+        FB --> GoOut[Go Output Plugin<br/>out_oms.so]
+        FB --> GoIn[Go Input Plugins<br/>containerinventory.so, perf.so]
+        FB --> RubyPlugins[Ruby Fluentd Plugins<br/>Inventory, Perf, MDM]
+    end
+
+    GoOut --> |Container Logs| LA[Log Analytics<br/>Workspace]
+    GoOut --> |Network Flow Logs| LA
+    RubyPlugins --> |Metrics| MDM[Azure Monitor<br/>Metrics / MDM]
+    RubyPlugins --> |Inventory| LA
+    GoIn --> |Container Inventory| LA
+    GoIn --> |Perf Counters| LA
+
+    RubyPlugins --> AI[Application Insights<br/>Agent Telemetry]
+    GoOut --> AI
+
+    subgraph "Build & Deploy"
+        DF[Dockerfile.multiarch] --> ACR[Azure Container Registry]
+        HC[Helm Charts] --> AKS[AKS Cluster]
+        AP[Azure Pipelines] --> ACR
+    end
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,75 @@
+# Docker-Provider (Azure Monitor Container Insights Agent)
+
+Azure Monitor agent for Kubernetes that collects container logs, metrics, inventory, and performance data from AKS and Arc-enabled Kubernetes clusters. Runs as Fluent Bit/Fluentd plugins inside containerized DaemonSet and ReplicaSet pods on Linux and Windows nodes.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log Collection Plugins | Ruby (Fluentd), Go (Fluent Bit) |
+| Build System | Make, Docker, Azure Pipelines |
+| Container Runtime | Docker (multi-arch: amd64 + arm64) |
+| Orchestration | Kubernetes (DaemonSet + ReplicaSet) |
+| Package Management | Helm Charts |
+| Telemetry | Application Insights (Ruby + Go SDKs) |
+| CI/CD | GitHub Actions (PR checks), Azure Pipelines (builds + releases) |
+| Security Scanning | CodeQL, DevSkim, Trivy |
+| Testing | Bash framework, Go test, Ruby Minitest, PowerShell Pester, Ginkgo E2E |
+| Infrastructure | Terraform, Bicep (onboarding scripts) |
+| Cloud Targets | AKS, Arc-enabled K8s, ARO |
+
+## Architecture Overview
+
+The agent is deployed as two workloads: a DaemonSet (`ama-logs`) on every node for log collection, and a ReplicaSet (`ama-logs-rs`) for cluster-level inventory. Both use Fluent Bit as the log pipeline with Go output plugins (`out_oms.so`) for sending data and Ruby Fluentd plugins for metrics, inventory, and MDM integration. Data flows to Log Analytics workspaces and Azure Monitor Metrics.
+
+## Functional Requirements
+### 1) Collect container logs from all pods and forward to Log Analytics
+### 2) Collect Kubernetes inventory (pods, nodes, containers, PVs) and send to Log Analytics
+### 3) Collect performance metrics (CPU, memory, disk) via CAdvisor and send to Azure Monitor Metrics
+### 4) Support multi-arch builds (amd64 + arm64) for Linux and Windows nodes
+### 5) Support multiple cloud environments (Azure Public, Azure China, Azure Government, Azure Bleu)
+
+## Non-Functional Requirements
+
+- **Security:** Trivy container scanning, CodeQL SAST, DevSkim analysis on every PR
+- **Observability:** Agent self-telemetry via Application Insights (heartbeat, exceptions, performance metrics)
+- **Reliability:** Liveness probes, graceful shutdown, retry logic for data transmission
+- **Performance:** Efficient log parsing with Fluent Bit, configurable flush intervals
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/ruby/` | Ruby Fluentd plugins (inventory, metrics, MDM filters) |
+| `source/plugins/go/src/` | Go Fluent Bit output plugin (container logs) |
+| `source/plugins/go/input/` | Go Fluent Bit input plugins (container inventory, perf) |
+| `kubernetes/linux/` | Linux Dockerfile, main.sh entry point, setup scripts |
+| `kubernetes/windows/` | Windows Dockerfile, main.ps1 entry point |
+| `charts/` | Helm charts for deployment |
+| `build/linux/` | Linux build system (Makefile, installer) |
+| `scripts/` | Onboarding, troubleshooting, and build scripts |
+| `test/` | Unit tests, E2E tests, scenario tests |
+| `.pipelines/` | Azure Pipelines for builds and releases |
+| `.github/workflows/` | GitHub Actions for PR checks |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `APPLICATIONINSIGHTS_AUTH` | Base64-encoded Application Insights instrumentation key |
+| `APPLICATIONINSIGHTS_ENDPOINT` | Application Insights ingestion endpoint URL |
+| `AKS_RESOURCE_ID` | Azure resource ID of the AKS cluster |
+| `AKS_REGION` | Azure region of the cluster |
+| `OS_TYPE` | Operating system type (linux/windows) |
+| `CONTROLLER_TYPE` | Kubernetes controller type (DaemonSet/ReplicaSet) |
+| `AGENT_VERSION` | Current agent version string |
+| `CONTAINER_RUNTIME` | Container runtime in use |
+
+## Acceptance Criteria
+
+- All unit tests pass: Bash, Go, Ruby, and PowerShell
+- CodeQL analysis reports no new vulnerabilities
+- DevSkim scan reports no new security issues
+- Trivy container scan shows no new critical/high vulnerabilities
+- Docker image builds successfully for both amd64 and arm64
+- Helm chart lints successfully

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,169 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for this repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand your codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `copilot-instructions.md` on every session — no action needed.
+3. When you open a file matching a language pattern, the corresponding `.instructions.md` file auto-activates.
+4. Invoke skills by typing their trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them in chat (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically every session | Root router — general rules, skill catalogue, build instructions |
+| `AGENTS.md` | Root | Automatically (supported tools) | Setup commands, code style, testing instructions, architecture |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match (`applyTo` glob) | Language-specific coding rules (Ruby, Go, Shell, PowerShell) |
+| `Prompt.md` | Root | On demand | Reusable task-spec template for describing new work |
+| Skill files (`SKILL.md`) | `.github/skills/` | On keyword trigger | Step-by-step guides for recurring development tasks |
+| `CodeReviewer.agent.md` | `.github/agents/` | On @-mention | Structured code review following repo conventions |
+| `SecurityReviewer.agent.md` | `.github/agents/` | On @-mention | Deep security analysis, threat modeling, STRIDE review |
+| `DocumentWriter.agent.md` | `.github/agents/` | On @-mention | Documentation authoring following repo standards |
+| `prd.agent.md` | `.github/agents/` | On @-mention | PRD generation tailored to this project |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically by VS Code | MCP server connections (GitHub, Microsoft Docs) |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: copilot-instructions.md (always loaded)
+  ├── General rules, skill catalogue, build instructions
+  ├── Routes to →
+  │
+Layer 2: .instructions.md files (auto-loaded when you open matching files)
+  ├── ruby.instructions.md → *.rb files
+  ├── go.instructions.md → *.go files
+  ├── shell.instructions.md → *.sh files
+  ├── powershell.instructions.md → *.ps1 files
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+**You don't need to manually load anything.** The system activates automatically based on what file you're editing and what you ask the AI to do.
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Performs structured code reviews covering correctness, style, security (STRIDE), telemetry gaps, and adherence to project conventions.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review my changes for telemetry gaps`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates and maintains documentation following this repo's structure and conventions.
+- **Example prompts:**
+  - `@DocumentWriter write release notes for version 3.1.36`
+  - `@DocumentWriter update the README for this module`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Performs deep security assessments including STRIDE threat modeling, attack surface analysis, dependency auditing, and infrastructure security review.
+- **Example prompts:**
+  - `@SecurityReviewer perform a threat model for the Go output plugin`
+  - `@SecurityReviewer review the Dockerfile security configuration`
+  - `@SecurityReviewer audit our container security context`
+- **When to use vs. @CodeReviewer:** Use `@SecurityReviewer` for dedicated, deep security analysis. The CodeReviewer applies a lightweight security checklist during routine reviews.
+
+### @prd (PRD Generator)
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **What it does:** Generates structured Product Requirements Documents tailored to this project's architecture and tech stack.
+- **Example prompts:**
+  - `@prd create a PRD for adding network flow log support`
+  - `@prd write requirements for a new telemetry stream`
+
+## Using Skills
+
+Skills are step-by-step guides that activate when you use their trigger phrases in chat.
+
+### Always-Available Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "threat model", "STRIDE analysis" | STRIDE-based security review with credential scanning |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Add Application Insights telemetry following existing patterns |
+| `fix-critical-vulnerabilities` | "fix CVE", "trivy fix", "patch vulnerability" | Fix critical/high vulnerabilities using repo scanning tools |
+
+### Commit-History-Driven Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `dependency-update` | "update dependency", "bump package" | Update Go modules and system packages safely |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix with regression test requirement |
+| `feature-development` | "add feature", "implement", "new plugin" | New feature scaffolding for plugins and components |
+| `test-authoring` | "add test", "write test" | Create tests following repo conventions (Bash/Go/Ruby/PS) |
+| `ci-cd-pipeline` | "update pipeline", "modify workflow" | CI/CD and Azure Pipeline changes |
+| `infrastructure` | "update Dockerfile", "modify Helm chart" | Container, Helm, and Kubernetes changes |
+| `code-refactoring` | "refactor", "restructure", "rename" | Code refactoring workflow |
+| `security-patch` | "security fix", "CVE patch" | Security-specific code fixes |
+| `documentation` | "update docs", "write release notes" | Documentation and release notes updates |
+
+**Example usage:**
+```
+# In Copilot Chat, just describe the task naturally:
+"Add a test for the new Ruby inventory plugin"
+"Fix the critical CVE in our Go dependencies"
+"Add telemetry to the network flow log handler"
+"Update the Fluent Bit version in the Dockerfile"
+```
+
+## Using Prompt.md for New Work
+
+`Prompt.md` is a reusable template for describing new tasks or features. Use it when:
+- Starting a new feature and want to give the AI full context.
+- Handing off a task specification to another developer or AI agent.
+- Creating a structured brief for a complex change.
+
+**How to use:**
+1. Copy `Prompt.md` to a new file (e.g., `feature-xyz-prompt.md`).
+2. Fill in the sections with your specific requirements.
+3. Reference it in Copilot Chat: "Implement the feature described in feature-xyz-prompt.md".
+
+## Using AGENTS.md
+
+`AGENTS.md` provides setup, style, and testing instructions. Most AI tools load it automatically. It's useful for:
+- **Onboarding:** Follow the Setup Commands to get a working build environment.
+- **Consistency:** Code Style sections ensure AI-generated code matches repo conventions.
+- **PR readiness:** PR Instructions help format commits and PRs correctly.
+
+## MCP Server Integration
+
+The `.vscode/mcp.json` file configures connections to external data sources:
+- **GitHub MCP:** Enables PR management, issue tracking, and branch operations directly from chat.
+- **Microsoft Docs MCP:** Enables validation of Azure SDK usage against official Microsoft documentation.
+
+MCP servers are configured in `.vscode/mcp.json`. Secrets use `${input:variable}` prompts — you'll be asked for credentials on first use.
+
+## Tips for Maximum Productivity
+
+1. **Let auto-loading work for you** — Just open the file you're working on. The `.instructions.md` files activate automatically based on file type.
+2. **Use natural language for skills** — Don't invoke skills by name. Just describe the task: "add a test", "bump dependencies", "review security".
+3. **Start reviews with @CodeReviewer** — It knows the repo's review patterns, linter rules, and security requirements.
+4. **Use @prd before big features** — A structured PRD helps the AI and your team understand the full scope before writing code.
+5. **Reference Prompt.md for complex tasks** — When a task needs more context than a chat message, fill in a copy of Prompt.md.
+6. **Check AGENTS.md for setup** — If the AI struggles with build or test commands, verify the Setup Commands in AGENTS.md.
+
+## Customizing These Artifacts
+
+These files are meant to evolve with your project:
+- **Add rules** to `.instructions.md` files when you establish new coding conventions.
+- **Add skills** when you identify a new recurring workflow (create a `SKILL.md` in `.github/skills/`).
+- **Update `copilot-instructions.md`** when project structure or build commands change.
+- **Update `AGENTS.md`** when setup commands, test strategies, or dev environment requirements change.
+- **Re-run generation** periodically (e.g., quarterly) to pick up new commit patterns.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow coding conventions | Verify `.instructions.md` `applyTo` glob matches the file you're editing |
+| Skill not activating | Use the exact trigger phrases listed in the skill table above |
+| Agent not available | Ensure the `.agent.md` file is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` config and provide credentials when prompted |
+| AI gives generic advice | It may not be loading `copilot-instructions.md` — verify the file exists in `.github/` |
+| Build/test commands fail | Update the Setup Commands section in `AGENTS.md` to match your current environment |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,67 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Testing shell script functions?** → Bash unit test in `test/unit-tests/test_cases/` using the custom framework (`test_framework.sh`)
+2. **Testing Go plugin logic?** → Go test file (`*_test.go`) in the same package directory, run with `go test`
+3. **Testing Ruby Fluentd plugin?** → Ruby test file (`*_test.rb`) in `source/plugins/ruby/`, run via `test/unit-tests/test_driver.rb`
+4. **Testing PowerShell functions?** → Pester test (`Test-*.ps1`) in `test/unit-tests/test_cases/`, run with `test_main.ps1`
+5. **Testing end-to-end log collection?** → Ginkgo test in `test/ginkgo-e2e/`, uses Azure SDK for Log Analytics queries
+6. **Testing container deployment?** → Ginkgo test in `test/ginkgo-e2e/containerstatus/` for pod scheduling validation
+
+## Test Patterns in This Repo
+
+### Bash Unit Tests
+- Framework: Custom bash test framework (`test/unit-tests/test_framework.sh`)
+- Location: Test functions in `test/unit-tests/test_functions/`, test cases in `test/unit-tests/test_cases/`
+- Naming: Functions named `test_*` or descriptive names like `getClusterCloudEnvironment.sh`
+- Entry point: `test/unit-tests/test_main.sh`
+- CI: Runs in `run_unit_tests.yml` GitHub Actions workflow
+
+### Go Unit Tests
+- Framework: Standard `go test` with `-cover -race` flags
+- Location: Test files alongside source in `source/plugins/go/`
+- Naming: `*_test.go` (standard Go convention)
+- Entry point: `test/unit-tests/run_go_tests.sh`
+- CI: Runs with Go 1.23.8 in `run_unit_tests.yml`
+
+### Ruby Unit Tests
+- Framework: Minitest (via `test_driver.rb`)
+- Location: `source/plugins/ruby/*_test.rb` alongside source files
+- Naming: `*_test.rb` matching the source file name
+- Entry point: `ruby test/unit-tests/test_driver.rb`
+- Prerequisites: `gem install fluentd -v "1.14.2"` and `gem install ipaddress`
+- Important: Set `$in_unit_test = true` to gate telemetry during tests
+- CI: Runs in `run_unit_tests.yml` after installing Fluentd gem
+
+### PowerShell Unit Tests
+- Framework: Pester 5.3.3
+- Location: Test functions in `test/unit-tests/test_functions/`, test cases in `test/unit-tests/test_cases/`
+- Naming: `Test-*.ps1` for test cases, function names matching test functions
+- Entry point: `test/unit-tests/test_main.ps1`
+- CI: Runs on `windows-latest` in `run_unit_tests.yml`
+
+### Ginkgo E2E Tests
+- Framework: Ginkgo v2 + Gomega
+- Location: `test/ginkgo-e2e/` with suites: `querylogs/`, `containerstatus/`, `livenessprobe/`
+- Dependencies: Azure SDK (`azquery`), Kubernetes client (`client-go`)
+- Pattern: `DescribeTable` with `Entry` for data-driven tests
+- Requires: Running AKS cluster with agent deployed, `AKS_RESOURCE_ID` env var
+
+## Common Test Utilities
+
+| Utility | Location | Purpose |
+|---------|----------|---------|
+| `utils` package | `test/ginkgo-e2e/utils/` | Kubernetes client setup, Log Analytics queries, pod validation |
+| `test_framework.sh` | `test/unit-tests/test_framework.sh` | Bash test assertion functions |
+| `test_framework.ps1` | `test/unit-tests/test_framework.ps1` | PowerShell test helpers |
+| Canned API responses | `test/unit-tests/canned-api-responses/` | Mock Kubernetes API responses for unit tests |
+
+## Test Data
+
+- Canned Kubernetes API responses: `test/unit-tests/canned-api-responses/`
+- Scenario test manifests: `test/scenario/yamls/` (pod definitions for testing)
+- Multiline log test data: `test/scenario/multiline/` (language-specific log patterns)
+- TestKube workflows: `test/testkube/` (Kubernetes-native test execution)


### PR DESCRIPTION
## Summary

Auto-generated AI agent artifacts for coding assistants.

### What's included
- `copilot-instructions.md` — root instructions for AI agents
- `AGENTS.md` — setup, style, and testing instructions
- `Prompt.md` — structured prompt template
- `.instructions.md` files — language/framework-specific conventions (Ruby, Go, Shell, PowerShell)
- `SKILL.md` files — 12 task-specific skills derived from commit history (dependency-update, bug-fix, feature-development, ci-cd-pipeline, infrastructure, test-authoring, code-refactoring, security-patch, documentation) plus always-generated skills (security-review, telemetry-authoring, fix-critical-vulnerabilities)
- Agent definitions: CodeReviewer, SecurityReviewer, DocumentWriter, prd
- `.vscode/mcp.json` — MCP server configuration (GitHub, Microsoft Docs)
- `test/AGENTS.md` — test framework guide
- `coding-agent-instructions.md` — user guide for all artifacts

### How to verify
1. Open the repo in VS Code / GitHub Codespaces
2. Start a Copilot Chat session
3. Verify agents respond correctly: `@CodeReviewer`, `@SecurityReviewer`, `@DocumentWriter`, `@prd`
4. Check that `.instructions.md` files activate for matching file types

> Auto-generated by the agentify prompt. Review before merging.