### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,86 @@
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Docker-Provider repository (Azure Monitor Container Insights agent). You review changes for correctness, security, telemetry coverage, and adherence to project conventions across Ruby, Go, Shell, and PowerShell code.
+
+## Review Philosophy
+Prioritize these areas based on the repo's history and patterns:
+1. **Security & CVE exposure** — Hardcoded secrets, vulnerable dependencies, Trivy scan compliance
+2. **Telemetry coverage** — New error paths and entry points must have Application Insights instrumentation
+3. **Error handling** — All external calls (Kubernetes API, Azure endpoints) must have proper error handling
+4. **Correctness** — Logic errors, race conditions in concurrent Go code, nil/null safety
+5. **Test coverage** — New functionality must have corresponding unit tests
+
+## Scope
+- **Review**: `source/plugins/`, `kubernetes/`, `build/`, `charts/`, `test/`, `.github/workflows/`, `scripts/`
+- **Skip**: Auto-generated files, `node_modules/`, `vendor/`, lock files, `.trivyignore` (unless adding new entries)
+
+## Review Triggers
+- On pull requests targeting `ci_dev` or `ci_prod` branches
+- On code changes in source, Dockerfiles, Helm charts, or CI workflows
+- Excluded: documentation-only PRs (Markdown changes only)
+
+## PR Diff Method
+Use `gh pr diff <number>` to obtain the correct diff. Do NOT use `git diff origin/ci_prod...HEAD` — use `git diff $(git merge-base origin/ci_prod HEAD)...HEAD` for local review.
+
+## Review Checklist
+- [ ] Code follows naming conventions (Ruby: `snake_case`, Go: `PascalCase`/`camelCase`)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded configuration values
+- [ ] Error handling follows repo patterns (Ruby: `begin/rescue`, Go: `if err != nil`)
+- [ ] Logging uses project conventions (Ruby: `$log.warn/error`, Go: `Log()`)
+- [ ] `frozen_string_literal: true` in all Ruby files
+- [ ] CI checks would pass (lint, build, test, Trivy scan)
+- [ ] Helm chart `Chart.yaml` version bumped if chart files changed
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Auth checks at entry points; tokens validated
+- [ ] **Tampering** — Input validated; TLS verification enabled on HTTP calls
+- [ ] **Repudiation** — Security actions logged via ApplicationInsights
+- [ ] **Information Disclosure** — No secrets in logs/errors; env vars for credentials
+- [ ] **Denial of Service** — Resource limits set; chunk sizes bounded; HTTP timeouts configured
+- [ ] **Elevation of Privilege** — Non-root containers; RBAC least-privilege
+- [ ] **Credential Leak Scan** — No API keys, tokens, or connection strings in changed files
+- [ ] **Weak Pattern Scan** — No disabled TLS, weak crypto, or shell injection vectors
+
+### Telemetry Review Checklist
+- [ ] New error paths have `ApplicationInsightsUtility.sendExceptionTelemetry` (Ruby) or `appinsights.TrackException` (Go)
+- [ ] New entry points track operation name, duration, and success/failure
+- [ ] New external calls track target, duration, and status
+- [ ] Telemetry follows existing patterns (same SDK, naming, dimensions)
+- [ ] No sensitive data in telemetry properties
+- [ ] Test isolation preserved (telemetry gated for unit test environments)
+
+## Language-Specific Best Practices
+
+### Go
+- **Reviewer-focus**: Error handling completeness (`if err != nil` → log + return), goroutine leak prevention, proper mutex usage for shared state.
+- **Idiomatic**: Use `Log()` function, not `fmt.Println`. Use `os.Getenv()` for config. Build tags for platform-specific code.
+- **Common mistakes**: Forgetting to close HTTP response bodies, not checking Fluent Bit return codes.
+
+### Ruby
+- **Reviewer-focus**: `frozen_string_literal: true` present, `require_relative` for internal deps, proper `begin/rescue` blocks on API calls.
+- **Idiomatic**: Use `ApplicationInsightsUtility` for telemetry, `KubernetesApiClient` for K8s API, chunk-based processing.
+- **Common mistakes**: Missing error handling on JSON parsing, not checking env var nil/empty before use.
+
+### Shell
+- **Reviewer-focus**: Variable quoting, `set -e` usage, no world-writable permissions.
+- **Common mistakes**: Unquoted variables in conditionals, missing error checks on critical commands.
+
+### PowerShell
+- **Reviewer-focus**: Pester 5.x test patterns, proper error handling with `try/catch`.
+
+## Security Checks
+
+### CI Security Tool Coverage
+- **SAST**: CodeQL (`.github/workflows/codeql-analysis.yml`)
+- **Pattern matching**: DevSkim (`.github/workflows/devskim.yml`)
+- **Container scanning**: Trivy (`.github/workflows/pr-checker.yml`)
+- **Dependency updates**: Manual (no Dependabot/Renovate configured — recommend adding)
+
+## Testing Expectations
+- Go changes → `./test/unit-tests/run_go_tests.sh`
+- Ruby changes → `./test/unit-tests/run_ruby_tests.sh`
+- Shell changes → `./test/unit-tests/test_main.sh`
+- PowerShell changes → `./test/unit-tests/test_main.ps1`
+- All four suites run in CI via `run_unit_tests.yml`

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,64 @@
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Docker-Provider repository. Your job is to create and maintain documentation that is accurate, consistent, and follows the project's documentation conventions.
+
+## Audience & Tone
+- Primary audience: DevOps engineers and SREs who deploy and manage Azure Monitor Container Insights
+- Secondary audience: contributors developing the agent itself
+- Tone: direct, technical, task-oriented
+- Use second person ("you") for instructional content
+- Assume familiarity with Kubernetes, Docker, and Azure Monitor concepts
+
+## Documentation Structure
+- `README.md` — Project overview and quick start
+- `Documentation/` — Detailed guides organized by topic:
+  - `Documentation/AgentSettings/` — Agent configuration options
+  - `Documentation/DCR/` — Data Collection Rule documentation
+  - `Documentation/External/` — External-facing docs (Grafana dashboards)
+  - `Documentation/Internal/` — Internal-facing docs
+  - `Documentation/MultiTenancyLogging/` — Multi-tenancy setup guides
+  - `Documentation/NetworkFlowLogging/` — Network flow logging docs
+- `ReleaseNotes.md` — Chronological release notes
+- `Dev Guide.md` — Developer contribution guide
+- `MARINER.md` — Mariner-specific documentation
+- `ReleaseProcess.md` — Release procedures
+
+## Writing Conventions
+- Heading style: ATX (`#`, `##`, `###`)
+- Code blocks: use triple backticks with language annotation (```bash, ```yaml, ```go)
+- Lists: use `-` for unordered lists
+- File references: use backtick-wrapped relative paths (`source/plugins/go/src/`)
+- Maximum line length: no enforced limit (wrap at logical boundaries)
+- Include `## Prerequisites` section in setup/installation guides
+
+## Documentation Types
+- **README files**: Project and directory overviews
+- **Configuration guides**: Step-by-step setup instructions with YAML/JSON examples
+- **Release notes**: Version-based entries with bullet points for changes
+- **Developer guides**: Contribution instructions with build/test commands
+
+## Templates
+
+### Release Note Entry
+```markdown
+## Release <version>
+- <change description> (#<PR number>)
+- <change description> (#<PR number>)
+```
+
+### Code Comment Conventions
+- Ruby: Use `#` comments above complex logic; no RDoc conventions enforced
+- Go: Use `//` comments; exported functions should have godoc-style comments
+- Shell: Use `#` comments for non-obvious logic; include header comment block in scripts
+
+## Cross-References
+- Reference other docs with relative Markdown links
+- Reference source files with backtick-wrapped paths
+- Reference PRs with `(#1234)` format
+
+## Validation
+- All file paths referenced in documentation must exist in the repo
+- All code examples must be syntactically valid
+- All build/test commands must match actual CI configuration
+- Release note entries must reference valid PR numbers

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,81 @@
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Docker-Provider repository. You perform deep security assessments that go beyond routine code review. This agent is for Kubernetes monitoring infrastructure that handles sensitive cluster data and credentials.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist on every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR modifies authentication logic (AAD MSI, FIC auth, Arc cluster identity)
+- New external-facing endpoints or data streams are added
+- Dockerfiles or Kubernetes RBAC manifests are modified
+- Preparing for a release with security-sensitive changes
+- After a CVE fix to assess residual exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- **Entry points**: Fluent Bit HTTP endpoints, Kubernetes API watchers, named pipe listeners (Windows), MDSD pipeline
+- **Trust boundaries**: Container → Host, Agent → Kubernetes API, Agent → Azure Monitor, Agent → MDM endpoint
+- **Sensitive data**: Instrumentation keys (`APPLICATIONINSIGHTS_AUTH`), cluster identity tokens, Azure JSON credentials (`/etc/kubernetes/host/azure.json`)
+- **Network exposure**: Ports in Dockerfiles, ingress in Helm chart templates
+
+### 2. STRIDE Deep Analysis
+
+**Spoofing:**
+- Authentication paths: `arc_k8s_cluster_identity.rb`, `ingestion_token_utils.go`, FIC auth
+- AAD MSI auth mode verification (`AAD_MSI_AUTH_MODE` env var)
+- Token refresh and expiry handling
+
+**Tampering:**
+- Kubernetes API response validation before processing
+- Config file integrity (fluentd/fluent-bit configs in container)
+- Image supply chain — base image pinning, no `latest` tags
+
+**Repudiation:**
+- Audit logging via Application Insights telemetry
+- Authentication failure tracking
+
+**Information Disclosure:**
+- Secret handling: env vars only, never config files or logs
+- Log scrubbing: ensure container logs collected don't leak agent secrets
+- Telemetry properties: no PII or credentials in custom dimensions
+
+**Denial of Service:**
+- Kubernetes API pagination (chunk sizes)
+- HTTP client timeouts on all outbound calls
+- Container resource limits in Helm values and manifests
+- Fluent Bit back-pressure handling
+
+**Elevation of Privilege:**
+- Container security context in `kubernetes/ama-logs.yaml`
+- ClusterRole permissions (least-privilege for API access)
+- Dockerfile USER directive
+
+### 3. Dependency Security Assessment
+- Go modules: check `source/plugins/go/src/go.mod` against known CVEs
+- OS packages: check Dockerfile `apt-get install` packages
+- Ruby gems: check for vulnerable gem versions
+- Trivy scan compliance
+
+### 4. Infrastructure Security Review
+- Container images: non-root user, minimal base image, pinned versions
+- Kubernetes RBAC: `kubernetes/ama-logs.yaml` ClusterRole/ClusterRoleBinding
+- Secret management: mounted secrets vs env vars
+- Network policies: ingress/egress restrictions in Helm templates
+
+## Output Format
+
+### Findings Summary
+| # | Severity | STRIDE | Finding | Location | Recommendation |
+|---|----------|--------|---------|----------|----------------|
+
+### Detailed Findings
+For each finding:
+- **Description:** What the vulnerability or risk is
+- **Impact:** What an attacker could achieve
+- **Reproduction:** Steps to demonstrate (if applicable)
+- **Recommendation:** Specific fix with code reference
+- **Priority:** Critical / High / Medium / Low

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,62 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or changes to the Docker-Provider agent."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider (Azure Monitor Container Insights) agent. You follow a consistent template tailored to this project's Kubernetes monitoring architecture and multi-language codebase.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring gap or user pain does this solve?
+- Success criteria: how do we measure this is working? (telemetry metrics, log coverage, error rates)
+
+### 2. Requirements
+- Functional requirements (what data to collect, where to send it, what format)
+- Non-functional requirements (latency, resource usage, scale limits, backward compatibility)
+- Out of scope (explicitly state what this does NOT include)
+
+### 3. Architecture
+- Which components are affected? (Go plugin, Ruby plugin, shell scripts, Dockerfiles, Helm charts)
+- Data flow: how does data move from source → Fluent Bit/Fluentd → Azure Monitor?
+- Configuration: new env vars, ConfigMap fields, or Helm values needed?
+- Platform considerations: Linux-only, Windows-only, or both?
+- DaemonSet vs ReplicaSet: which controller type handles this feature?
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change:
+  - Go: `source/plugins/go/src/` or `source/plugins/go/input/`
+  - Ruby: `source/plugins/ruby/`
+  - Shell: `kubernetes/linux/`
+  - PowerShell: `kubernetes/windows/`
+  - Helm: `charts/azuremonitor-containers/`
+- Feature gating strategy (env var flag for safe rollout)
+
+### 5. Testing Strategy
+- Unit tests: Go (`testify`), Ruby (Fluentd test driver), Bash, PowerShell (Pester)
+- E2E tests: Ginkgo or pytest scenarios to add
+- Scale testing: impact on large clusters (thousands of nodes/pods)
+- Trivy scan: no new critical/high CVEs introduced
+
+### 6. Monitoring & Observability
+- New telemetry to add via `ApplicationInsightsUtility` (Ruby) or `appinsights` (Go)
+- Custom metrics and event names following `<component>.<operation>.<measurement>` convention
+- Standard dimensions: Computer, ControllerType, AgentVersion, ClusterId
+- Error tracking for new code paths
+
+### 7. Deployment
+- Rollout strategy: feature flag → canary → production
+- Helm chart changes: new values, template updates, Chart.yaml version bump
+- Configuration changes: new env vars, ConfigMap entries
+- Backward compatibility: ensure older agent versions continue to work
+- Rollback procedure: disable feature via env var
+
+## Adaptation Rules
+- Reference actual Go, Ruby, Shell, and PowerShell source paths
+- Architecture section must map to the Fluent Bit/Fluentd plugin architecture
+- Testing strategy must include all four unit test suites
+- Deployment section must account for both AKS and Arc-enabled clusters

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Repository Instructions
+
+## Summary
+
+Docker-Provider (aka Azure Monitor Container Insights agent, `ama-logs`) is a Kubernetes monitoring agent that collects container logs, metrics, inventory, and events from AKS and Arc-enabled Kubernetes clusters. It ships as a Linux/Windows container image running Fluent Bit (Go output/input plugins) and Fluentd (Ruby input/filter/output plugins), forwarding data to Azure Monitor Log Analytics and Azure Monitor Metrics (MDM). Primary languages: Ruby, Go, Shell, PowerShell. Runtime: Kubernetes DaemonSet + ReplicaSet.
+
+## General Guidelines
+
+1. Follow existing code patterns — sample 3–5 neighboring files before adding new code.
+2. Use `frozen_string_literal: true` in all Ruby files.
+3. Use `ApplicationInsightsUtility` (Ruby) or `appinsights` SDK (Go) for telemetry — never introduce new telemetry libraries.
+4. All secrets must come from environment variables — never hardcode keys, tokens, or connection strings.
+5. Test changes with the appropriate unit test suite: `test/unit-tests/test_main.sh` (Bash), `test/unit-tests/run_go_tests.sh` (Go), `test/unit-tests/run_ruby_tests.sh` (Ruby), or `test/unit-tests/test_main.ps1` (PowerShell).
+6. Container images are built via `cd build/linux && make` (Linux) and Docker build in `kubernetes/linux/Dockerfile.multiarch`.
+7. Helm charts in `charts/` must have `Chart.yaml` version bumped for any chart changes.
+8. PR titles typically include a short description and PR number: `description (#1234)`.
+
+## Build Instructions
+
+```bash
+# Prerequisites: Go 1.23+, Ruby with fluentd gem, build-essential, Docker
+# Linux build
+cd build/linux && make
+
+# Docker image build
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag>
+
+# Unit tests
+./test/unit-tests/test_main.sh        # Bash tests
+./test/unit-tests/run_go_tests.sh     # Go tests
+./test/unit-tests/run_ruby_tests.sh   # Ruby tests (requires fluentd gem)
+```
+
+## Task-Specific Skills
+
+| Skill | Triggers | Description |
+|-------|----------|-------------|
+| `#dependency-update` | update dependency, bump package, upgrade library | Safe dependency update workflow |
+| `#test-authoring` | add test, write test | Create tests following repo conventions |
+| `#bug-fix` | fix bug, resolve issue, hotfix | Structured bug fix with regression test |
+| `#feature-development` | add feature, implement, new plugin | New feature scaffolding |
+| `#code-refactoring` | refactor, restructure, rename | Behavior-preserving refactoring |
+| `#infrastructure` | update Dockerfile, Helm chart, k8s manifest | Infrastructure change workflow |
+| `#security-review` | security review, threat model, STRIDE | STRIDE-based security review |
+| `#telemetry-authoring` | add telemetry, add metrics, instrument code | Add telemetry following existing patterns |
+| `#fix-critical-vulnerabilities` | fix CVE, trivy fix, vulnerability fix | Fix critical/high CVEs |
+
+## Known Patterns & Gotchas
+
+- The Go plugin builds as a shared library (`out_oms.so`) loaded by Fluent Bit — it uses CGo exports.
+- Ruby plugins use Fluentd's plugin API (`Fluent::Plugin`) — input, filter, and output types.
+- `kubernetes/linux/setup.sh` and `kubernetes/linux/main.sh` are the container entrypoint scripts — changes here affect all deployments.
+- The `CONTROLLER_TYPE` env var (`DaemonSet`/`ReplicaSet`) determines which code paths execute.
+- Trivy scanning runs in the `pr-checker` workflow and blocks PRs with critical/high CVEs.
+- `.trivyignore` can temporarily suppress specific CVEs — always add a comment explaining why.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.go"
+description: "Go coding conventions for Fluent Bit plugins in this repository."
+---
+
+# Go Conventions
+
+- Use the custom `Log()` function for all logging — never use `fmt.Println` or `log.Print` in production code.
+- Always check `err != nil` after every function call and log the error with context before returning.
+- Fluent Bit output plugin exports use `//export FLBPlugin*` CGo comments — follow the existing pattern in `out_oms.go`.
+- Use `sync.Mutex` or `sync.Once` for shared state — the plugins run concurrently across goroutines.
+- Telemetry: use `appinsights.NewTelemetryClient()` and `appinsights.TrackEvent()`/`TrackMetric()` — reference `telemetry.go` for patterns.
+- Environment variables: use `os.Getenv()` for configuration — never hardcode connection strings or keys.
+- Build tags: use `//go:build linux` or `//go:build windows` for platform-specific files (e.g., `utils_linux.go`, `utils_windows.go`).
+- Dependencies are in `source/plugins/go/src/go.mod` — run `go mod tidy` after any dependency changes.
+- Unit tests use `testify` assertions — place `*_test.go` files alongside source.
+- The plugin compiles to a shared object (`out_oms.so`) loaded by Fluent Bit — avoid `init()` side effects that break the plugin loader.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "**/*.ps1,**/*.psm1"
+description: "PowerShell coding conventions for this repository."
+---
+
+# PowerShell Conventions
+
+- Use `param()` blocks at the top of scripts for parameter declarations.
+- The Windows agent entrypoint is `kubernetes/windows/main.ps1` — changes affect all Windows deployments.
+- Helper functions live in `kubernetes/windows/functions/` — use dot-sourcing to import them.
+- Use Pester 5.x for unit tests — test files follow `*.Tests.ps1` naming convention.
+- Environment variables: access via `$env:VAR_NAME` — never hardcode secrets or connection strings.
+- Use `Write-Host` for user-facing output, structured logging for production telemetry.
+- Windows Docker image is built from `kubernetes/windows/Dockerfile`.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.rb"
+description: "Ruby coding conventions for Fluentd plugins in this repository."
+---
+
+# Ruby Conventions
+
+- Always include `# frozen_string_literal: true` as the second line (after shebang if present).
+- Fluentd plugins must register with `Fluent::Plugin.register_input/filter/output('name', self)`.
+- Use `require_relative` for project files (e.g., `require_relative "ApplicationInsightsUtility"`), `require` for gems.
+- Use `ApplicationInsightsUtility.sendExceptionTelemetry(e)` for error telemetry — never create new telemetry clients.
+- Class variables (`@@`) are the standard pattern for shared state within plugin classes.
+- Wrap external API calls (Kubernetes, MDM) in `begin/rescue` blocks and log errors via `$log.warn` or `$log.error`.
+- Use the `KubernetesApiClient` utility for all Kubernetes API interactions — do not create raw HTTP clients.
+- Configuration comes from env vars (`ENV["VAR_NAME"]`) — never hardcode cluster-specific values.
+- Chunked processing: use `PODS_CHUNK_SIZE`, `NODES_CHUNK_SIZE` env vars for batch sizes.
+- Constants go in `constants.rb` — reference `require_relative "constants"`.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**/*.sh"
+description: "Shell script conventions for this repository."
+---
+
+# Shell Conventions
+
+- Use `#!/bin/bash` shebang for all scripts.
+- Source shared environment: `source /opt/env_vars` in container entrypoint scripts.
+- Quote all variable expansions: `"$VAR"` not `$VAR`.
+- Use `set -e` in scripts that must fail on error.
+- Check `CONTROLLER_TYPE` (`DaemonSet`/`ReplicaSet`) and `CONTAINER_TYPE` env vars for conditional logic.
+- Log to files under `/var/opt/microsoft/docker-cimprov/log/` — follow the existing log path conventions.
+- Use `if [ condition ]; then` style (POSIX-compatible) rather than `[[ ]]` when possible.
+- Container scripts in `kubernetes/linux/` are the main entrypoints — changes affect all deployed agents.
+- Installer scripts in `build/linux/installer/` follow the installbuilder pattern — do not restructure.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,44 @@
+# Bug Fix
+
+## Description
+Structured workflow for fixing bugs in the Docker-Provider agent.
+
+USE FOR: fix bug, resolve issue, hotfix, patch, debug, error fix
+DO NOT USE FOR: feature development, refactoring without behavior change, performance optimization
+
+## Instructions
+
+### When to Apply
+When a bug is reported in container log collection, inventory, metrics, or agent behavior.
+
+### Step-by-Step Procedure
+1. **Reproduce**: Identify the code path — check `CONTROLLER_TYPE` (DaemonSet vs ReplicaSet) and `OS_TYPE` (Linux vs Windows) to narrow scope.
+2. **Locate**: Trace the issue through the data flow:
+   - Log collection: `source/plugins/go/src/oms.go` → `out_oms.go`
+   - Inventory: `source/plugins/ruby/in_kube_*.rb` or `source/plugins/go/input/`
+   - Metrics/MDM: `source/plugins/ruby/filter_*2mdm.rb` → `out_mdm.rb`
+   - Startup/config: `kubernetes/linux/main.sh` or `kubernetes/linux/setup.sh`
+3. **Fix**: Apply the minimal change that addresses the root cause.
+4. **Test**: Add a regression test in the appropriate framework.
+5. **Verify**: Run the relevant unit test suite.
+6. **Telemetry**: Ensure error paths have `ApplicationInsightsUtility.sendExceptionTelemetry` (Ruby) or `appinsights.TrackException` (Go) calls.
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` — Go plugin logic
+- `source/plugins/ruby/*.rb` — Ruby plugin logic
+- `kubernetes/linux/main.sh`, `kubernetes/linux/setup.sh` — Container entrypoints
+- Corresponding test files
+
+### Validation
+- Relevant unit test suite passes
+- Docker image builds successfully
+- No regression in existing test coverage
+
+## Examples from This Repo
+- `cfcc530` — fix: bleu cloud name is azurebleucloud (#1598)
+- `5c0bca0` — bug fix (#1593)
+- `fbcc3de` — fix bug (#1577)
+
+## References
+- `source/plugins/ruby/omslog.rb` — Logging utility
+- `source/plugins/go/src/telemetry.go` — Go telemetry patterns

--- a/.github/skills/code-refactoring/SKILL.md
+++ b/.github/skills/code-refactoring/SKILL.md
@@ -1,0 +1,38 @@
+# Code Refactoring
+
+## Description
+Guide for refactoring existing code while preserving behavior.
+
+USE FOR: refactor, restructure, rename, extract method, simplify, clean up
+DO NOT USE FOR: adding features, changing behavior, fixing bugs
+
+## Instructions
+
+### When to Apply
+When improving code structure, readability, or maintainability without changing functionality.
+
+### Step-by-Step Procedure
+1. **Identify scope**: Determine which files and modules are affected.
+2. **Run existing tests** before making changes to establish a baseline.
+3. **Make changes incrementally**: rename, extract, or restructure one concern at a time.
+4. **Update imports/references**: If renaming files or moving code, update all `require_relative` (Ruby), import paths (Go), or source commands (Shell).
+5. **Run all affected test suites** after each change.
+6. **Verify Docker image builds** to catch any broken references.
+
+### Files Typically Involved
+- Depends on refactoring scope — could touch any source files
+- Corresponding test files must be updated to match
+
+### Validation
+- All unit test suites pass (unchanged behavior)
+- Docker image builds successfully
+- No new test failures
+
+## Examples from This Repo
+- `f58b7f0` — Longw/networkflow strean rename (#1570)
+- `e26dab1` — Longw/networkflow rename (#1553)
+- `e8c6f0d` — update mapping logic from extensions to aggregate (#1585)
+
+## References
+- `source/plugins/ruby/constants.rb` — Shared constants
+- `source/plugins/go/src/extension/` — Extension module patterns

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,47 @@
+# Dependency Update
+
+## Description
+Guide for safely updating Go modules, Ruby gems, and other dependencies in the Docker-Provider agent.
+
+USE FOR: update dependency, bump package, upgrade library, update go.mod, update gems, renovate
+DO NOT USE FOR: adding a brand-new dependency, removing a dependency, major version migration requiring code changes
+
+## Instructions
+
+### When to Apply
+When upgrading package versions in `go.mod`, `go.sum`, or system-level packages in Dockerfiles.
+
+### Step-by-Step Procedure
+1. Identify which dependency to update and the target version.
+2. For Go modules:
+   - Edit `source/plugins/go/src/go.mod` (and/or `source/plugins/go/input/go.mod`) with the new version.
+   - Run `cd source/plugins/go/src && go mod tidy` (repeat for `input/` if applicable).
+   - Verify `go.sum` is updated consistently.
+3. For Dockerfile packages:
+   - Update package versions in `kubernetes/linux/Dockerfile.multiarch` or `kubernetes/windows/Dockerfile`.
+4. For test dependencies:
+   - Update `test/ginkgo-e2e/*/go.mod` files if test modules share the updated dependency.
+5. Run unit tests: `./test/unit-tests/run_go_tests.sh`
+6. Build the Docker image: `cd build/linux && make`
+7. Verify Trivy scan passes (the PR checker runs this automatically).
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `test/ginkgo-e2e/*/go.mod`
+
+### Validation
+- `go mod tidy` exits without errors
+- `./test/unit-tests/run_go_tests.sh` passes
+- Docker image builds successfully
+- Trivy scan shows no new critical/high CVEs
+
+## Examples from This Repo
+- `30c4efb` — Fix CVEs though updating go packages and ruby gem (#1414)
+- `090c1dd` — Upgrade Fluent Bit to 4.0.9, add missing dependencies (#1535)
+- `a71f549` — Fluent bit 4.0.14 (#1601)
+
+## References
+- [Go Modules Reference](https://go.dev/ref/mod)
+- `build/linux/Makefile` — build targets

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,46 @@
+# Feature Development
+
+## Description
+Guide for adding new features to the Docker-Provider agent (new data streams, plugins, or capabilities).
+
+USE FOR: add feature, implement, new plugin, new data stream, new endpoint, new module
+DO NOT USE FOR: bug fixes, refactoring, documentation-only changes
+
+## Instructions
+
+### When to Apply
+When adding new data collection capabilities, new output destinations, or new operational features.
+
+### Step-by-Step Procedure
+1. **Design**: Determine the feature scope:
+   - New Fluent Bit plugin? → Go code in `source/plugins/go/`
+   - New Fluentd plugin? → Ruby code in `source/plugins/ruby/`
+   - New container entrypoint logic? → Shell in `kubernetes/linux/` or PowerShell in `kubernetes/windows/`
+2. **Create source files**:
+   - Go plugins: add to `source/plugins/go/src/` or `source/plugins/go/input/`
+   - Ruby plugins: add to `source/plugins/ruby/`, register with `Fluent::Plugin.register_*`
+3. **Add configuration**: Update Fluent Bit/Fluentd config files in `kubernetes/linux/` as needed.
+4. **Add telemetry**: Use `ApplicationInsightsUtility` (Ruby) or `appinsights` (Go) for tracking the new feature's operation.
+5. **Add tests**: Create unit tests in the appropriate framework.
+6. **Update Dockerfile** if new dependencies are needed.
+7. **Update Helm chart values** if new configuration options are exposed.
+
+### Files Typically Involved
+- `source/plugins/go/src/` or `source/plugins/ruby/` — New plugin code
+- `kubernetes/linux/setup.sh` or `kubernetes/linux/main.sh` — Entrypoint changes
+- `charts/azuremonitor-containers/values.yaml` — Helm configuration
+- `build/linux/Makefile` — Build system updates for new Go plugins
+
+### Validation
+- All unit test suites pass
+- Docker image builds successfully
+- New feature is gated by env var or config flag for safe rollout
+
+## Examples from This Repo
+- `c02975e` — Adding change for networkflow logs new stream (#1551)
+- `089b095` — Added FIC auth support (#1539)
+- `c9f5dfa` — Add private link support for high log scale (#1512)
+
+## References
+- `source/plugins/go/src/out_oms.go` — Go output plugin pattern
+- `source/plugins/ruby/in_kube_perfinventory.rb` — Ruby input plugin pattern

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,57 @@
+# Fix Critical Vulnerabilities
+
+## Description
+Identify and fix critical/high CVEs in the Docker-Provider agent using the repo's scanning tools (Trivy, CodeQL, DevSkim).
+
+USE FOR: fix critical vulnerability, CVE fix, trivy fix, patch CVE, address vulnerabilities, security bump
+DO NOT USE FOR: general code refactoring, feature development, non-security dependency updates
+
+## Instructions
+
+### When to Apply
+When Trivy scan reports critical or high CVEs in the container image, or when security scanning identifies vulnerabilities in dependencies.
+
+### Step-by-Step Procedure
+1. **Identify vulnerabilities**:
+   - Run Trivy locally: `trivy image <image-tag>` or check PR checker workflow output.
+   - Note CVE IDs, affected packages, and fixed versions.
+   - Check `.trivyignore` for any temporarily suppressed CVEs.
+2. **Determine fix approach**:
+   - **Go dependency CVE**: Update version in `source/plugins/go/src/go.mod` and `source/plugins/go/input/go.mod`, run `go mod tidy`.
+   - **OS package CVE**: Update package version in `kubernetes/linux/Dockerfile.multiarch` or `kubernetes/windows/Dockerfile`.
+   - **Ruby gem CVE**: Update or remove affected gem — check if it's used by Fluentd plugins.
+   - **Base image CVE**: Update base image tag in Dockerfile.
+3. **Apply fixes**:
+   - Update the dependency/package to the patched version.
+   - If no fix is available, add to `.trivyignore` with a comment explaining the CVE and expected fix timeline.
+4. **Test**:
+   - Run `./test/unit-tests/run_go_tests.sh` (for Go changes).
+   - Build Docker image: `cd build/linux && make`
+   - Run Trivy scan to verify the CVE is resolved.
+5. **Update release notes** in `ReleaseNotes.md` with CVE fix details.
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/windows/Dockerfile`
+- `.trivyignore` — for temporary suppression
+- `ReleaseNotes.md` — document fixes
+
+### Validation
+- Trivy scan shows no critical/high unfixed CVEs
+- All unit test suites pass
+- Docker image builds successfully
+- PR checker workflow passes
+
+## Examples from This Repo
+- `31c5bc4` — Longw/3.1.35 address vulnerabilities (#1605)
+- `6f4c31f` — 3.1.32 CVE fixes (#1596)
+- `733532d` — 3.1.31 CVEs fixes (#1572)
+- `15e97f5` — Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)
+- `9dcd86c` — CVEs Fix (#1526)
+
+## References
+- `.github/workflows/pr-checker.yml` — Trivy scan configuration
+- `.trivyignore` — Suppressed CVEs with justifications
+- `ReleaseNotes.md` — Release documentation

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,51 @@
+# Infrastructure
+
+## Description
+Guide for modifying Dockerfiles, Helm charts, Kubernetes manifests, and deployment configurations.
+
+USE FOR: update Dockerfile, Helm chart, Kubernetes manifest, deployment config, pipeline
+DO NOT USE FOR: application logic changes, test-only changes, documentation
+
+## Instructions
+
+### When to Apply
+When modifying container images, Helm charts, Kubernetes deployment manifests, or CI/CD pipelines.
+
+### Step-by-Step Procedure
+1. **Dockerfiles**:
+   - Linux: Edit `kubernetes/linux/Dockerfile.multiarch`
+   - Windows: Edit `kubernetes/windows/Dockerfile`
+   - Always use pinned base image tags (not `latest`)
+   - Ensure `USER` directive runs as non-root where possible
+2. **Helm charts**:
+   - Charts are in `charts/azuremonitor-containers/` and `charts/azuremonitor-containers-geneva/`
+   - Bump version in `Chart.yaml` for any change
+   - Update `values.yaml` for new configuration options
+   - Verify templates render correctly: `helm template <chart-dir>`
+3. **Kubernetes manifests**:
+   - Main manifest: `kubernetes/ama-logs.yaml`
+   - Contains DaemonSet, ReplicaSet, ConfigMap definitions
+4. **Deployment pipelines**:
+   - Azure Pipelines configs in `.pipelines/`
+   - GitHub Actions in `.github/workflows/`
+
+### Files Typically Involved
+- `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- `charts/azuremonitor-containers/Chart.yaml`, `charts/azuremonitor-containers/values.yaml`
+- `charts/azuremonitor-containers/templates/`
+- `kubernetes/ama-logs.yaml`
+- `.pipelines/*.yaml`
+
+### Validation
+- Docker image builds: `cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t test`
+- Helm lint: `helm lint charts/azuremonitor-containers/`
+- Trivy scan passes (run via PR checker)
+
+## Examples from This Repo
+- `a71f549` — Fluent bit 4.0.14 (#1601)
+- `090c1dd` — Upgrade Fluent Bit to 4.0.9, add missing dependencies (#1535)
+- `a9286fd` — deploy new image to prod clusters using helm chart
+
+## References
+- `charts/azuremonitor-containers/Chart.yaml` — Helm chart metadata
+- `.github/workflows/pr-checker.yml` — Build and scan workflow

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,85 @@
+# Security Review
+
+## Description
+Perform a STRIDE-based security review of changes to the Docker-Provider agent.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues
+
+## Instructions
+
+### When to Apply
+For any PR that modifies authentication logic, network-facing code, data handling, Dockerfiles, Helm charts, or dependency changes.
+
+### Step-by-Step Procedure
+
+#### 1. STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Verify token/credential validation in `source/plugins/ruby/arc_k8s_cluster_identity.rb` and `source/plugins/go/src/ingestion_token_utils.go`.
+- Check that service-to-service calls use managed identity or certificate-based auth.
+- Verify AAD MSI auth mode is correctly checked (`AAD_MSI_AUTH_MODE` env var).
+
+**Tampering (Data Integrity)**
+- Input validation on Kubernetes API responses before processing.
+- TLS verification is enabled for all outbound HTTP calls (no `InsecureSkipVerify`).
+- File permissions on config files and certificates are restrictive.
+
+**Repudiation (Auditability)**
+- Security-relevant actions logged via `ApplicationInsightsUtility` (Ruby) or `appinsights` (Go).
+- Authentication failures are tracked in telemetry.
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets: `APPLICATIONINSIGHTS_AUTH`, connection strings, tokens must come from env vars.
+- Secrets not logged: check `$log.warn`/`$log.error`/`Log()` calls don't include sensitive values.
+- `.trivyignore` entries are justified with comments.
+
+**Denial of Service (Availability)**
+- Container resource limits set in Kubernetes manifests and Helm charts.
+- Chunk sizes bounded (`PODS_CHUNK_SIZE`, `NODES_CHUNK_SIZE`).
+- HTTP timeouts configured on outbound connections.
+
+**Elevation of Privilege (Authorization)**
+- Dockerfile `USER` directive — verify non-root where possible.
+- Kubernetes RBAC: `kubernetes/ama-logs.yaml` ClusterRole uses least-privilege.
+- No `privileged: true` or `hostNetwork: true` without justification.
+
+#### 2. Credential & Secret Leak Detection
+- Scan for hardcoded strings matching: API keys, tokens (`ghp_`, `Bearer`), connection strings, private keys.
+- Verify `.gitignore` excludes `*.pem`, `*.key`, `.env`.
+- Check that `APPLICATIONINSIGHTS_AUTH` and `APPLICATIONINSIGHTS_ENDPOINT` values are never logged.
+
+#### 3. Language-Specific Weak Patterns
+
+**Go:**
+- No `#nosec` without justification comment.
+- No `fmt.Sprintf` for SQL/command construction with user input.
+- `exec.Command` not used with unsanitized input.
+
+**Ruby:**
+- No `eval`/`send` with user-controlled input.
+- `YAML.safe_load` instead of `YAML.load` for untrusted data.
+- No `system()` with unvalidated input.
+
+**Shell:**
+- All variables quoted in commands.
+- No `chmod 777` or overly permissive permissions.
+- `set -e` in security-critical scripts.
+- No secrets passed as command-line arguments.
+
+**Dockerfiles/k8s:**
+- No `latest` tags for base images.
+- Secrets in mounted volumes, not ENV.
+- Security contexts set (readOnlyRootFilesystem, runAsNonRoot where possible).
+
+### Validation
+- Trivy scan passes
+- CodeQL scan passes
+- DevSkim scan passes
+- No credentials in changed files
+
+## References
+- `.github/workflows/codeql-analysis.yml` — CodeQL SAST
+- `.github/workflows/devskim.yml` — DevSkim pattern matching
+- `.github/workflows/pr-checker.yml` — Trivy container scanning
+- `SECURITY.md` — Security policy

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,92 @@
+# Telemetry Authoring
+
+## Description
+Guide for adding telemetry instrumentation following the existing Application Insights patterns in the Docker-Provider agent.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+When adding new code paths, error handling, or features that need observability instrumentation.
+
+### Step-by-Step Procedure
+
+#### 1. Telemetry Pattern Discovery
+Before adding telemetry, identify the existing pattern in the relevant language:
+
+**Ruby — uses `ApplicationInsightsUtility` wrapper:**
+```ruby
+require_relative "ApplicationInsightsUtility"
+
+# Track exceptions
+ApplicationInsightsUtility.sendExceptionTelemetry(e)
+
+# Track custom events
+ApplicationInsightsUtility.sendCustomEvent("EventName", {"property" => "value"})
+
+# Track metrics
+ApplicationInsightsUtility.sendMetricTelemetry("metricName", metricValue, {})
+```
+
+**Go — uses `appinsights` SDK directly:**
+```go
+import "github.com/microsoft/ApplicationInsights-Go/appinsights"
+
+// Track events (see telemetry.go for initialization pattern)
+telemetryClient.TrackEvent("EventName")
+
+// Track metrics
+telemetryClient.TrackMetric("metricName", value)
+
+// Track exceptions
+telemetryClient.TrackException(err)
+```
+
+#### 2. What to Instrument (priority order)
+
+a. **Error paths** — every `rescue`/`if err != nil` for unexpected failures:
+   - Include: error type, message, operation context
+   - Ruby: `ApplicationInsightsUtility.sendExceptionTelemetry(e)`
+   - Go: `SendException(err)` or `telemetryClient.TrackException(err)`
+
+b. **Entry points** (new plugins, handlers):
+   - Track operation name, duration, success/failure
+   - Ruby: Use timer pattern from existing plugins (e.g., `in_kube_perfinventory.rb`)
+   - Go: Track in `FLBPluginFlush` pattern (see `oms.go`)
+
+c. **External calls** (Kubernetes API, Azure endpoints):
+   - Track target, duration, status code
+   - Ruby: Wrap with `begin/rescue` and send telemetry on failure
+   - Go: Log and track with `appinsights`
+
+d. **Custom metrics** (counters, gauges):
+   - Follow naming: `<component>.<operation>.<measurement>` (e.g., `container_logs.flush.count`)
+   - Standard properties: `Computer`, `ControllerType`, `AgentVersion`
+
+#### 3. Standard Dimensions
+Always include these properties when available:
+- `Computer` / hostname
+- `ControllerType` (`DaemonSet`/`ReplicaSet`)
+- `AgentVersion` (from `AGENT_VERSION` env var)
+- `ClusterId` (from `AKS_RESOURCE_ID` env var)
+
+#### 4. Anti-Patterns to Avoid
+- Do NOT log sensitive data (keys, tokens, PII, request bodies)
+- Do NOT add telemetry inside tight loops
+- Do NOT use `puts`/`print`/`fmt.Println` for production telemetry
+- Do NOT create new TelemetryClient instances — reuse existing ones
+- Do NOT hardcode instrumentation keys — use `APPLICATIONINSIGHTS_AUTH` env var
+- Respect `$in_unit_test` / `GOUNITTEST` guards in test environments
+
+### Validation
+- Telemetry import matches existing files
+- Metric/event names follow repo naming conventions
+- Standard dimensions included
+- Unit tests pass (telemetry doesn't break test isolation)
+
+## References
+- `source/plugins/ruby/ApplicationInsightsUtility.rb` — Ruby telemetry wrapper
+- `source/plugins/go/src/telemetry.go` — Go telemetry initialization and patterns
+- `source/plugins/go/input/lib/applicationinsights.go` — Go input plugin telemetry

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,45 @@
+# Test Authoring
+
+## Description
+Guide for adding tests following the repo's multi-language test conventions.
+
+USE FOR: add test, write test, test coverage, add unit test, add integration test, test for feature
+DO NOT USE FOR: fixing flaky tests, refactoring test infrastructure, E2E test environment setup
+
+## Instructions
+
+### When to Apply
+When adding new functionality or fixing bugs that require regression tests.
+
+### Step-by-Step Procedure
+1. Determine the language of the code under test:
+   - **Go** → Create `*_test.go` file alongside the source in `source/plugins/go/src/` or `source/plugins/go/input/`.
+   - **Ruby** → Create `*_test.rb` file alongside the source in `source/plugins/ruby/`.
+   - **Bash** → Create `test/unit-tests/test_cases/test_<name>.sh` following the test framework.
+   - **PowerShell** → Create `test/unit-tests/*.Tests.ps1` using Pester 5.x.
+2. Follow existing test patterns:
+   - Go: Use `testify` assertions (`assert.Equal`, `assert.NoError`), `gomock` for mocking.
+   - Ruby: Use Fluentd test driver (`Fluent::Test::Driver::Input/Filter/Output`).
+   - Bash: Use the custom test framework (`test/unit-tests/test_framework.sh`).
+   - PowerShell: Use Pester `Describe`/`It`/`Should` blocks.
+3. Run the appropriate test suite to verify.
+4. Ensure tests are deterministic — no dependency on live Kubernetes API or network access.
+
+### Files Typically Involved
+- `source/plugins/go/src/*_test.go`
+- `source/plugins/ruby/*_test.rb`
+- `test/unit-tests/test_cases/test_*.sh`
+- `test/unit-tests/*.Tests.ps1`
+
+### Validation
+- Run the specific test suite for the language
+- CI workflow `run_unit_tests.yml` passes all four suites
+
+## Examples from This Repo
+- `source/plugins/go/src/oms_test.go` — Go unit tests for the OMS output plugin
+- `source/plugins/ruby/in_kube_nodes_test.rb` — Ruby test for Kubernetes node inventory
+- `test/unit-tests/test_cases/test_getClusterCloudEnvironment.sh` — Bash unit test
+
+## References
+- `test/unit-tests/test_framework.sh` — Bash test framework documentation
+- `.github/workflows/run_unit_tests.yml` — CI test configuration

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Clone the repository
+git clone https://github.com/microsoft/Docker-Provider.git
+cd Docker-Provider
+
+# Install Go (1.23+)
+# See https://go.dev/doc/install
+
+# Install Ruby dependencies (for Ruby plugin tests)
+sudo gem install fluentd -v "1.14.2" --no-document
+sudo gem install ipaddress --no-document
+
+# Install build dependencies (Linux)
+sudo apt-get install build-essential -y
+
+# Build Go plugins
+cd build/linux && make
+```
+
+## Code Style
+
+### Ruby
+- Always use `frozen_string_literal: true` pragma at the top of every file.
+- Fluent plugins inherit from `Fluent::Plugin::Input`, `Fluent::Plugin::Filter`, or `Fluent::Plugin::Output`.
+- Use `require_relative` for project-internal dependencies, `require` for gems.
+- Class variables (`@@`) are used extensively for shared state within plugins.
+- Use double-quoted strings for string interpolation, single or double for literals (both are used).
+- Naming: `snake_case` for methods/variables, `PascalCase` for classes, `SCREAMING_SNAKE` for constants.
+
+### Go
+- Standard `package main` for Fluent Bit output plugins; exported functions use `//export` CGo comments.
+- Use `PascalCase` for exported functions, `camelCase` for unexported.
+- Error handling: always check `err != nil` and log before returning.
+- Logging via the custom `Log()` function (writes to lumberjack file logger).
+- Telemetry via `appinsights` SDK — `appinsights.NewTelemetryClient()`.
+
+### Shell (Bash)
+- Use `#!/bin/bash` shebang.
+- Source shared env: `source /opt/env_vars`.
+- Use `set -e` in critical scripts.
+- Quote all variable expansions.
+
+### PowerShell
+- Use `param()` block for script parameters.
+- Follow Pester 5.x conventions for tests.
+
+## Testing Instructions
+
+Four test suites run in CI via `run_unit_tests.yml`:
+
+| Suite | Command | Framework |
+|-------|---------|-----------|
+| Bash | `./test/unit-tests/test_main.sh` | Custom shell test framework |
+| Go | `./test/unit-tests/run_go_tests.sh` | `go test` + `testify` |
+| Ruby | `./test/unit-tests/run_ruby_tests.sh` | Fluentd test driver |
+| PowerShell | `./test/unit-tests/test_main.ps1` | Pester 5.3.3 |
+
+**E2E tests:** Ginkgo-based tests in `test/ginkgo-e2e/` and Python tests in `test/e2e/`.
+
+**Test file naming:**
+- Go: `*_test.go` alongside source files
+- Ruby: `*_test.rb` alongside source files
+- Bash: `test/unit-tests/test_cases/test_*.sh`
+- PowerShell: `test/unit-tests/*.Tests.ps1`
+
+## Dev Environment Tips
+
+- The agent runs as a Kubernetes DaemonSet (per-node) and ReplicaSet (cluster-level).
+- `CONTROLLER_TYPE` env var (`DaemonSet`/`ReplicaSet`) determines active code paths.
+- `OS_TYPE` env var (`linux`/`windows`) determines platform-specific behavior.
+- Container image is built from `kubernetes/linux/Dockerfile.multiarch` (Linux) or `kubernetes/windows/Dockerfile` (Windows).
+- The main entrypoint is `/opt/main.sh` (Linux) or `C:\opt\amalogswindows\scripts\powershell\main.ps1` (Windows).
+- Key env vars: `APPLICATIONINSIGHTS_AUTH`, `AKS_RESOURCE_ID`, `AKS_REGION`, `AGENT_VERSION`, `AZMON_CLUSTER_COLLECT_ENV_VAR`.
+
+## PR Instructions
+
+- Commit messages: freeform with descriptive summary, PR number in parentheses (e.g., `Fix CVEs through updating go packages (#1414)`).
+- Target branches: `ci_dev` (development) or `ci_prod` (production).
+- CI checks: PR builds Linux and Windows Docker images, runs Trivy scan, runs all unit test suites.
+- PRs with critical/high CVEs from Trivy will be blocked.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Cluster"
+        DS[DaemonSet: ama-logs] --> |container logs| FB[Fluent Bit]
+        RS[ReplicaSet: ama-logs-rs] --> |cluster inventory| FD[Fluentd Ruby Plugins]
+        FB --> |out_oms.so| GO[Go Output Plugin]
+        FB --> |containerinventory.so| GI[Go Input Plugin]
+        FD --> |filters| MDM[MDM Metrics Output]
+        FD --> |inventory/events| LA[Log Analytics]
+        GO --> |logs| LA
+        GO --> |logs| AMA[AMA/MDSD Pipeline]
+        GI --> |container inventory| FB
+    end
+    LA --> |Azure Monitor| AM[Azure Monitor Logs]
+    MDM --> |Azure Monitor| AMM[Azure Monitor Metrics]
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,84 @@
+# Docker-Provider (Azure Monitor Container Insights Agent)
+
+A Kubernetes monitoring agent that collects container logs, metrics, inventory, and events from AKS and Arc-enabled Kubernetes clusters. Ships as Linux/Windows container images running Fluent Bit with Go plugins and Fluentd with Ruby plugins.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log collection (output) | Go — Fluent Bit output plugin (`out_oms.so`) |
+| Log collection (input) | Go — Fluent Bit input plugins (`containerinventory.so`, `perf.so`) |
+| Inventory & metrics | Ruby — Fluentd input/filter/output plugins |
+| Container runtime | Docker (Linux multiarch, Windows) |
+| Orchestration | Kubernetes (DaemonSet + ReplicaSet) |
+| Package management | Helm charts |
+| Telemetry | Application Insights (Go SDK + Ruby wrapper) |
+| Build system | Make + Go build + Docker build |
+| CI/CD | GitHub Actions |
+| Security scanning | CodeQL, DevSkim, Trivy |
+| IaC | Terraform, Bicep (onboarding scripts) |
+| Unit tests | Go test/testify, Fluentd test driver, Bash framework, Pester |
+| E2E tests | Ginkgo (Go), pytest (Python) |
+
+## Architecture Overview
+
+The agent deploys two pod types:
+1. **DaemonSet** — runs on every node, collects container stdout/stderr logs via Fluent Bit, forwards to Log Analytics or AMA/MDSD pipeline.
+2. **ReplicaSet** — single instance per cluster, collects Kubernetes inventory (pods, nodes, events, deployments), performance metrics, and sends to Log Analytics and MDM.
+
+Key data flow: Kubernetes API → Ruby/Go plugins → Fluent Bit/Fluentd → Azure Monitor (Logs + Metrics).
+
+## Functional Requirements
+### 1) Collect container stdout/stderr logs from all pods and forward to Azure Monitor Logs
+### 2) Collect Kubernetes object inventory (pods, nodes, events, deployments, HPA)
+### 3) Collect container performance metrics (CPU, memory) via cAdvisor
+### 4) Send custom metrics to Azure Monitor Metrics (MDM) for alerting
+### 5) Support Arc-enabled Kubernetes clusters alongside AKS
+### 6) Support Windows and Linux nodes
+### 7) Support multi-tenancy logging and Prometheus scraping
+
+## Non-Functional Requirements
+- Must operate within Kubernetes resource limits (CPU/memory)
+- Must handle large clusters (thousands of nodes/pods) via chunked processing
+- Must support proxy configurations for restricted networks
+- Must not leak secrets or PII in logs/telemetry
+- Container images must pass Trivy critical/high CVE scanning
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/go/src/` | Go Fluent Bit output plugin source |
+| `source/plugins/go/input/` | Go Fluent Bit input plugin source |
+| `source/plugins/ruby/` | Ruby Fluentd plugins |
+| `kubernetes/linux/` | Linux container Dockerfile and entrypoint scripts |
+| `kubernetes/windows/` | Windows container Dockerfile and entrypoint scripts |
+| `build/linux/` | Linux build system (Makefile, installer) |
+| `charts/` | Helm charts for deployment |
+| `test/unit-tests/` | Unit test suites (Bash, Go, Ruby, PowerShell) |
+| `test/ginkgo-e2e/` | Ginkgo E2E tests |
+| `test/e2e/` | Python E2E tests |
+| `.github/workflows/` | CI/CD workflows |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `APPLICATIONINSIGHTS_AUTH` | Application Insights instrumentation key |
+| `APPLICATIONINSIGHTS_ENDPOINT` | Application Insights ingestion endpoint |
+| `AKS_RESOURCE_ID` | Azure resource ID of the AKS cluster |
+| `AKS_REGION` | Azure region of the cluster |
+| `AGENT_VERSION` | Current agent version string |
+| `CONTROLLER_TYPE` | `DaemonSet` or `ReplicaSet` — determines code paths |
+| `OS_TYPE` | `linux` or `windows` |
+| `CONTAINER_TYPE` | Container type identifier |
+| `AZMON_CLUSTER_COLLECT_ENV_VAR` | Cluster collection configuration |
+| `AZMON_LOG_TAIL_PATH` | Log tail file path |
+
+## Acceptance Criteria
+
+- All four unit test suites pass (Bash, Go, Ruby, PowerShell) in `run_unit_tests.yml`
+- Docker image builds successfully for both Linux and Windows
+- Trivy scan reports no unfixed critical/high CVEs
+- CodeQL and DevSkim scans pass without new findings
+- Helm chart version is bumped if chart files are modified

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,165 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Docker-Provider repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand this codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `.github/copilot-instructions.md` on every session — no action needed.
+3. When you open a `.go`, `.rb`, `.sh`, or `.ps1` file, the corresponding `.instructions.md` file auto-activates.
+4. Invoke skills by typing their trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them in chat (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically every session | Root router — general rules, build commands, skill catalogue |
+| `AGENTS.md` | Root | Automatically (supported tools) | Setup commands, code style, testing instructions, architecture |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match (`applyTo` glob) | Language-specific coding conventions |
+| `Prompt.md` | Root | On demand | Reusable task-spec template for describing new work |
+| Skill files (`SKILL.md`) | `.github/skills/` | On keyword trigger | Step-by-step guides for recurring development tasks |
+| `CodeReviewer.agent.md` | `.github/agents/CodeReviewer.agent.md` | On @-mention | Structured code review following repo conventions |
+| `SecurityReviewer.agent.md` | `.github/agents/SecurityReviewer.agent.md` | On @-mention | Deep security analysis, threat modeling, STRIDE review |
+| `DocumentWriter.agent.md` | `.github/agents/DocumentWriter.agent.md` | On @-mention | Documentation authoring following repo doc standards |
+| `prd.agent.md` | `.github/agents/prd.agent.md` | On @-mention | PRD generation tailored to this project's architecture |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically by VS Code | MCP server connections (GitHub, Microsoft Docs) |
+| `test/AGENTS.md` | `test/AGENTS.md` | Automatically (supported tools) | Test framework guide and decision tree |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: .github/copilot-instructions.md (always loaded)
+  ├── General rules, build commands, skill catalogue
+  ├── Routes to →
+  │
+Layer 2: .github/instructions/*.instructions.md (auto-loaded on file match)
+  ├── go.instructions.md — Go coding conventions (*.go files)
+  ├── ruby.instructions.md — Ruby coding conventions (*.rb files)
+  ├── shell.instructions.md — Shell conventions (*.sh files)
+  ├── powershell.instructions.md — PowerShell conventions (*.ps1/*.psm1 files)
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+**You don't need to manually load anything.** The system activates automatically based on what file you're editing and what you ask the AI to do.
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Performs structured code reviews covering correctness, STRIDE security, telemetry gaps, and adherence to Ruby/Go/Shell/PowerShell conventions.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review my changes for telemetry gaps`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates and maintains documentation following the project's doc structure and conventions.
+- **Example prompts:**
+  - `@DocumentWriter write a README for this module`
+  - `@DocumentWriter update the release notes for 3.1.36`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Deep security assessments including threat modeling, attack surface analysis for the Kubernetes agent, and STRIDE analysis.
+- **Example prompts:**
+  - `@SecurityReviewer review the authentication changes in this PR`
+  - `@SecurityReviewer assess the security of our new data stream`
+  - `@SecurityReviewer audit the container security configuration`
+
+### @prd (PRD Generator)
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **What it does:** Generates structured Product Requirements Documents tailored to this project's Kubernetes monitoring architecture.
+- **Example prompts:**
+  - `@prd create a PRD for adding Windows container log filtering`
+  - `@prd write requirements for a new Prometheus scraping feature`
+
+## Using Skills
+
+Skills are step-by-step guides that activate when you use their trigger phrases in chat.
+
+### Always-Available Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "threat model", "STRIDE analysis" | STRIDE-based security review with credential scanning |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Add Application Insights telemetry following existing patterns |
+| `fix-critical-vulnerabilities` | "fix CVE", "trivy fix", "vulnerability fix" | Fix critical/high CVEs using Trivy scan results |
+
+### Commit-History-Driven Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `dependency-update` | "update dependency", "bump package" | Safe dependency update (Go modules, Dockerfile packages) |
+| `test-authoring` | "add test", "write test" | Create tests across Go, Ruby, Bash, and PowerShell |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix with regression test |
+| `feature-development` | "add feature", "implement", "new plugin" | New feature scaffolding for the agent |
+| `code-refactoring` | "refactor", "restructure", "rename" | Behavior-preserving refactoring workflow |
+| `infrastructure` | "update Dockerfile", "Helm chart", "k8s manifest" | Infrastructure change workflow |
+
+**Example usage:**
+```
+# In Copilot Chat, just describe the task naturally:
+"Add a test for the network flow log processing"
+"Fix the critical CVEs in our container image"
+"Add telemetry to the new Kubernetes event handler"
+"Update the Fluent Bit version in the Dockerfile"
+```
+
+## Using Prompt.md for New Work
+
+`Prompt.md` is a reusable template for describing new tasks or features. Use it when:
+- Starting a new feature and want to give the AI full context.
+- Handing off a task specification to another developer or AI agent.
+
+**How to use:**
+1. Copy `Prompt.md` to a new file (e.g., `feature-xyz-prompt.md`).
+2. Fill in the sections with your specific requirements.
+3. Reference it in Copilot Chat: "Implement the feature described in feature-xyz-prompt.md".
+
+## Using AGENTS.md
+
+`AGENTS.md` provides setup, style, and testing instructions. Most AI tools load it automatically. It's useful for:
+- **Onboarding:** Follow Setup Commands to get a working build environment.
+- **Consistency:** Code Style section ensures AI-generated code matches repo conventions.
+- **PR readiness:** PR Instructions help format commits correctly.
+
+## MCP Server Integration
+
+The `.vscode/mcp.json` configures connections to external data sources:
+- **GitHub MCP:** Enables PR creation, issue management, and branch operations from chat.
+- **Microsoft Docs MCP:** Enables validation against official Azure Monitor documentation.
+
+MCP servers use `${input:variable}` prompts — you'll be asked for credentials on first use.
+
+## Tips for Maximum Productivity
+
+1. **Let auto-loading work for you** — Just open the file you're working on. The `.instructions.md` files activate based on file type.
+2. **Use natural language for skills** — Don't invoke skills by name. Just say "add a test" or "fix this CVE".
+3. **Start reviews with @CodeReviewer** — It knows the STRIDE checklist, telemetry patterns, and language conventions.
+4. **Use @prd before big features** — A structured PRD helps scope work before writing code.
+5. **Check AGENTS.md for setup** — If the AI struggles with builds, verify Setup Commands.
+6. **Trust the context chain** — The layered system ensures the right context at the right time.
+
+## Customizing These Artifacts
+
+These files evolve with the project:
+- **Add rules** to `.instructions.md` files when new conventions are established.
+- **Add skills** when you identify new recurring workflows (create a `SKILL.md` in `.github/skills/`).
+- **Update `copilot-instructions.md`** when build commands or project structure changes.
+- **Update `AGENTS.md`** when setup commands or test strategies change.
+- **Re-run generation** periodically to pick up new commit patterns and refresh skills.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow coding conventions | Verify `.instructions.md` `applyTo` glob matches the file type you're editing |
+| Skill not activating | Use exact trigger phrases from the skills table |
+| Agent not available | Ensure `.agent.md` file is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` config and provide credentials when prompted |
+| AI gives generic advice | It may not be loading `copilot-instructions.md` — verify the file exists at `.github/copilot-instructions.md` |
+| Build/test commands fail | Update Setup Commands in `AGENTS.md` to match your environment |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,66 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Go plugin logic with no external dependencies?** → Go unit test (`testify` in `source/plugins/go/src/*_test.go`)
+2. **Go code needing mocks?** → Go unit test with `gomock` (`source/plugins/go/src/`)
+3. **Ruby Fluentd plugin behavior?** → Ruby test with Fluentd test driver (`source/plugins/ruby/*_test.rb`)
+4. **Bash script logic?** → Bash unit test (`test/unit-tests/test_cases/test_*.sh` using `test_framework.sh`)
+5. **PowerShell script logic?** → Pester test (`test/unit-tests/*.Tests.ps1`)
+6. **End-to-end Kubernetes behavior?** → Ginkgo test (`test/ginkgo-e2e/`) or pytest (`test/e2e/`)
+7. **Container log query validation?** → Ginkgo querylogs (`test/ginkgo-e2e/querylogs/`)
+8. **Liveness/readiness behavior?** → Ginkgo livenessprobe (`test/ginkgo-e2e/livenessprobe/`)
+
+## Test Patterns in This Repo
+
+### Unit Tests — Go
+- Framework: `go test` with `testify` assertions
+- Mocking: `gomock` (`github.com/golang/mock`)
+- Location: `source/plugins/go/src/*_test.go`, `source/plugins/go/input/lib/*_test.go`
+- Run: `./test/unit-tests/run_go_tests.sh`
+- CI: `Golang-Tests` job in `run_unit_tests.yml`
+
+### Unit Tests — Ruby
+- Framework: Fluentd test driver
+- Location: `source/plugins/ruby/*_test.rb`
+- Run: `./test/unit-tests/run_ruby_tests.sh`
+- Prerequisites: `gem install fluentd -v "1.14.2"`, `gem install ipaddress`
+- CI: `Ruby-Tests` job in `run_unit_tests.yml`
+
+### Unit Tests — Bash
+- Framework: Custom shell test framework (`test/unit-tests/test_framework.sh`)
+- Location: `test/unit-tests/test_cases/test_*.sh`
+- Helper functions: `test/unit-tests/test_functions/`
+- Canned API responses: `test/unit-tests/canned-api-responses/`
+- Run: `./test/unit-tests/test_main.sh`
+- CI: `Linux-Bash-Tests` job in `run_unit_tests.yml`
+
+### Unit Tests — PowerShell
+- Framework: Pester 5.3.3
+- Location: `test/unit-tests/*.Tests.ps1`
+- Run: `./test/unit-tests/test_main.ps1`
+- CI: `Windows-PowerShell-Tests` job in `run_unit_tests.yml`
+
+### E2E Tests — Ginkgo
+- Framework: Ginkgo (Go BDD test framework)
+- Location: `test/ginkgo-e2e/`
+- Suites: `querylogs/`, `containerstatus/`, `livenessprobe/`
+- Shared utilities: `test/ginkgo-e2e/utils/`
+
+### E2E Tests — Python
+- Framework: pytest
+- Location: `test/e2e/src/tests/`
+- Suites: `test_e2e_workflows.py`, `test_rs_workflows.py`, `test_ds_workflows.py`
+
+## Common Test Utilities
+- `test/ginkgo-e2e/utils/kubernetes_api_utils.go` — Kubernetes API helpers for E2E
+- `test/unit-tests/test_framework.sh` — Bash test assertion framework
+- `test/unit-tests/test_functions/` — Shared bash test helper functions
+- `test/unit-tests/canned-api-responses/` — Mock Kubernetes API responses for bash tests
+
+## Test Data
+- Canned Kubernetes API responses: `test/unit-tests/canned-api-responses/`
+- E2E test manifests: `test/scenario/yamls/`
+- Testkube configurations: `test/testkube/`


### PR DESCRIPTION
## Summary

Auto-generated AI agent artifacts for coding assistants.

### What's included
- `copilot-instructions.md` — root instructions for AI agents
- `AGENTS.md` — setup, code style, testing instructions, architecture diagram
- `Prompt.md` — structured task-spec template
- `.instructions.md` files — Go, Ruby, Shell, PowerShell coding conventions
- `SKILL.md` files — 9 task-specific skills derived from commit history:
  - dependency-update, test-authoring, bug-fix, feature-development, code-refactoring, infrastructure
  - Always-generated: security-review, telemetry-authoring, fix-critical-vulnerabilities
- Agent definitions: CodeReviewer, SecurityReviewer, DocumentWriter, prd
- `.vscode/mcp.json` — GitHub and Microsoft Docs MCP server configuration
- `test/AGENTS.md` — test framework guide and decision tree
- `coding-agent-instructions.md` — comprehensive user guide for all artifacts

### How to verify
1. Open the repo in VS Code / GitHub Codespaces
2. Start a Copilot Chat session
3. Verify agents respond correctly: `@CodeReviewer`, `@SecurityReviewer`, `@DocumentWriter`, `@prd`
4. Check that `.instructions.md` files activate for matching file types

> Auto-generated by the agentify prompt. Review before merging.