### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,90 @@
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Azure Monitor for containers agent repository. You review pull requests for correctness, style, security, telemetry coverage, and adherence to project conventions.
+
+## Review Philosophy
+1. **CVE/vulnerability discipline** — container image and dependency updates must pass Trivy scans with no new CRITICAL/HIGH CVEs
+2. **Telemetry coverage** — new code paths must emit telemetry via `ApplicationInsightsUtility` (Ruby) or `SendEvent` (Go)
+3. **Error handling** — all external calls wrapped in error handling with exception telemetry
+4. **Multi-architecture compatibility** — changes must work on both amd64 and arm64
+5. **Azure Linux compatibility** — no Debian/Ubuntu-specific commands in container context
+
+## Scope
+- **Review:** `source/plugins/go/`, `source/plugins/ruby/`, `kubernetes/`, `build/`, `charts/`, `scripts/`, `test/`
+- **Skip:** auto-generated files, `go.sum`, `*.cache`, vendored code, `node_modules`
+
+## Review Triggers
+- On pull requests targeting `ci_dev` or `ci_prod` branches
+- Excluded: documentation-only PRs (only `.md` files changed)
+
+## PR Diff Method
+- **GitHub:** `gh pr diff <number>` or `git diff $(git merge-base origin/ci_prod HEAD)...HEAD`
+- Always use the PR's own base..head range, never compare against the live tip of `ci_prod`.
+
+## Review Checklist
+- [ ] Go code follows PascalCase constants, camelCase locals, proper import ordering
+- [ ] Ruby code has `frozen_string_literal: true`, uses Fluentd logger (`$log.warn/info/error`)
+- [ ] Shell scripts use `set -e`, quote variables, work on Azure Linux (no apt-get)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded instrumentation keys
+- [ ] Error handling wraps all external calls with telemetry
+- [ ] No TODO/FIXME comments without linked issue
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Auth checks present at entry points; tokens validated
+- [ ] **Tampering** — Input validated at trust boundaries; file permissions restrictive
+- [ ] **Repudiation** — Security actions logged; no sensitive data in logs
+- [ ] **Information Disclosure** — No hardcoded secrets; no secrets in telemetry/logs; env vars used
+- [ ] **Denial of Service** — Resource limits set; no unbounded goroutines; container limits defined
+- [ ] **Elevation of Privilege** — Containers non-root where possible; RBAC least-privilege; security contexts set
+- [ ] **Credential Leak Scan** — No API keys, tokens, passwords, or private keys in changed files
+- [ ] **Weak Pattern Scan** — No disabled TLS verification, weak crypto, shell injection, or unsafe deserialization
+
+### Telemetry Review Checklist
+- [ ] **New error paths have telemetry** — `sendExceptionTelemetry` (Ruby) or error event (Go) for unexpected failures
+- [ ] **New entry points instrumented** — new plugin callbacks track operation metrics
+- [ ] **Telemetry follows existing patterns** — uses same SDK/helper and naming conventions
+- [ ] **No sensitive data in telemetry** — dimensions don't contain PII, credentials, or raw log content
+- [ ] **No telemetry regressions** — existing telemetry calls not removed without explanation
+
+## Language-Specific Best Practices
+
+### Go
+- **Enforced by tooling:** `go vet`, `go test -race` (race condition detection)
+- **Reviewer-focus:** proper mutex usage for shared state in Fluent Bit callbacks, correct Fluent Bit return codes (`FLB_OK`, `FLB_ERROR`, `FLB_RETRY`), no goroutine leaks
+- **Common mistakes:** missing `go mod tidy` after dependency changes, forgetting to update all 6 `go.mod` files
+
+### Ruby
+- **Reviewer-focus:** proper `begin/rescue/end` with `sendExceptionTelemetry`, correct Fluentd plugin registration, no blocking calls in hot paths
+- **Common mistakes:** missing `frozen_string_literal` comment, using `puts` instead of `$log`, hardcoded env var values
+
+### Shell
+- **Reviewer-focus:** Azure Linux (tdnf) compatibility, proper variable quoting, idempotent scripts for container restarts
+- **Common mistakes:** using `apt-get`, missing `set -e`, unquoted variables
+
+### PowerShell
+- **Reviewer-focus:** Pester test structure, proper error handling with `try/catch`
+- **Common mistakes:** missing `Set-StrictMode`, incorrect Pester assertion syntax
+
+## Security Checks
+
+### CI Security Tool Coverage
+- **SAST:** CodeQL (`.github/workflows/codeql-analysis.yml`)
+- **Security patterns:** DevSkim (`.github/workflows/devskim.yml`)
+- **Container/dependency scanning:** Trivy (`.github/workflows/pr-checker.yml`)
+- **Secret scanning:** Not configured — recommend adding Gitleaks or detect-secrets
+
+## Testing Expectations
+- Go changes: `go test -cover -race` in affected module
+- Ruby changes: test via `test/unit-tests/run_ruby_tests.sh`
+- Shell changes: test via `test/unit-tests/test_main.sh`
+- PowerShell changes: test via Pester (`test/unit-tests/test_main.ps1`)
+- Infrastructure changes: container image builds and Trivy scan passes
+
+## Common Issues to Flag
+- Missing telemetry in new error handling paths
+- Hardcoded values that should be environment variables
+- CVE fixes that don't update all 6 `go.mod` files
+- Dockerfile changes that break multi-arch builds
+- Helm chart `values.yaml` changes without corresponding `Chart.yaml` version bump

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,62 @@
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Azure Monitor for containers agent repository. You create and maintain documentation that is accurate, consistent, and follows the project's documentation conventions.
+
+## Audience & Tone
+- Primary audience: developers and SREs who operate or contribute to the container monitoring agent
+- Writing tone: technical but accessible, direct and actionable
+- Use second person ("you") for instructions, imperative for commands
+- Assume knowledge of Kubernetes, Docker, and Azure Monitor basics
+
+## Documentation Structure
+- `README.md` — project overview, prerequisites, repo structure
+- `Dev Guide.md` — developer setup and contribution guide
+- `ReleaseNotes.md` — version-by-version release notes
+- `Documentation/` — feature-specific docs organized by topic:
+  - `Documentation/AgentSettings/` — agent configuration
+  - `Documentation/DCR/` — Data Collection Rules
+  - `Documentation/External/` — external documentation (Grafana)
+  - `Documentation/Internal/` — internal documentation
+  - `Documentation/MultiTenancyLogging/` — multi-tenancy setup
+  - `Documentation/NetworkFlowLogging/` — network flow log docs
+- `scripts/onboarding/` — cluster onboarding guides and scripts
+- `charts/` — Helm chart documentation in `Chart.yaml`
+
+## Writing Conventions
+- Heading style: ATX (`#`, `##`, `###`)
+- Code blocks: fenced with language annotation (```bash, ```go, ```yaml)
+- Links: inline style `[text](url)`
+- File naming: kebab-case for new docs, preserve existing naming
+- Line wrapping: no hard wrapping, one sentence per line preferred
+
+## Documentation Types
+
+### Release Notes (`ReleaseNotes.md`)
+Format: version header with date, bullet list of changes, PR references
+```markdown
+## Release 03-05-2025 (Version 3.1.35)
+- Fix: address CVE-YYYY-NNNNN in package (#PR)
+- Feature: add network flow logs support (#PR)
+```
+
+### README / Developer Guides
+- Prerequisites section with required tool versions
+- Step-by-step setup instructions with exact commands
+- Repo structure tree with descriptions
+
+### Code Comment Conventions
+- Go: `//` comments above functions describing purpose
+- Ruby: `#` comments for non-obvious logic
+- Shell: `#` comments describing script purpose at top, section markers
+
+## Cross-References
+- Reference Helm chart values by name (e.g., "See `charts/azuremonitor-containers/values.yaml`")
+- Reference environment variables by name with backticks
+- Link to Azure Monitor documentation for external concepts
+
+## Validation
+- All file paths referenced in documentation must exist
+- All commands must be syntactically valid and runnable
+- All links must point to valid targets
+- Release notes must include PR numbers

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,63 @@
+---
+description: "Dedicated Security Reviewer — deep threat modeling, attack surface analysis, and security architecture review for the Azure Monitor container agent"
+---
+
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Azure Monitor for containers agent repository. You perform deep security assessments that go beyond routine code review. You are invoked explicitly when a thorough security analysis is needed.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist applied to every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR introduces or modifies authentication/authorization logic (e.g., FIC auth, workload identity)
+- New network-facing functionality is added (e.g., network flow logs)
+- Infrastructure changes modify security boundaries (Dockerfiles, Helm charts, RBAC)
+- Preparing for a security audit or compliance review
+- After a security incident to assess exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- Kubernetes API access (service account tokens, RBAC roles)
+- cAdvisor API endpoint on each node
+- Fluent Bit HTTP endpoints (health check, metrics)
+- MDSD/AMA socket communication
+- Application Insights outbound telemetry
+- Container-to-host file system mounts (`/var/log`, `/var/lib/docker`)
+- Helm chart configurable parameters
+- ConfigMap-driven agent configuration
+
+### 2. STRIDE Deep Analysis
+For each identified attack surface:
+
+**Spoofing:** Service account token validation, managed identity usage, authentication for telemetry endpoints
+
+**Tampering:** Input validation on Kubernetes API responses, ConfigMap content validation, log data integrity
+
+**Repudiation:** Agent telemetry as audit trail, logging of configuration changes
+
+**Information Disclosure:** Secrets in environment variables vs. mounted secrets, telemetry data sanitization, log content filtering
+
+**Denial of Service:** Resource limits in DaemonSet/ReplicaSet specs, Fluent Bit buffer limits, API call rate limiting, large cluster scaling
+
+**Elevation of Privilege:** Container security context, RBAC role scope, host filesystem access, privileged capabilities
+
+### 3. Dependency Security Assessment
+- Go modules: check `go.mod` for known vulnerabilities
+- Ruby gems: installed during container build in `setup.sh`
+- Container base image: Azure Linux (CBL-Mariner) — check for OS-level CVEs
+- Fluent Bit: third-party binary with its own dependency tree
+
+### 4. Infrastructure Security Review
+- `kubernetes/linux/Dockerfile.multiarch` — USER directive, base image, installed packages
+- `kubernetes/windows/Dockerfile` — Windows-specific security considerations
+- `charts/azuremonitor-containers/` — Helm chart security contexts, RBAC, service accounts
+- `kubernetes/ama-logs.yaml` — combined manifest security settings
+
+## Output Format
+Produce a structured security assessment with findings table (Severity, STRIDE, Finding, Location, Recommendation) and detailed findings with exploitation scenarios.
+
+For the procedural STRIDE checklist, invoke the `security-review` skill.

--- a/.github/agents/ThreatModelAnalyst.agent.md
+++ b/.github/agents/ThreatModelAnalyst.agent.md
@@ -1,0 +1,73 @@
+---
+description: "Threat Model Analyst — generates STRIDE-based threat models with Mermaid security boundary diagrams, severity ratings, and timestamped artifacts under threat-model/"
+---
+
+# ThreatModelAnalyst Agent
+
+## Description
+You are a senior security architect specializing in threat modeling. You perform comprehensive threat model analysis following the **Microsoft Threat Modeling methodology** and produce structured, persistent artifacts including:
+
+1. A **Mermaid architecture diagram** with clearly labeled security/trust boundaries
+2. A **full STRIDE analysis** for every component crossing a trust boundary, with severity ratings
+3. A **threat catalogue** with mitigations and residual risk assessment
+
+All artifacts are generated under `threat-model/YYYY-MM-DD/` at the repository root.
+
+**Reference:** https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool
+
+## Methodology — Microsoft SDL Threat Modeling
+
+Follow the four-question framework:
+1. **What are we building?** — Identify components, data flows, and external dependencies
+2. **What can go wrong?** — Apply STRIDE to each component and data flow
+3. **What are we going to do about it?** — Document mitigations (existing and recommended)
+4. **Did we do a good job?** — Validate completeness and residual risk
+
+## Execution Procedure
+
+### Step 1: Repository Analysis
+Key components to analyze in this repo:
+- **Fluent Bit DaemonSet** — log pipeline on every node, processes container stdout/stderr
+- **Go Output Plugin (out_oms.so)** — C-shared library, sends data to MDSD/AMA and ADX
+- **Ruby Fluentd Plugins** — collect Kubernetes inventory (pods, nodes, events, services)
+- **ReplicaSet Instance** — single cluster-wide collector for inventory data
+- **Metrics Extension** — Prometheus metrics scraping and MDM export
+- **MDSD/AMA Sidecar** — Azure Monitor Agent for data forwarding
+- **Application Insights** — agent health telemetry endpoint
+- **Kubernetes API Server** — source for inventory and event data
+- **cAdvisor** — container metrics source on each node
+- **Azure Log Analytics** — destination for logs and inventory
+- **Azure Data Explorer** — alternative log destination
+- **Geneva / Azure Monitor Metrics** — metrics destination
+
+### Step 2: Trust Boundaries
+- External network ↔ Cluster network (ingress, API server)
+- Cluster network ↔ Node host (kubelet, cAdvisor)
+- Node host ↔ Agent container (file mounts, sockets)
+- Agent container ↔ MDSD sidecar (Unix socket / named pipe)
+- Agent → Azure backends (HTTPS outbound)
+- Agent → Application Insights (HTTPS outbound telemetry)
+- ConfigMap → Agent (configuration injection)
+
+### Step 3: Generate Mermaid Diagram
+Create a diagram showing all components with trust boundary subgraphs, data flow labels, and risk color coding.
+
+### Step 4: STRIDE Analysis
+For every component and data flow crossing a trust boundary, evaluate all six STRIDE categories with severity ratings using the DREAD-aligned scale (Critical 9-10, High 7-8, Medium 4-6, Low 1-3).
+
+### Step 5: Generate Artifacts
+Create the date-stamped directory `threat-model/YYYY-MM-DD/` containing:
+- `threat-model-report.md` — full report with executive summary
+- `threat-model-diagram.mmd` — Mermaid diagram source
+- `stride-analysis.md` — detailed STRIDE analysis table
+- `threat-catalogue.md` — prioritized threat catalogue
+
+### Step 6: Update Index
+Update `threat-model/README.md` to index the new run (append-only).
+
+## Anti-Patterns
+- Do NOT generate generic threat models — every threat must reference specific components in this repo
+- Do NOT skip components — assess everything crossing a trust boundary
+- Do NOT assume mitigations work without verifying in codebase
+- Do NOT place artifacts outside `threat-model/`
+- Do NOT overwrite previous runs — always create new date-stamped directory

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,63 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or changes to the Azure Monitor container agent."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Azure Monitor for containers agent. You follow a consistent template and tailor the content to the project's architecture, tech stack, and conventions.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring/observability gap does this address?
+- Success criteria: how do we know this is working?
+
+### 2. Requirements
+- Functional requirements (what the feature must do)
+- Non-functional requirements (performance, security, multi-arch support, Azure Linux compatibility)
+- Out of scope (explicitly state what this does NOT include)
+
+### 3. Architecture
+- Which components are affected (Go output plugin, Ruby input plugins, startup scripts, Helm charts)?
+- Data flow: how does data move from source → Fluent Bit → output → Azure backend?
+- Configuration: what new ConfigMap settings or environment variables are needed?
+- Dependencies: external services, packages, or infrastructure changes
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change:
+  - Go plugins: `source/plugins/go/src/`
+  - Ruby plugins: `source/plugins/ruby/`
+  - Container build: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/linux/setup.sh`
+  - Helm charts: `charts/azuremonitor-containers/`
+  - Kubernetes manifests: `kubernetes/ama-logs.yaml`
+- Multi-architecture considerations (amd64, arm64)
+- Backward compatibility strategy
+
+### 5. Testing Strategy
+- Unit tests: Go (`go test`), Ruby (test driver), Bash, PowerShell (Pester)
+- E2E tests: Ginkgo (`test/ginkgo-e2e/`), pytest (`test/e2e/`)
+- Integration test scenarios with real Kubernetes cluster
+- Performance/load test requirements if applicable
+
+### 6. Monitoring & Observability
+- New telemetry to add (Application Insights events/metrics via existing SDK)
+- Follow existing patterns: `ApplicationInsightsUtility` (Ruby), `SendEvent` (Go)
+- Standard dimensions: computer, controller_type, container_runtime
+- Alerting requirements
+- Rollback indicators
+
+### 7. Deployment
+- Rollout strategy: update Helm chart version, Azure Pipelines release
+- Configuration changes: new Helm values, ConfigMap parameters
+- Rollback procedure: revert Helm chart version, redeploy previous image
+- Multi-cluster considerations (AKS, Arc-enabled)
+
+## Adaptation Rules
+- Reference the actual Go/Ruby/Shell/PowerShell tech stack
+- Use real component names (Fluent Bit, MDSD, AMA, Geneva, ADX)
+- Architecture section must map to actual project structure
+- Testing strategy must align with existing test frameworks
+- Deployment must align with Azure Pipelines and Helm chart release process

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,59 @@
+# Repository Instructions
+
+## Summary
+
+This repository contains the Azure Monitor for containers agent (Linux and Windows). It is a Kubernetes monitoring agent that collects container logs, performance metrics, inventory data, and Kubernetes events. The primary languages are Ruby (~18%), Go (~8%), Shell (~10%), PowerShell (~6%), and Python (~5%) for E2E tests. It runs as a DaemonSet and ReplicaSet inside Kubernetes clusters and ships data to Azure Monitor (Log Analytics, Azure Data Explorer, and Geneva). The agent uses Fluent Bit as the log pipeline with custom Go output plugins and Ruby Fluentd input/filter plugins.
+
+## General Guidelines
+
+1. All Go code lives in `source/plugins/go/` and must build with `go build -buildmode=c-shared` producing shared object files.
+2. All Ruby Fluentd plugins live in `source/plugins/ruby/` and follow Fluentd plugin naming: `in_*.rb` (input), `filter_*.rb` (filter), `out_*.rb` (output).
+3. Shell scripts must work on Azure Linux (CBL-Mariner / Azure Linux 3) — no Debian/Ubuntu-specific tools.
+4. Never hardcode secrets or instrumentation keys. Use environment variables (`APPLICATIONINSIGHTS_AUTH`, `APPLICATIONINSIGHTS_ENDPOINT`, etc.).
+5. Configuration changes to the agent are parsed at startup from ConfigMaps — see `build/common/installer/scripts/` for parsers.
+6. Test all changes with the CI test suites before submitting: Bash (`test/unit-tests/test_main.sh`), Go (`test/unit-tests/run_go_tests.sh`), Ruby (`test/unit-tests/run_ruby_tests.sh`), PowerShell (`test/unit-tests/test_main.ps1`).
+7. If newer commits make prior changes unnecessary, revert them rather than leaving dead code.
+8. Helm chart changes in `charts/` must keep `values.yaml` and `Chart.yaml` versions in sync.
+
+## Build Instructions
+
+**Prerequisites:** Go 1.25.7+, Ruby 3.3.x, Docker, Azure Linux / Ubuntu
+
+**Build Go plugins:**
+```bash
+cd source/plugins/go/src && make
+```
+
+**Build Linux container image:**
+```bash
+cd build/linux && make
+```
+
+**Run all unit tests (CI-identical):**
+```bash
+# Bash tests
+./test/unit-tests/test_main.sh
+
+# Go tests
+./test/unit-tests/run_go_tests.sh
+
+# Ruby tests (requires fluentd gem)
+./test/unit-tests/run_ruby_tests.sh
+
+# PowerShell tests (Windows, requires Pester 5.3.3)
+./test/unit-tests/test_main.ps1
+```
+
+**Run Ginkgo E2E tests:**
+```bash
+cd test/ginkgo-e2e/<suite> && go test -v ./...
+```
+
+## Known Patterns & Gotchas
+
+- The Go output plugin (`out_oms.so`) is a C-shared library loaded by Fluent Bit — do not use `main` package imports that conflict with CGo.
+- Ruby plugins use a custom `ApplicationInsightsUtility` singleton for telemetry (not the standard gem) — see `source/plugins/ruby/ApplicationInsightsUtility.rb`.
+- The agent builds on Azure Linux (Mariner) using `tdnf` — `apt-get` commands will not work in the container build.
+- Trivy scans run in PR CI; check `.trivyignore` for intentionally suppressed CVEs.
+- The primary CI/CD pipeline is Azure Pipelines (`.pipelines/`) — GitHub Actions are used for CodeQL, DevSkim, unit tests, and stale issue management.
+- The default branch is `ci_prod`, not `main`.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.go"
+description: Go coding conventions for the Azure Monitor container agent Go plugins.
+---
+
+# Go Conventions
+
+- Build with `-buildmode=c-shared` — all plugin code is in package `main` and produces `.so` files loaded by Fluent Bit.
+- Constants use `PascalCase`: `ContainerLogDataType`, `ResourceIdEnv`, `TelegrafMetricOriginPrefix`.
+- Use `os.Getenv("ENV_VAR")` for configuration — never hardcode values.
+- Error handling: always check `err != nil` immediately; log with `Log()` or `fmt.Sprintf` and return appropriate Fluent Bit return codes (`output.FLB_OK`, `output.FLB_ERROR`, `output.FLB_RETRY`).
+- Telemetry: use the `appinsights.TelemetryClient` singleton initialized in `telemetry.go`. Call `SendEvent()` for custom events; do not create new `TelemetryClient` instances.
+- Use `sync.Mutex` / `sync.RWMutex` for shared state protection — the Fluent Bit plugin callbacks run concurrently.
+- Import ordering: stdlib → third-party (`github.com/...`) → internal (`Docker-Provider/source/plugins/go/src/...`).
+- Use `msgp` for MessagePack serialization and `ugorji/go/codec` for encoding — follow existing patterns in `oms.go`.
+- Unit tests go in `*_test.go` files in the same directory; run with `go test -cover -race`.
+- Do not use `fmt.Println` for production logging — use the structured logging helpers or `Log()`.
+- Respect the `GOUNITTEST` environment variable guard to skip telemetry emission during tests.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: "**/*.rb"
+description: Ruby coding conventions for the Azure Monitor container agent Fluentd plugins.
+---
+
+# Ruby Conventions
+
+- Add `# frozen_string_literal: true` at the top of every Ruby file.
+- Fluentd plugin naming: `in_*.rb` (input), `filter_*.rb` (filter), `out_*.rb` (output).
+- Plugin classes extend `Fluent::Input`, `Fluent::Filter`, or `Fluent::Output` with `Fluent::Plugin.register_*`.
+- Class names: `PascalCase` (e.g., `CAdvisorMetricsAPIClient`, `KubernetesApiClient`).
+- Method names: `camelCase` (e.g., `getContainerLogs`, `parseNodeLimits`).
+- Class-level variables: `@@VariableName` (e.g., `@@hostName`, `@@os_type`).
+- Telemetry: use the `ApplicationInsightsUtility` singleton from `ApplicationInsightsUtility.rb`:
+  - `ApplicationInsightsUtility.sendExceptionTelemetry(errorStr)` for errors
+  - `ApplicationInsightsUtility.sendCustomEvent(eventName, properties)` for events
+  - `ApplicationInsightsUtility.sendMetricTelemetry(name, value, props)` for metrics
+  - `ApplicationInsightsUtility.sendAPIResponseTelemetry(...)` for API response tracking
+- Wrap all external calls (Kubernetes API, cAdvisor) in `begin/rescue/end` with exception telemetry.
+- Logging: use `$log.warn`, `$log.info`, `$log.error` (Fluentd logger) — never `puts` or `print`.
+- Environment variables: access via `ENV["VAR_NAME"]`; never hardcode keys or endpoints.
+- JSON handling: use `require "json"` and `JSON.parse` / `JSON.generate`.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.sh"
+description: Shell scripting conventions for the Azure Monitor container agent build and setup scripts.
+---
+
+# Shell Conventions
+
+- Use `#!/bin/bash` shebang; prefer `set -e` to fail on errors in build/setup scripts.
+- Target Azure Linux (CBL-Mariner / Azure Linux 3) — use `tdnf` instead of `apt-get` for package management in container contexts.
+- Environment variables: `UPPER_SNAKE_CASE` (e.g., `AZMON_CLUSTER_LOG_TAIL_PATH`, `CONTROLLER_TYPE`).
+- Local variables in functions: `lower_snake_case`.
+- Quote all variable expansions: `"$VAR"` to prevent word splitting.
+- Use `#!/bin/bash` compatible syntax — avoid Bash 5+ specific features for portability.
+- Scripts in `build/common/installer/scripts/` parse ConfigMap settings — changes must handle missing or empty values gracefully.
+- Scripts in `kubernetes/linux/` run at container startup — they must be idempotent and handle restarts.
+- Do not hardcode secrets, instrumentation keys, or connection strings.
+- Log messages should include the script/function name for traceability.
+- Use `curl` with appropriate timeouts and error handling for HTTP calls.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,51 @@
+# Bug Fix
+
+## Description
+Guides the agent through fixing bugs in the container agent codebase, including diagnosis, fix implementation, and regression testing.
+
+USE FOR: fix bug, resolve issue, patch, hotfix, debug, error fix
+DO NOT USE FOR: feature development, refactoring, performance optimization
+
+## Instructions
+
+### When to Apply
+When addressing a reported bug, error condition, or unexpected behavior in the container agent.
+
+### Step-by-Step Procedure
+1. Identify the affected component:
+   - Go output plugin: `source/plugins/go/src/`
+   - Ruby Fluentd plugins: `source/plugins/ruby/`
+   - Startup/setup scripts: `kubernetes/linux/`, `kubernetes/windows/`
+   - Build infrastructure: `build/`
+2. Reproduce the issue if possible using local tests or logs.
+3. Implement the fix in the relevant source files.
+4. Add or update a regression test covering the fixed behavior.
+5. Run the appropriate unit test suite:
+   - Go: `./test/unit-tests/run_go_tests.sh`
+   - Ruby: `./test/unit-tests/run_ruby_tests.sh`
+   - Bash: `./test/unit-tests/test_main.sh`
+   - PowerShell: `./test/unit-tests/test_main.ps1`
+6. Verify the fix does not introduce regressions in other test suites.
+7. If the bug affects telemetry, verify error telemetry is emitted via `ApplicationInsightsUtility.sendExceptionTelemetry` (Ruby) or `SendEvent` (Go).
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` — Go plugin fixes
+- `source/plugins/ruby/*.rb` — Ruby plugin fixes
+- `kubernetes/linux/main.sh`, `kubernetes/linux/setup.sh` — startup script fixes
+- `kubernetes/windows/main.ps1` — Windows agent fixes
+- `build/common/installer/scripts/` — ConfigMap parsing fixes
+
+### Validation
+- All unit tests pass
+- Regression test added for the specific bug
+- No new warnings in CI
+
+## Examples from This Repo
+- `bug fix (#1593)` — general bug fix
+- `fix bug (#1577)` — bug resolution
+- `Fix FIC Auth support issues (#1547)` — auth-related fix
+- `Fix testkube mongodb issue (#1584)` — test infrastructure fix
+
+## References
+- `test/unit-tests/` — unit test suites
+- `.github/workflows/run_unit_tests.yml` — CI test configuration

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,44 @@
+# CI/CD Pipeline
+
+## Description
+Guides changes to the CI/CD pipeline configurations including GitHub Actions workflows and Azure Pipelines.
+
+USE FOR: modify CI, update pipeline, change workflow, fix build pipeline, update GitHub Actions, update Azure Pipelines
+DO NOT USE FOR: application code changes, documentation-only changes
+
+## Instructions
+
+### When to Apply
+When modifying build, test, scan, or deployment pipeline configurations.
+
+### Step-by-Step Procedure
+1. Identify the pipeline type:
+   - GitHub Actions: `.github/workflows/*.yml` — CodeQL, DevSkim, unit tests, PR checks, stale management
+   - Azure Pipelines: `.pipelines/*.yaml` — primary build, release, test framework pipelines
+2. Make changes following the existing YAML structure and indentation.
+3. For GitHub Actions: test locally with `act` or verify via PR CI checks.
+4. For Azure Pipelines: changes to `.pipelines/` are tested via the Azure DevOps pipeline runs.
+5. Ensure pipeline changes do not break existing PR checks.
+
+### Files Typically Involved
+- `.github/workflows/codeql-analysis.yml` — CodeQL SAST scanning
+- `.github/workflows/devskim.yml` — DevSkim security scanning
+- `.github/workflows/pr-checker.yml` — PR build and Trivy scan
+- `.github/workflows/run_unit_tests.yml` — unit test execution
+- `.pipelines/azure_pipeline_mergedbranches.yaml` — merged branch builds
+- `.pipelines/ci-aks-prod-release.yaml` — AKS production release
+- `.pipelines/ci-arc-k8s-extension-prod-release.yaml` — Arc K8s extension release
+
+### Validation
+- Pipeline YAML is valid (no syntax errors)
+- Existing CI checks still pass on PRs
+- New or modified steps produce expected output
+
+## Examples from This Repo
+- `Testkube workflow migration (#1589)` — test pipeline migration
+- `Update ci-aks-prod-release.yaml for Azure Pipelines (#1599)` — pipeline update
+- `let trivy fail when cves are detected (#1591)` — scan enforcement change
+
+## References
+- `.github/workflows/` — GitHub Actions configurations
+- `.pipelines/` — Azure Pipelines configurations

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,47 @@
+# Dependency Update
+
+## Description
+Guides the agent through safely updating Go modules, Ruby gems, and other dependencies in the container agent, including rebuilding and testing.
+
+USE FOR: update dependency, bump package, upgrade library, update go.mod, update gem, renovate, dependabot
+DO NOT USE FOR: adding a brand new dependency, removing a dependency, major version migration
+
+## Instructions
+
+### When to Apply
+When updating package versions in any of the project's dependency files, typically to fix vulnerabilities or stay current.
+
+### Step-by-Step Procedure
+1. Identify the dependency file(s) to update:
+   - Go modules: `source/plugins/go/src/go.mod`, `source/plugins/go/input/go.mod`, `test/ginkgo-e2e/*/go.mod`
+   - Ruby: gem versions in `kubernetes/linux/setup.sh` (installed during container build)
+   - Container base image: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+2. Update the dependency version in the appropriate file.
+3. For Go modules: run `go mod tidy` in each affected module directory.
+4. For Go modules: verify transitive dependencies with `go mod graph | grep <package>`.
+5. Build the Go plugins: `cd source/plugins/go/src && make`.
+6. Run unit tests: `./test/unit-tests/run_go_tests.sh` and `./test/unit-tests/run_ruby_tests.sh`.
+7. Run Trivy scan if updating for vulnerability fixes: `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+8. Update `.trivyignore` if needed (add justification comments for unfixable CVEs).
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- `kubernetes/linux/setup.sh` (Ruby gem installs)
+- `.trivyignore`
+
+### Validation
+- `go build` succeeds in all affected modules
+- All unit tests pass
+- Trivy scan shows no new CRITICAL/HIGH CVEs
+
+## Examples from This Repo
+- `Longw/3.1.35 address vulnerabilties (#1605)` — Go module updates for CVE fixes
+- `3.1.32 CVE fixes (#1596)` — dependency version bumps
+- `3.1.31 CVEs fixes (#1572)` — multiple Go module updates
+
+## References
+- `source/plugins/go/src/go.mod` — primary Go dependency file
+- `.trivyignore` — suppressed CVEs with justifications

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,44 @@
+# Documentation
+
+## Description
+Guides updating documentation including release notes, README files, and onboarding guides.
+
+USE FOR: update docs, update readme, add release notes, update changelog, document feature
+DO NOT USE FOR: code changes, test changes, infrastructure changes
+
+## Instructions
+
+### When to Apply
+When updating project documentation, release notes, or developer guides.
+
+### Step-by-Step Procedure
+1. Identify the documentation type:
+   - Release notes → `ReleaseNotes.md`
+   - Developer guide → `README.md`, `Dev Guide.md`
+   - Feature documentation → `Documentation/` directory
+   - Onboarding guides → `scripts/onboarding/`
+   - Helm chart docs → `charts/*/Chart.yaml` (description, appVersion)
+2. Follow existing formatting conventions (ATX headings, inline code blocks).
+3. Update version numbers consistently across all references.
+4. Verify all file paths and commands referenced in docs actually exist.
+
+### Files Typically Involved
+- `ReleaseNotes.md` — release notes for each version
+- `README.md` — project overview and developer guide
+- `Dev Guide.md` — development guide
+- `Documentation/` — feature-specific documentation
+- `charts/*/Chart.yaml` — Helm chart metadata
+
+### Validation
+- All file paths referenced in documentation exist
+- All commands listed in documentation work
+- Markdown renders correctly
+
+## Examples from This Repo
+- `release notes for 3.1.35 (#1608)` — version release notes
+- `3.1.34 release notes and chart update (#1603)` — release docs with chart update
+- `add deprecation note for helm chart (#1546)` — deprecation notice
+
+## References
+- `ReleaseNotes.md` — existing release notes format
+- `Documentation/` — existing documentation structure

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,53 @@
+# Feature Development
+
+## Description
+Guides the agent through adding new features to the container monitoring agent, including plugin development, configuration, and testing.
+
+USE FOR: add feature, implement, new plugin, new data type, new stream, create, new endpoint
+DO NOT USE FOR: bug fixes, refactoring, documentation-only changes
+
+## Instructions
+
+### When to Apply
+When adding new monitoring capabilities, new data streams, new plugin functionality, or new configuration options.
+
+### Step-by-Step Procedure
+1. Determine the feature scope and which component(s) to modify:
+   - New data collection → Ruby input plugin (`source/plugins/ruby/in_*.rb`)
+   - New data transformation → Ruby filter plugin (`source/plugins/ruby/filter_*.rb`)
+   - New output destination → Go output plugin (`source/plugins/go/src/`)
+   - New configuration option → ConfigMap parser (`build/common/installer/scripts/`)
+2. Follow existing plugin patterns:
+   - Ruby: extend `Fluent::Input`/`Fluent::Filter`/`Fluent::Output`, register with `Fluent::Plugin.register_*`
+   - Go: add data type constants, implement flush logic following `oms.go` patterns
+3. Add telemetry for the new feature:
+   - Ruby: use `ApplicationInsightsUtility.sendCustomEvent` / `sendMetricTelemetry`
+   - Go: use `SendEvent` with appropriate dimensions
+4. Add configuration via environment variables (follow `AZMON_*` naming convention).
+5. Update Helm chart `values.yaml` if new configuration parameters are needed.
+6. Write unit tests for the new functionality.
+7. Update `kubernetes/linux/Dockerfile.multiarch` and/or `kubernetes/windows/Dockerfile` if new build dependencies are required.
+
+### Files Typically Involved
+- `source/plugins/ruby/in_*.rb` — new input plugins
+- `source/plugins/go/src/oms.go` — output plugin modifications
+- `source/plugins/go/src/telemetry.go` — telemetry additions
+- `build/common/installer/scripts/` — ConfigMap parsing
+- `charts/azuremonitor-containers/values.yaml` — Helm chart configuration
+- `kubernetes/linux/main.sh` — startup script updates
+
+### Validation
+- All unit tests pass including new tests
+- Feature works with both DaemonSet and ReplicaSet controllers where applicable
+- Telemetry emits correctly for new feature paths
+- Helm chart values are documented
+
+## Examples from This Repo
+- `Adding change for networkflow logs new stream (#1551)` — new data stream
+- `Added FIC auth support (#1539)` — new authentication feature
+- `OTLP optimize telemetry (#1545)` — telemetry feature optimization
+- `Gangams/workload identity geneva (#1543)` — workload identity support
+
+## References
+- `source/plugins/ruby/` — existing Ruby plugin patterns
+- `source/plugins/go/src/oms.go` — Go output plugin pattern

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,95 @@
+# Fix Critical Vulnerabilities
+
+## Description
+Identifies and fixes critical and high severity vulnerabilities using the repo's own scanning tools (Trivy, CodeQL, DevSkim).
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure, resolve critical CVE, dependency vulnerability fix, container image vulnerability
+DO NOT USE FOR: general dependency updates without security motivation, adding new security scanning tools, security architecture review, threat modeling, low/medium severity vulnerabilities unless explicitly requested
+
+## Instructions
+
+### When to Apply
+When the CI pipeline or manual scan reports critical or high severity vulnerabilities that need remediation.
+
+### Step-by-Step Procedure
+
+#### 1. Vulnerability Discovery
+This repo uses the following scanning tools:
+- **Trivy** — container image and filesystem vulnerability scanning (`.github/workflows/pr-checker.yml`)
+- **CodeQL** — static analysis / SAST (`.github/workflows/codeql-analysis.yml`)
+- **DevSkim** — security pattern matching (`.github/workflows/devskim.yml`)
+
+Run scans locally:
+```bash
+# Filesystem scan for Go/Ruby dependencies
+trivy fs --severity CRITICAL,HIGH --scanners vuln .
+
+# Specific Go module scan
+trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/go.mod
+```
+
+#### 2. Vulnerability Triage
+Categorize each finding:
+- **Direct Go dependency** — listed in `require` block of `go.mod` → directly fixable
+- **Transitive Go dependency** — `// indirect` in `go.mod` → bump parent dependency
+- **Container base image** — update base image in Dockerfiles
+- **OS package** — update in `kubernetes/linux/setup.sh` or Dockerfile
+- **Ruby gem** — update or remove in `setup.sh`
+- **Already ignored** — check `.trivyignore` for existing suppression with justification
+
+#### 3. Fix Implementation
+
+**Go module vulnerabilities:**
+```bash
+# Update all go.mod files (6 locations)
+cd source/plugins/go/src && go get <package>@<fixed-version> && go mod tidy && cd -
+cd source/plugins/go/input && go get <package>@<fixed-version> && go mod tidy && cd -
+cd test/ginkgo-e2e/querylogs && go get <package>@<fixed-version> && go mod tidy && cd -
+cd test/ginkgo-e2e/containerstatus && go get <package>@<fixed-version> && go mod tidy && cd -
+cd test/ginkgo-e2e/livenessprobe && go get <package>@<fixed-version> && go mod tidy && cd -
+cd test/ginkgo-e2e/utils && go get <package>@<fixed-version> && go mod tidy && cd -
+```
+
+**Ruby gem vulnerabilities:**
+- Update version in `kubernetes/linux/setup.sh`
+- Or remove unused gems: `gem uninstall <gem> --force` (see existing patterns in `setup.sh`)
+
+**Container base image vulnerabilities:**
+- Update `FROM` line in `kubernetes/linux/Dockerfile.multiarch` and/or `kubernetes/windows/Dockerfile`
+
+**Unfixable vulnerabilities:**
+- Add to `.trivyignore` with CVE ID, date, and justification comment
+
+#### 4. Build and Test
+```bash
+# Build Go plugins
+cd source/plugins/go/src && make
+
+# Run all unit tests
+./test/unit-tests/run_go_tests.sh
+./test/unit-tests/run_ruby_tests.sh
+./test/unit-tests/test_main.sh
+
+# Re-run vulnerability scan
+trivy fs --severity CRITICAL,HIGH --scanners vuln .
+```
+
+#### 5. Commit
+Follow the repo's commit message format:
+- Single CVE: `fix CVE-YYYY-NNNNN in <package> (#PR)`
+- Multiple: `address vulnerabilities (#PR)` or `CVE fixes (#PR)`
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- `kubernetes/linux/setup.sh`
+- `.trivyignore`
+
+### Validation
+- Build succeeds for all affected components
+- All existing tests pass
+- Re-scan shows targeted CVEs resolved
+- No new critical/high vulnerabilities introduced
+- `.trivyignore` entries have proper justification

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,56 @@
+# Infrastructure
+
+## Description
+Guides changes to container images, Kubernetes manifests, Helm charts, and deployment configurations.
+
+USE FOR: update Dockerfile, modify Helm chart, change Kubernetes manifest, update deployment config, modify container image
+DO NOT USE FOR: application logic changes, test changes, documentation-only changes
+
+## Instructions
+
+### When to Apply
+When modifying container build, Kubernetes deployment, or Helm chart configurations.
+
+### Step-by-Step Procedure
+1. Identify the infrastructure component:
+   - Container images: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+   - Kubernetes manifests: `kubernetes/ama-logs.yaml`
+   - Helm charts: `charts/azuremonitor-containers/`, `charts/azuremonitor-containers-geneva/`
+   - Deployment configs: `deployment/`
+   - Onboarding (Bicep/Terraform): `scripts/onboarding/aks/`
+2. For Dockerfile changes:
+   - Update package versions in `setup.sh` (not directly in Dockerfile where possible)
+   - Ensure multi-arch compatibility (amd64 + arm64)
+   - Run Trivy scan: `trivy image --severity CRITICAL,HIGH <image>`
+3. For Helm chart changes:
+   - Update `Chart.yaml` version
+   - Update `values.yaml` with new/changed parameters
+   - Keep `charts/azuremonitor-containers/` and `charts/azuremonitor-containers-geneva/` in sync where applicable
+4. For Kubernetes manifest changes:
+   - Update `kubernetes/ama-logs.yaml` (combined DaemonSet + ReplicaSet manifest)
+5. Build and scan the container image to verify.
+
+### Files Typically Involved
+- `kubernetes/linux/Dockerfile.multiarch` — Linux container image
+- `kubernetes/windows/Dockerfile` — Windows container image
+- `kubernetes/linux/setup.sh` — Linux container setup script
+- `kubernetes/ama-logs.yaml` — Kubernetes deployment manifest
+- `charts/azuremonitor-containers/Chart.yaml` — Helm chart metadata
+- `charts/azuremonitor-containers/values.yaml` — Helm chart values
+- `deployment/` — deployment configurations
+
+### Validation
+- Container image builds successfully
+- Trivy scan passes
+- Helm chart lints without errors: `helm lint charts/azuremonitor-containers/`
+- Kubernetes manifest is valid YAML
+
+## Examples from This Repo
+- `Fluent bit 4.0.14 (#1601)` — Fluent Bit version upgrade
+- `Upgrade Fluent Bit to 4.0.9 (cloudnative build) (#1535)` — infrastructure update
+- `deploy new image to prod clusters using helm chart` — deployment change
+- `Longw/3.1.35 address vulnerabilties (#1605)` — container image CVE fixes
+
+## References
+- `kubernetes/linux/Dockerfile.multiarch` — Linux image definition
+- `charts/` — Helm chart directory

--- a/.github/skills/security-patch/SKILL.md
+++ b/.github/skills/security-patch/SKILL.md
@@ -1,0 +1,54 @@
+# Security Patch
+
+## Description
+Guides applying security fixes including CVE remediation, vulnerability patching, and security configuration updates.
+
+USE FOR: security fix, CVE patch, vulnerability fix, security update, patch vulnerability
+DO NOT USE FOR: general dependency updates without security motivation, security architecture review, threat modeling
+
+## Instructions
+
+### When to Apply
+When addressing security vulnerabilities, CVEs, or security-related configuration issues.
+
+### Step-by-Step Procedure
+1. Identify the vulnerability source:
+   - Go module CVEs → update `go.mod` files
+   - Ruby gem CVEs → update gem versions in `kubernetes/linux/setup.sh`
+   - Container base image CVEs → update base image in Dockerfiles
+   - OS package CVEs → update packages in `setup.sh` or Dockerfile
+2. Apply the fix:
+   - For Go: `go get <package>@<fixed-version>` then `go mod tidy`
+   - For Ruby: update gem version in setup script
+   - For base image: update `FROM` line in Dockerfile
+   - For OS packages: update `tdnf install` commands
+3. Update ALL affected go.mod files (there are 6 in this repo).
+4. Rebuild: `cd source/plugins/go/src && make`
+5. Run all unit tests.
+6. Run Trivy scan to verify fix: `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+7. Update `.trivyignore` for unfixable CVEs (with date and justification).
+8. Remove gems with known CVEs that are not used (see `setup.sh` patterns like `gem uninstall net-imap --force`).
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/linux/setup.sh`
+- `.trivyignore`
+
+### Validation
+- Trivy scan shows targeted CVEs are resolved
+- No new CRITICAL/HIGH CVEs introduced
+- All unit tests pass
+- Container image builds successfully
+
+## Examples from This Repo
+- `Longw/3.1.35 address vulnerabilties (#1605)` — multi-CVE fix
+- `3.1.32 CVE fixes (#1596)` — CVE remediation
+- `3.1.31 CVEs fixes (#1572)` — vulnerability fixes
+- `Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)` — CVE + test fixes
+
+## References
+- `.trivyignore` — suppressed CVEs
+- `.github/workflows/pr-checker.yml` — Trivy CI scan configuration

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,88 @@
+# Security Review
+
+## Description
+Performs a STRIDE-based security review of code changes, including credential leak detection and weak security pattern scanning.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit, hardening review
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## Instructions
+
+### When to Apply
+Apply to every PR that modifies authentication/authorization logic, network-facing code, data handling, infrastructure (Dockerfiles, Helm charts, scripts), or dependency changes.
+
+### Step-by-Step Procedure
+
+#### 1. STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Are authentication checks present at all entry points?
+- Are tokens/credentials validated before use?
+- Are service-to-service calls authenticated (mTLS, managed identity)?
+
+**Tampering (Data Integrity)**
+- Is input validated and sanitized at trust boundaries?
+- Are file permissions restrictive (no world-writable files)?
+- Is data integrity maintained in transit (TLS)?
+
+**Repudiation (Auditability)**
+- Are security-relevant actions logged with context?
+- Do logs avoid leaking sensitive data?
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets, API keys, tokens, or connection strings in code.
+- No secrets in log output, error messages, or telemetry properties.
+- Env vars used for secrets (`APPLICATIONINSIGHTS_AUTH`, not config files).
+- Debug endpoints disabled in production configs.
+
+**Denial of Service (Availability)**
+- Resource limits set (timeouts, max payload sizes, container CPU/memory limits).
+- No unbounded loops or goroutine leaks.
+- Container resource limits set in Kubernetes manifests and Helm values.
+
+**Elevation of Privilege (Authorization)**
+- Containers running as non-root where possible.
+- RBAC roles follow least-privilege principle.
+- Security contexts set in Kubernetes manifests.
+
+#### 2. Credential & Secret Leak Detection
+- Scan all changed files for hardcoded secrets: API keys, tokens, passwords, private keys, connection strings.
+- Check that `.gitignore` excludes secret files (`*.pem`, `*.key`, `.env`).
+- Verify test fixtures don't contain real credentials.
+
+#### 3. Weak Security Patterns
+
+**Go:**
+- No `#nosec` annotations without justification comments.
+- No unchecked `err` returns from security-sensitive functions.
+- No `fmt.Sprintf` for SQL/command construction with user input.
+- No `exec.Command` with unsanitized input.
+
+**Ruby:**
+- No `eval`, `send` with user-controlled input.
+- No `system()` or backtick execution with unsanitized input.
+- No `YAML.load` (use `YAML.safe_load`).
+
+**Shell/Bash:**
+- No unquoted variables in commands.
+- No `chmod 777` or overly permissive permissions.
+- No secrets passed as command-line arguments.
+- `set -e` present in security-critical scripts.
+
+**Infrastructure (Dockerfiles, k8s, Helm):**
+- No running as root without justification.
+- No `latest` tags (non-reproducible builds).
+- No secrets in ENV (use mounted secrets).
+- No privileged containers without justification.
+- Security contexts set (readOnlyRootFilesystem, runAsNonRoot).
+
+#### 4. CI Security Integration
+- CodeQL running in CI (`.github/workflows/codeql-analysis.yml`)
+- DevSkim running in CI (`.github/workflows/devskim.yml`)
+- Trivy scanning in PR checker (`.github/workflows/pr-checker.yml`)
+- Verify `.trivyignore` entries have valid justification
+
+### Validation
+- Run CodeQL and DevSkim scans
+- Verify `.gitignore` excludes secret file patterns
+- Confirm `SECURITY.md` exists and describes responsible disclosure

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,70 @@
+# Telemetry Authoring
+
+## Description
+Guides adding telemetry instrumentation following the existing Application Insights patterns used in the container agent.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add logging, add Application Insights, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+When adding new telemetry instrumentation to any part of the container agent codebase.
+
+### Step-by-Step Procedure
+
+#### 1. Telemetry Pattern Discovery
+Before adding ANY telemetry, identify the existing pattern for the language:
+
+**Go (source/plugins/go/src/):**
+- SDK: `github.com/microsoft/ApplicationInsights-Go/appinsights`
+- Client: `TelemetryClient` singleton initialized in `telemetry.go`
+- Events: `SendEvent(eventName, dimensions)` — see `telemetry.go`
+- Metrics: `SendContainerLogPluginMetrics()`, `SendTracesAsMetrics()`
+- Common properties: `CommonProperties` map (computer, controller_type, etc.)
+- Init: `TelemetryClient = appinsights.NewTelemetryClient(instrumentationKey)`
+
+**Ruby (source/plugins/ruby/):**
+- Helper: `ApplicationInsightsUtility` class in `ApplicationInsightsUtility.rb`
+- Events: `ApplicationInsightsUtility.sendCustomEvent(eventName, properties)`
+- Metrics: `ApplicationInsightsUtility.sendMetricTelemetry(name, value, props)`
+- Exceptions: `ApplicationInsightsUtility.sendExceptionTelemetry(errorStr)`
+- API tracking: `ApplicationInsightsUtility.sendAPIResponseTelemetry(code, uri, eventName, hash, tracker)`
+- Init: `ApplicationInsightsUtility.initializeUtility()` called at startup
+
+#### 2. What to Instrument (priority order)
+
+a. **Error paths** — Every `rescue`/`if err != nil` block representing an unexpected failure:
+   - Ruby: `ApplicationInsightsUtility.sendExceptionTelemetry(errorStr)`
+   - Go: log the error and send via `SendEvent` with error dimensions
+
+b. **Entry points and API boundaries** — HTTP handlers, plugin callbacks:
+   - Track: operation name, duration, success/failure
+   - Go pattern: telemetry dimensions map with count/status fields
+
+c. **External calls** — Kubernetes API, cAdvisor API, MDSD:
+   - Ruby: `ApplicationInsightsUtility.sendAPIResponseTelemetry(response.code, uri, ...)`
+   - Go: track response codes and timing
+
+d. **Critical business logic** — data processing milestones, cache operations:
+   - Ruby: `ApplicationInsightsUtility.sendCustomEvent(eventName, properties)`
+   - Go: `SendEvent(eventName, telemetryDimensions)`
+
+#### 3. Telemetry Conventions
+- Standard dimensions: `Computer` (hostname), `ControllerType` (DS/RS), `ContainerRuntime`
+- Metric naming: descriptive names like `LastProcessedContainerInventoryCount`, `FlushedRecordsCount`
+- Event naming: PascalCase descriptive names like `HeartBeatEvent`, `KubeMonAgentEventsFlushedEvent`
+- Env var for key: `APPLICATIONINSIGHTS_AUTH` (never hardcode)
+- Env var for endpoint: `APPLICATIONINSIGHTS_ENDPOINT`
+
+#### 4. Anti-Patterns to Avoid
+- Do NOT log sensitive data (credentials, tokens, PII)
+- Do NOT add telemetry inside tight loops
+- Do NOT use `puts`/`print`/`fmt.Println` for production telemetry
+- Do NOT create new TelemetryClient instances — reuse the singleton
+- Do NOT hardcode instrumentation keys
+
+### Validation
+- Verify telemetry import matches existing files
+- Verify event/metric names follow the repo's naming convention
+- Run unit tests to ensure telemetry additions don't break test isolation

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,51 @@
+# Test Authoring
+
+## Description
+Guides adding new tests to the container agent, covering unit tests (Go, Ruby, Bash, PowerShell) and E2E tests (Ginkgo, pytest).
+
+USE FOR: add test, write test, test coverage, add unit test, add integration test, add e2e test
+DO NOT USE FOR: fixing flaky tests, refactoring test infrastructure, test tooling changes
+
+## Instructions
+
+### When to Apply
+When adding tests for new or existing functionality across any of the supported test frameworks.
+
+### Step-by-Step Procedure
+1. Choose the right test framework:
+   - Go code → `go test` in `source/plugins/go/src/*_test.go`
+   - Ruby code → Ruby test file alongside source or via `test/unit-tests/test_driver.rb`
+   - Bash scripts → Shell test in `test/unit-tests/test_cases/*.sh` using the custom framework
+   - PowerShell → Pester test in `test/unit-tests/Test-*.ps1`
+   - Cluster-level E2E → Ginkgo in `test/ginkgo-e2e/<suite>/`
+   - Workflow E2E → pytest in `test/e2e/src/tests/`
+2. Follow the naming convention for the chosen framework.
+3. Place the test file in the correct location:
+   - Go: same directory as source (`*_test.go`)
+   - Ruby: `source/plugins/ruby/*_test.rb` or `test/unit-tests/test_driver.rb`
+   - Bash: `test/unit-tests/test_cases/`
+   - PowerShell: `test/unit-tests/Test-*.ps1` with matching function in `test/unit-tests/test_functions/`
+4. Write tests following existing patterns in the same directory.
+5. Run the test suite to verify: see `AGENTS.md` Testing Instructions for exact commands.
+
+### Files Typically Involved
+- `source/plugins/go/src/*_test.go` — Go unit tests
+- `source/plugins/ruby/*_test.rb` — Ruby unit tests
+- `test/unit-tests/test_cases/*.sh` — Bash test cases
+- `test/unit-tests/Test-*.ps1` — PowerShell test cases
+- `test/ginkgo-e2e/*/` — Ginkgo E2E tests
+- `test/e2e/src/tests/test_*.py` — Python E2E tests
+
+### Validation
+- New test passes when run in isolation
+- All existing tests still pass
+- CI test workflow runs successfully
+
+## Examples from This Repo
+- `Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)` — Ginkgo test improvements
+- `Fix testkube mongodb issue (#1584)` — test infrastructure fix
+- `Testkube workflow migration (#1589)` — test framework migration
+
+## References
+- `test/unit-tests/README.md` — unit test documentation
+- `.github/workflows/run_unit_tests.yml` — CI test configuration

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Clone the repository
+git clone https://github.com/microsoft/Docker-Provider.git
+cd Docker-Provider
+
+# Install Go (version 1.25.7+ required)
+# See scripts/build/linux/install-build-pre-requisites.sh for reference
+
+# Install Ruby 3.3.x and Fluentd
+gem install fluentd -v "1.14.2" --no-document
+gem install ipaddress --no-document
+
+# Build Go output plugin
+cd source/plugins/go/src && make && cd -
+
+# Build Go input plugins
+cd source/plugins/go/input/containerinventory && make && cd -
+cd source/plugins/go/input/perf && make && cd -
+
+# Build Linux container image (requires Docker)
+cd build/linux && make && cd -
+```
+
+## Code Style
+
+### Go
+- Package name: `main` for plugins (C-shared library constraint)
+- Constants: `PascalCase` (e.g., `ContainerLogDataType`, `ResourceIdEnv`)
+- Variables: `camelCase` for local, `PascalCase` for exported
+- Error handling: check `err != nil` immediately after call, log via `Log(message)` or `fmt.Sprintf`
+- Imports: standard library first, then third-party, then internal (`Docker-Provider/source/plugins/go/src/extension`)
+- No unused imports — build will fail
+
+### Ruby
+- `frozen_string_literal: true` comment at top of every file
+- Class naming: `PascalCase` (e.g., `ApplicationInsightsUtility`, `KubernetesApiClient`)
+- Method naming: `camelCase` (e.g., `getContainerLogs`, `sendTelemetry`)
+- Class-level variables: `@@VariableName`
+- All Fluentd plugins extend `Fluent::Input`, `Fluent::Filter`, or `Fluent::Output`
+- Error handling: `begin/rescue/end` blocks with telemetry via `ApplicationInsightsUtility.sendExceptionTelemetry`
+- Logging: `$log.warn`, `$log.info`, `$log.error` (Fluentd logger)
+
+### Shell (Bash)
+- Use `#!/bin/bash` shebang
+- Use `set -e` for error handling in build/setup scripts
+- Variables: `UPPER_SNAKE_CASE` for env vars, `lower_snake_case` for locals
+- Must work on Azure Linux (CBL-Mariner) — no apt-get, use `tdnf`
+
+### PowerShell
+- Functions: `Verb-Noun` convention (e.g., `Get-ClusterCloudEnvironment`, `Is-CanaryRegion`)
+- Testing: Pester 5.3.3 framework
+- `Set-StrictMode -Version Latest` preferred
+
+## Testing Instructions
+
+The CI runs four test suites on every PR to `ci_dev` and `ci_prod`:
+
+| Suite | Command | Framework | Location |
+|-------|---------|-----------|----------|
+| Bash unit tests | `./test/unit-tests/test_main.sh` | Custom shell framework | `test/unit-tests/test_cases/` |
+| Go unit tests | `./test/unit-tests/run_go_tests.sh` | `go test` | `source/plugins/go/src/*_test.go` |
+| Ruby unit tests | `./test/unit-tests/run_ruby_tests.sh` | Ruby test driver | `source/plugins/ruby/*_test.rb`, `test/unit-tests/test_driver.rb` |
+| PowerShell tests | `./test/unit-tests/test_main.ps1` | Pester 5.3.3 | `test/unit-tests/Test-*.ps1` |
+
+**E2E tests (not in PR CI — run manually or via Azure Pipelines):**
+
+| Suite | Framework | Location |
+|-------|-----------|----------|
+| Ginkgo E2E | Ginkgo/Gomega | `test/ginkgo-e2e/` (querylogs, containerstatus, livenessprobe) |
+| Python E2E | pytest | `test/e2e/src/tests/` |
+
+**Test naming conventions:**
+- Go: `*_test.go` in same package
+- Ruby: `*_test.rb` alongside source or in `test/unit-tests/`
+- Bash: `test/unit-tests/test_cases/*.sh`
+- PowerShell: `test/unit-tests/Test-*.ps1`
+
+## Dev Environment Tips
+
+- Use VS Code with Go and Ruby extensions
+- Set `GOPATH` and ensure Go 1.25.7+ is on PATH
+- For Ruby plugin development, install fluentd gem locally: `gem install fluentd -v "1.14.2"`
+- The agent reads configuration from environment variables and Kubernetes ConfigMaps
+- Key env vars: `APPLICATIONINSIGHTS_AUTH`, `AKS_RESOURCE_ID`, `ACS_RESOURCE_NAME`, `CONTROLLER_TYPE`, `CONTAINER_RUNTIME`, `OS_TYPE`
+
+## PR Instructions
+
+- **Commit messages:** Freeform with PR number suffix (e.g., `Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)`)
+- **Branch naming:** Feature branches, no strict convention
+- **Target branches:** `ci_dev` for development, `ci_prod` for production
+- **Required CI checks:** PR checker (build + Trivy scan), unit tests (Bash, Go, Ruby, PowerShell), CodeQL, DevSkim
+- **Merge strategy:** Squash merge with PR title as commit message
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Cluster"
+        subgraph "DaemonSet (per node)"
+            FB["Fluent Bit<br/>Log Pipeline"]
+            GoOut["Go Output Plugin<br/>(out_oms.so)"]
+            RubyIn["Ruby Fluentd Plugins<br/>(in_*, filter_*, out_*)"]
+            ME["Metrics Extension"]
+        end
+        subgraph "ReplicaSet (single)"
+            RS_FB["Fluent Bit<br/>(ReplicaSet)"]
+            RS_Ruby["Ruby Plugins<br/>(kube_events, kube_nodes, etc.)"]
+        end
+    end
+    FB --> GoOut
+    FB --> RubyIn
+    RS_FB --> RS_Ruby
+    GoOut -->|"MDSD/AMA"| LA["Azure Log Analytics"]
+    GoOut -->|"MDSD/AMA"| ADX["Azure Data Explorer"]
+    RubyIn -->|"MDM"| Geneva["Geneva / Azure Monitor Metrics"]
+    RS_Ruby -->|"MDSD/AMA"| LA
+    GoOut -->|"App Insights SDK"| AI["Application Insights<br/>(Telemetry)"]
+    RubyIn -->|"App Insights"| AI
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,86 @@
+# Azure Monitor for Containers Agent
+
+Azure Monitor for containers is a Kubernetes monitoring agent that collects container logs, performance metrics, inventory data, and Kubernetes events from AKS and Arc-enabled Kubernetes clusters. It runs as a DaemonSet (per-node) and ReplicaSet (single instance) inside clusters, shipping data to Azure Log Analytics, Azure Data Explorer, and Geneva Metrics.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log pipeline | Fluent Bit (cloudnative build) |
+| Output plugin | Go 1.25.7 (C-shared library) |
+| Input/Filter plugins | Ruby 3.3.x (Fluentd) |
+| Container OS | Azure Linux (CBL-Mariner) |
+| Build system | Make, Docker |
+| CI/CD | Azure Pipelines, GitHub Actions |
+| Unit testing | go test, Ruby test driver, Bash test framework, Pester (PowerShell) |
+| E2E testing | Ginkgo (Go), pytest (Python) |
+| Telemetry | Application Insights (Go SDK + custom Ruby wrapper) |
+| Container orchestration | Kubernetes (DaemonSet + ReplicaSet) |
+| Infrastructure | Helm charts, Bicep, Terraform (onboarding scripts) |
+| Security scanning | CodeQL, DevSkim, Trivy |
+
+## Architecture Overview
+
+The agent deploys as two workloads:
+1. **DaemonSet** — runs on every node, collects container logs via Fluent Bit, processes them through the Go output plugin (`out_oms.so`), and forwards to Azure Monitor backends (MDSD/AMA).
+2. **ReplicaSet** — single instance per cluster, collects cluster-level inventory (pods, nodes, events, services) via Ruby Fluentd plugins and forwards to Azure Monitor.
+
+Both workloads use Application Insights for agent health telemetry.
+
+## Functional Requirements
+### 1) Collect container stdout/stderr logs and forward to Azure Log Analytics or ADX
+### 2) Collect Kubernetes inventory (pods, nodes, events, services, deployments, PVs)
+### 3) Collect performance metrics (CPU, memory, disk) via cAdvisor
+### 4) Support Prometheus metrics scraping and MDM (Geneva) metrics export
+### 5) Support Windows and Linux nodes with platform-specific builds
+### 6) Support network flow logs (Retina integration)
+
+## Non-Functional Requirements
+
+- Must run on Azure Linux (CBL-Mariner) base images
+- Must support multi-architecture builds (amd64, arm64)
+- Must pass Trivy vulnerability scans (CRITICAL and HIGH severity)
+- Must emit agent health telemetry to Application Insights
+- Must support configurable log collection via Kubernetes ConfigMaps
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/go/src/` | Go Fluent Bit output plugin source |
+| `source/plugins/go/input/` | Go Fluent Bit input plugins (container inventory, perf) |
+| `source/plugins/ruby/` | Ruby Fluentd input/filter/output plugins |
+| `build/linux/Makefile` | Linux agent build |
+| `kubernetes/linux/Dockerfile.multiarch` | Multiarch Linux container image |
+| `kubernetes/windows/Dockerfile` | Windows container image |
+| `charts/` | Helm charts for deployment |
+| `test/unit-tests/` | Unit test suites (Bash, Go, Ruby, PowerShell) |
+| `test/ginkgo-e2e/` | Ginkgo E2E tests |
+| `test/e2e/` | Python E2E tests |
+| `.pipelines/` | Azure Pipelines CI/CD |
+| `.github/workflows/` | GitHub Actions (CodeQL, DevSkim, unit tests) |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `APPLICATIONINSIGHTS_AUTH` | Application Insights instrumentation key |
+| `APPLICATIONINSIGHTS_ENDPOINT` | Application Insights endpoint URL |
+| `AKS_RESOURCE_ID` | Azure resource ID of the AKS cluster |
+| `ACS_RESOURCE_NAME` | Resource name for non-AKS clusters |
+| `CONTROLLER_TYPE` | Deployment type: `DaemonSet` or `ReplicaSet` |
+| `CONTAINER_RUNTIME` | Container runtime name |
+| `OS_TYPE` | Operating system type (`linux` or `windows`) |
+| `AZMON_CLUSTER_COLLECT_STDOUT_LOGS` | Enable/disable stdout log collection |
+| `AZMON_CLUSTER_COLLECT_STDERR_LOGS` | Enable/disable stderr log collection |
+| `AZMON_MULTILINE_ENABLED` | Enable multiline log processing |
+| `AZMON_KUBERNETES_METADATA_ENABLED` | Enable Kubernetes metadata enrichment |
+| `AZMON_RETINA_FLOW_LOGS_ENABLED` | Enable network flow log collection |
+
+## Acceptance Criteria
+
+- All unit tests pass (Bash, Go, Ruby, PowerShell)
+- Trivy scan shows no new CRITICAL/HIGH vulnerabilities
+- CodeQL and DevSkim scans pass
+- Container image builds successfully for both linux/amd64 and linux/arm64
+- Helm chart lints without errors

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,138 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Azure Monitor for containers agent repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand your codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `copilot-instructions.md` on every session — no action needed.
+3. When you open a file matching a language pattern (`.go`, `.rb`, `.sh`), the corresponding `.instructions.md` file auto-activates.
+4. Invoke skills by typing their trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them in chat (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically every session | Root router — general rules, build instructions, known patterns |
+| `AGENTS.md` | Root | Automatically (supported tools) | Setup commands, code style, testing instructions, architecture diagram |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match (`applyTo` glob) | Language-specific coding rules (Go, Ruby, Shell) |
+| `Prompt.md` | Root | On demand | Reusable task-spec template for describing new work |
+| Skill files (`SKILL.md`) | `.github/skills/` | On keyword trigger | Step-by-step guides for recurring development tasks |
+| `CodeReviewer.agent.md` | `.github/agents/CodeReviewer.agent.md` | On @-mention | Structured code review following repo conventions |
+| `SecurityReviewer.agent.md` | `.github/agents/SecurityReviewer.agent.md` | On @-mention | Deep security analysis, threat modeling, attack surface review |
+| `ThreatModelAnalyst.agent.md` | `.github/agents/ThreatModelAnalyst.agent.md` | On @-mention | STRIDE threat modeling with Mermaid diagrams under `threat-model/` |
+| `DocumentWriter.agent.md` | `.github/agents/DocumentWriter.agent.md` | On @-mention | Documentation authoring following repo doc standards |
+| `prd.agent.md` | `.github/agents/prd.agent.md` | On @-mention | PRD generation tailored to this project's architecture |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically by VS Code | MCP server connections (GitHub, Microsoft Docs) |
+| `test/AGENTS.md` | `test/AGENTS.md` | Automatically in test directory | Test framework guide and decision tree |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: copilot-instructions.md (always loaded)
+  ├── General rules, build instructions, known patterns
+  ├── Routes to →
+  │
+Layer 2: .instructions.md files (auto-loaded when you open matching files)
+  ├── go.instructions.md — Go coding rules (*.go files)
+  ├── ruby.instructions.md — Ruby coding rules (*.rb files)
+  ├── shell.instructions.md — Shell scripting rules (*.sh files)
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Performs structured code reviews covering correctness, style, security (STRIDE), telemetry gaps, and adherence to project conventions.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review my changes for telemetry gaps`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates and maintains documentation following repo conventions and structure.
+- **Example prompts:**
+  - `@DocumentWriter write release notes for version 3.1.36`
+  - `@DocumentWriter update the README with the new network flow logs feature`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Performs deep security assessments including STRIDE analysis, dependency auditing, and infrastructure review.
+- **Example prompts:**
+  - `@SecurityReviewer review the authentication changes in this PR`
+  - `@SecurityReviewer assess the attack surface of our Fluent Bit configuration`
+
+### @ThreatModelAnalyst
+- **Invoke:** Type `@ThreatModelAnalyst` in Copilot Chat.
+- **What it does:** Generates persistent threat model artifacts under `threat-model/YYYY-MM-DD/`.
+- **Example prompts:**
+  - `@ThreatModelAnalyst perform a full threat model analysis`
+  - `@ThreatModelAnalyst analyze the Kubernetes RBAC and secrets management`
+
+### @prd (PRD Generator)
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **What it does:** Generates structured Product Requirements Documents tailored to the container agent architecture.
+- **Example prompts:**
+  - `@prd create a PRD for adding OpenTelemetry trace collection`
+  - `@prd write requirements for a new health check endpoint`
+
+## Using Skills
+
+Skills are step-by-step guides that activate when you use their trigger phrases in chat.
+
+### Always-Available Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "STRIDE analysis", "credential leak check" | STRIDE-based security review with credential scanning |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Guides adding telemetry following existing AppInsights patterns |
+| `fix-critical-vulnerabilities` | "fix critical vulnerability", "CVE fix", "trivy fix" | Identifies and fixes CVEs using repo's scanning tools |
+
+### Commit-History-Driven Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `dependency-update` | "update dependency", "bump package" | Safe dependency updates with proper testing |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix workflow with regression testing |
+| `feature-development` | "add feature", "implement", "new plugin" | New feature scaffolding — plugin development, config, tests |
+| `test-authoring` | "add test", "write test" | Creates tests following repo conventions |
+| `documentation` | "update docs", "release notes" | Documentation updates following existing patterns |
+| `ci-cd-pipeline` | "modify CI", "update pipeline" | CI/CD pipeline configuration changes |
+| `infrastructure` | "update Dockerfile", "modify Helm chart" | Container and deployment infrastructure changes |
+| `security-patch` | "security fix", "CVE patch" | Security vulnerability remediation |
+
+## Using Prompt.md for New Work
+
+`Prompt.md` is a reusable template for describing new tasks or features. Copy it, fill in the sections, and reference it in Copilot Chat.
+
+## MCP Server Integration
+
+The `.vscode/mcp.json` file configures two MCP servers:
+- **GitHub MCP:** Enables PR management, issue tracking, and branch operations from chat.
+- **Microsoft Docs MCP:** Enables searching official Azure Monitor documentation for validation.
+
+Secrets use `${input:variable}` prompts — you'll be asked for credentials on first use.
+
+## Tips for Maximum Productivity
+
+1. **Let auto-loading work for you** — Just open the file you're working on. The `.instructions.md` files activate automatically.
+2. **Use natural language for skills** — Just describe the task: "add a test", "bump dependencies", "review security".
+3. **Start reviews with @CodeReviewer** — It knows the review patterns, linter rules, and security requirements.
+4. **Use @prd before big features** — A structured PRD helps plan the full scope before coding.
+5. **Check AGENTS.md for setup** — Verify Setup Commands are accurate for your environment.
+6. **Check test/AGENTS.md for testing** — Use the decision tree to pick the right test framework.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow coding conventions | Verify `.instructions.md` `applyTo` glob matches the file you're editing |
+| Skill not activating | Use the exact trigger phrases listed in the skill table above |
+| Agent not available | Ensure the `.agent.md` file is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` config and provide credentials when prompted |
+| Build commands fail | Update the Setup Commands section in `AGENTS.md` to match your environment |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,60 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Pure Go logic with no external dependencies?** → Go unit test (`go test`) in `source/plugins/go/src/*_test.go`
+2. **Ruby plugin behavior?** → Ruby test in `source/plugins/ruby/*_test.rb` via `test/unit-tests/test_driver.rb`
+3. **Bash script logic?** → Shell test in `test/unit-tests/test_cases/*.sh` using the custom test framework
+4. **PowerShell function behavior?** → Pester test in `test/unit-tests/Test-*.ps1`
+5. **End-to-end cluster behavior (logs, status)?** → Ginkgo test in `test/ginkgo-e2e/<suite>/`
+6. **End-to-end workflow validation?** → pytest test in `test/e2e/src/tests/test_*.py`
+
+## Test Patterns in This Repo
+
+### Go Unit Tests
+- Framework: `go test` with `github.com/stretchr/testify` assertions and `github.com/golang/mock` mocking
+- Location: `source/plugins/go/src/*_test.go` (same package)
+- Naming: `func Test<FunctionName>(t *testing.T)`
+- Run: `cd source/plugins/go/src && go test -cover -race`
+- CI command: `./test/unit-tests/run_go_tests.sh`
+
+### Ruby Unit Tests
+- Framework: custom test driver (`test/unit-tests/test_driver.rb`) with Fluentd test helpers
+- Location: `source/plugins/ruby/*_test.rb`
+- Naming: `<plugin_name>_test.rb` alongside source
+- Run: `./test/unit-tests/run_ruby_tests.sh`
+- Requires: `fluentd` gem (v1.14.2), `ipaddress` gem
+
+### Bash Unit Tests
+- Framework: custom shell test framework (`test/unit-tests/test_framework.sh`)
+- Location: `test/unit-tests/test_cases/*.sh`
+- Helper functions: `test/unit-tests/test_functions/*.sh`
+- Run: `./test/unit-tests/test_main.sh`
+
+### PowerShell Unit Tests
+- Framework: Pester 5.3.3
+- Location: `test/unit-tests/Test-*.ps1`
+- Helper functions: `test/unit-tests/test_functions/*.ps1`
+- Run: `./test/unit-tests/test_main.ps1`
+
+### Ginkgo E2E Tests
+- Framework: Ginkgo/Gomega (Go BDD)
+- Location: `test/ginkgo-e2e/` with suites: `querylogs`, `containerstatus`, `livenessprobe`
+- Shared utilities: `test/ginkgo-e2e/utils/`
+- Run: `cd test/ginkgo-e2e/<suite> && go test -v ./...`
+- Requires: running Kubernetes cluster with agent deployed
+
+### Python E2E Tests
+- Framework: pytest
+- Location: `test/e2e/src/tests/test_*.py`
+- Naming: `test_<workflow>_workflows.py`
+- Requires: running cluster, AAD token, Log Analytics workspace access
+
+## Common Test Utilities
+- `test/unit-tests/canned-api-responses/` — mock Kubernetes API responses for unit tests
+- `test/ginkgo-e2e/utils/kubernetes_api_utils.go` — Kubernetes client helpers for E2E
+- `test/ginkgo-e2e/utils/query_logs_api_utils.go` — Log Analytics query helpers
+- `test/ginkgo-e2e/utils/setup_utils.go` — E2E test setup/teardown
+- `test/ginkgo-e2e/utils/constants.go` — shared test constants


### PR DESCRIPTION
## Summary

Auto-generated AI agent artifacts for coding assistants.

### What's included
- `copilot-instructions.md` — root instructions for AI agents
- `AGENTS.md` — setup, style, and testing instructions
- `Prompt.md` — structured prompt template
- `.instructions.md` files — language-specific conventions (Go, Ruby, Shell)
- `SKILL.md` files — 11 task-specific skills derived from commit history
- Agent definitions: CodeReviewer, SecurityReviewer, ThreatModelAnalyst, DocumentWriter, prd
- `.vscode/mcp.json` — MCP server configuration (GitHub, Microsoft Docs)
- `test/AGENTS.md` — test framework guide
- `coding-agent-instructions.md` — user guide for all artifacts

### How to verify
1. Open the repo in VS Code / GitHub Codespaces
2. Start a Copilot Chat session
3. Verify agents respond correctly: `@CodeReviewer`, `@SecurityReviewer`, `@ThreatModelAnalyst`, `@DocumentWriter`, `@prd`
4. Check that `.instructions.md` files activate for matching file types

> Auto-generated by the agentify prompt. Review before merging.