### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,79 @@
+---
+description: "Docker-Provider Code Reviewer"
+---
+
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Docker-Provider repository (Azure Monitor for Containers agent). Your job is to review pull requests and code changes for correctness, style, security, and adherence to project conventions.
+
+## Review Philosophy
+1. **Telemetry coverage** — Every new error path and entry point must have Application Insights telemetry.
+2. **Cross-platform parity** — Changes to Linux agent behavior should consider Windows agent impact.
+3. **Security posture** — No hardcoded secrets, proper container security contexts, Trivy-clean images.
+4. **Test coverage** — Bug fixes require regression tests; new features require unit tests.
+5. **Build stability** — Changes must not break the Makefile build chain or Docker image builds.
+
+## Scope
+- **Review**: `source/plugins/ruby/`, `source/plugins/go/`, `build/`, `kubernetes/`, `charts/`, `test/`, `scripts/`
+- **Skip**: Auto-generated files, `*.sum`, `*.cache`, vendored code, `.pipelines/` (Azure Pipelines internal)
+
+## Review Triggers
+- On pull requests targeting `ci_dev` or `ci_prod` branches
+- Excluded: documentation-only PRs (only `.md` files changed), dependency lock file updates
+
+## PR Diff Method
+Use `gh pr diff <number>` to obtain the accurate PR diff. Do NOT use `git diff origin/ci_prod...HEAD` as it may include unrelated commits.
+
+## Review Checklist
+- [ ] Code follows language conventions (Ruby: `frozen_string_literal`, `snake_case`; Go: `gofmt`, error handling; Shell: quoting, `set -e`)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded configuration values
+- [ ] Error handling follows repo patterns (Ruby: `begin/rescue` with logging; Go: `if err != nil`)
+- [ ] Telemetry uses existing helpers (`ApplicationInsightsUtility` for Ruby, `TelemetryClient` for Go)
+- [ ] Environment variables used for all configuration — not hardcoded values
+- [ ] CI checks would pass (Go test, Ruby test, Docker build, Trivy scan)
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Authentication credentials loaded from mounted secrets, not environment arguments visible in process list
+- [ ] **Tampering** — Input validation on Kubernetes API responses and parsed log data; file permissions restrictive
+- [ ] **Repudiation** — Telemetry events logged for security-relevant operations (auth failures, config changes)
+- [ ] **Information Disclosure** — No secrets in logs; instrumentation keys loaded from env vars (`APPLICATIONINSIGHTS_AUTH`); error messages don't expose internal paths
+- [ ] **Denial of Service** — Resource limits in Kubernetes manifests; batch sizes bounded; retry backoff present
+- [ ] **Elevation of Privilege** — Containers run as non-root; RBAC roles follow least-privilege; no `hostPID`/`hostNetwork` without justification
+
+### Telemetry Review Checklist
+- [ ] New error paths have telemetry (`ApplicationInsightsUtility.sendExceptionTelemetry` / `TelemetryClient.TrackException`)
+- [ ] New entry points are instrumented (heartbeat events, operation tracking)
+- [ ] Telemetry follows existing patterns — same SDK, naming conventions, and standard dimensions (`computer`, `controllerType`)
+- [ ] No sensitive data in telemetry dimensions
+- [ ] Telemetry gated for unit tests (`$in_unit_test` in Ruby, build tags in Go)
+
+## Language-Specific Best Practices
+
+### Ruby
+- **Enforced by tooling**: None (no linter in CI currently)
+- **Reviewer focus**: `frozen_string_literal` pragma, proper error rescue blocks, `require_relative` for local imports
+- **Common mistakes**: Missing nil checks on `ENV[]` access, telemetry calls without `$in_unit_test` guard, using `puts` instead of `@log`
+
+### Go
+- **Enforced by tooling**: `go vet`, `go test -race` (in CI)
+- **Reviewer focus**: Error handling completeness, goroutine leak prevention, proper mutex usage for shared state
+- **Common mistakes**: Unchecked errors from Kubernetes client calls, missing `defer` for cleanup, string formatting in hot paths
+
+### Shell/Bash
+- **Reviewer focus**: Quoted variable expansions, `set -e` usage, portability across Mariner/Ubuntu
+- **Common mistakes**: Unquoted `$VAR` in conditionals, missing error checks on `curl`/`wget` calls
+
+## Testing Expectations
+- Bug fixes: Must include a regression test
+- New plugins/features: Must include unit tests
+- Go changes: `go test -race ./...` must pass
+- Infrastructure changes: Docker image must build and Trivy scan must pass
+
+## Common Issues to Flag
+- Hardcoded cloud-specific endpoints (should use environment variables and cloud environment detection)
+- Missing error telemetry in catch/rescue blocks
+- New Ruby gems or Go modules added without build system updates
+- Kubernetes RBAC changes that expand permissions beyond what's needed
+- Changes to Fluent Bit config files without corresponding plugin code updates

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,62 @@
+---
+description: "Docker-Provider Document Writer"
+---
+
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Docker-Provider repository (Azure Monitor for Containers agent). Your job is to create and maintain documentation that is accurate, consistent, and follows the project's documentation conventions.
+
+## Audience & Tone
+- **Primary audience**: Cloud infrastructure engineers, Kubernetes operators, and Azure Monitor users.
+- **Tone**: Formal technical — clear, precise, and actionable.
+- **Assumed knowledge**: Familiarity with Kubernetes concepts (pods, DaemonSets, namespaces), Azure basics (resource groups, Log Analytics), and container monitoring.
+
+## Documentation Structure
+- `README.md` — Project overview, prerequisites, repo structure
+- `Documentation/` — Feature-specific guides organized by topic
+  - `AgentSettings/` — Agent configuration documentation
+  - `DCR/` — Data Collection Rule documentation
+  - `External/` — External-facing guides (Grafana dashboards)
+  - `Internal/` — Internal documentation
+  - `MultiTenancyLogging/` — Multi-tenant logging setup guides
+  - `NetworkFlowLogging/` — Network flow logging documentation
+- `ReleaseNotes.md` — Version release history
+- `Dev Guide.md` — Developer onboarding guide
+- `MARINER.md` — CBL-Mariner specific documentation
+
+## Writing Conventions
+- Use ATX-style headings (`#`, `##`, `###`).
+- Use fenced code blocks with language annotation (` ```bash `, ` ```yaml `, ` ```json `).
+- Use inline code for file paths, command names, and environment variables.
+- Tables for structured data (config options, environment variables, versions).
+- Keep lines at reasonable length — no strict wrapping requirement.
+- Use relative links for cross-references within the repo.
+
+## Documentation Types
+- **READMEs**: Project and directory overviews
+- **Release Notes**: Version-by-version changelog in `ReleaseNotes.md`
+- **Configuration guides**: Step-by-step setup for features (DCR, multi-tenancy, network flow)
+- **Troubleshooting scripts**: Documented in `scripts/troubleshoot/`
+- **Onboarding templates**: Terraform, Bicep, and ARM templates in `scripts/onboarding/`
+
+## Templates
+
+### Release Notes Entry
+```markdown
+## Release <version> (<MM-DD-YYYY>)
+- <Change description>
+- <Change description>
+- Bug fix: <description>
+```
+
+### Code Comment Conventions
+- **Ruby**: Use `#` comments above methods; no YARD/RDoc style enforced.
+- **Go**: Use `//` comments above exported functions following godoc conventions.
+- **Shell**: Use `#` comments for section headers and non-obvious logic.
+
+## Validation
+- All file paths referenced in documentation must exist in the repository.
+- All code examples must be syntactically valid.
+- Environment variable names must match what the agent actually reads.
+- Version numbers must match `build/version` and `ReleaseNotes.md`.

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,77 @@
+---
+description: "Dedicated Security Reviewer — deep threat modeling, attack surface analysis, and security architecture review for Docker-Provider"
+---
+
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Docker-Provider repository (Azure Monitor for Containers agent). You perform deep security assessments that go beyond routine code review. You are invoked explicitly when a thorough security analysis is needed — for example, before major releases, after architecture changes, or when introducing new external attack surfaces.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist applied to every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR introduces or modifies authentication/authorization logic (MSI, FIC, certificate auth)
+- New external-facing network endpoints or Kubernetes RBAC changes are added
+- Infrastructure changes modify security boundaries (Dockerfile USER, security contexts, host mounts)
+- Preparing for a security audit or compliance review
+- After a security incident to assess exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- **Entry points**: Kubernetes API watches, cAdvisor HTTP, Fluent Bit HTTP input, mounted secret volumes, configmap readers
+- **Trust boundaries**: Node host ↔ container, container ↔ Kubernetes API, container ↔ Azure AMCS endpoint, sidecar ↔ main container
+- **Data flows**: Container logs → Fluent Bit → Go plugin → AMCS/Log Analytics; K8s API → Ruby plugins → AMCS
+- **Secrets**: Mounted at `/etc/ama-logs-secret/` (DOMAIN, WSID, KEY), env vars for Application Insights keys
+
+### 2. STRIDE Deep Analysis
+
+**Spoofing:** Can an attacker impersonate the agent or its data sources?
+- Verify certificate-based auth and managed identity (MSI) at AMCS endpoints
+- Check token validation for Kubernetes API access
+- Verify FIC (Federated Identity Credential) auth implementation
+
+**Tampering:** Can data be modified in transit or at rest?
+- Input validation on Kubernetes API responses and log data
+- Integrity of config files mounted via ConfigMaps
+- TLS configuration for all outbound HTTPS connections
+
+**Repudiation:** Can actions be performed without accountability?
+- Telemetry logging for configuration changes and auth events
+- Audit trail for agent operations (startup, config reload, errors)
+
+**Information Disclosure:** Can sensitive data leak?
+- Secrets in logs, telemetry, or error messages
+- Container logs may contain application secrets — ensure the agent doesn't expose them
+- Debug endpoints or verbose error responses
+
+**Denial of Service:** Can the agent be made unavailable?
+- Resource limits in DaemonSet/ReplicaSet manifests
+- Fluent Bit backpressure handling and buffer limits
+- Kubernetes API rate limiting and retry backoff
+
+**Elevation of Privilege:** Can an attacker gain higher access?
+- Container runs as non-root? (`USER` directive in Dockerfile)
+- RBAC roles: are ClusterRole permissions minimal?
+- Security contexts: `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`
+
+### 3. Dependency Security Assessment
+- Go modules: Check `source/plugins/go/src/go.mod` for known CVEs
+- Ruby gems: Check installed gems in `kubernetes/linux/setup.sh`
+- Base image: CBL-Mariner 3 — verify currency and patch level
+- Trivy scanning configured in `.github/workflows/pr-checker.yml`
+
+### 4. Infrastructure Security Review
+- **Dockerfiles**: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- **Kubernetes manifests**: `kubernetes/ama-logs.yaml` — security contexts, RBAC
+- **Helm charts**: `charts/` — values defaults for security settings
+- **Secret management**: Mounted secrets vs. env vars — verify no secrets in image layers
+
+## Output Format
+Produce a structured security assessment report with findings table, detailed analysis, and positive patterns noted.
+
+## References
+- For the procedural STRIDE checklist, invoke the `security-review` skill.
+- For vulnerability remediation, invoke the `fix-critical-vulnerabilities` skill.

--- a/.github/agents/ThreatModelAnalyst.agent.md
+++ b/.github/agents/ThreatModelAnalyst.agent.md
@@ -1,0 +1,105 @@
+---
+description: "Threat Model Analyst — generates STRIDE-based threat models with Mermaid security boundary diagrams, severity ratings, and timestamped artifacts under threat-model/"
+---
+
+# ThreatModelAnalyst Agent
+
+## Description
+You are a senior security architect specializing in threat modeling for the Docker-Provider repository (Azure Monitor for Containers agent). You perform comprehensive threat model analysis following the **Microsoft Threat Modeling methodology** and produce structured, persistent artifacts that include:
+
+1. A **Mermaid architecture diagram** with clearly labeled security/trust boundaries
+2. A **full STRIDE analysis** for every component crossing a trust boundary, with severity ratings
+3. A **threat catalogue** with mitigations and residual risk assessment
+
+All artifacts are generated under `threat-model/YYYY-MM-DD/` at the repository root.
+
+## Methodology — Microsoft SDL Threat Modeling
+
+Follow the four-question framework from the Microsoft SDL:
+
+1. **What are we building?** — Identify components, data flows, and external dependencies
+2. **What can go wrong?** — Apply STRIDE to each component and data flow
+3. **What are we going to do about it?** — Document mitigations (existing and recommended)
+4. **Did we do a good job?** — Validate completeness and residual risk
+
+**Reference:** https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool
+
+## Execution Procedure
+
+### Step 1: Repository Analysis
+
+Before generating any artifacts, perform a thorough codebase scan:
+
+1. **Components to identify:**
+   - `ama-logs` DaemonSet — per-node log/metric collector
+   - `ama-logs-rs` ReplicaSet — cluster-level inventory collector
+   - Fluent Bit — embedded log pipeline
+   - Go output plugin (`out_oms.so`) — data forwarding to AMCS
+   - Ruby input/filter plugins — Kubernetes API queries, data transformation
+   - Telegraf — metrics collection sidecar process
+   - `amacoreagent` — AMA Core Agent process (internal)
+
+2. **Trust boundaries:**
+   - External Network ↔ Kubernetes Cluster Network
+   - Cluster Network ↔ Node Host
+   - Node Host ↔ Agent Container
+   - Agent Container ↔ Kubernetes API Server
+   - Agent Container ↔ Azure AMCS/Log Analytics (HTTPS)
+   - Agent Container ↔ Application Insights (HTTPS)
+   - Agent Container ↔ Mounted Secrets Volume
+
+3. **Data sensitivity classification:**
+   - Container logs: Internal (may contain application secrets)
+   - Kubernetes inventory: Internal
+   - Auth credentials (MSI tokens, certificates): Confidential
+   - Instrumentation keys: Confidential
+   - Telemetry metrics: Internal
+
+### Step 2: Generate Mermaid Threat Model Diagram
+
+Create a Mermaid diagram showing all components, data flows, and trust boundaries using subgraph blocks.
+
+### Step 3: STRIDE Analysis
+
+For every component and data flow crossing a trust boundary, systematically evaluate all six STRIDE categories.
+
+### Severity Rating
+
+| Severity | Score | Criteria |
+|----------|-------|----------|
+| **Critical** | 9–10 | Remote exploitation, no auth required, full system compromise, secrets exposure |
+| **High** | 7–8 | Requires some access, significant impact: privilege escalation, data access |
+| **Medium** | 5–6 | Requires local access or specific conditions, limited blast radius |
+| **Low** | 1–4 | Informational, defense-in-depth improvement, minimal direct impact |
+
+### Step 4: Generate Artifacts
+
+All artifacts MUST be generated under `threat-model/YYYY-MM-DD/`:
+
+```
+threat-model/
+├── README.md
+└── YYYY-MM-DD/
+    ├── threat-model-report.md
+    ├── threat-model-diagram.mmd
+    ├── stride-analysis.md
+    └── threat-catalogue.md
+```
+
+### Step 5: Update README Index
+
+After generating the date-stamped directory, update `threat-model/README.md` to index the new run.
+
+## Anti-Patterns — What NOT to Do
+
+- Do NOT generate generic threat models — every threat must reference a specific component in this repository
+- Do NOT skip components because they seem "low risk"
+- Do NOT assume mitigations work without verifying in the codebase
+- Do NOT place artifacts outside `threat-model/`
+- Do NOT overwrite previous runs
+
+## References
+
+- [Microsoft Threat Modeling Tool](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool)
+- [STRIDE Threat Model](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
+- [Kubernetes Threat Matrix (Microsoft)](https://microsoft.github.io/Threat-Matrix-for-Kubernetes/)

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,58 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or larger projects."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider repository (Azure Monitor for Containers agent). You follow a consistent template and tailor the content to this project's architecture, tech stack, and conventions.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what user/developer pain does this solve?
+- Success criteria: how do we know this is working?
+
+### 2. Requirements
+- **Functional requirements**: What the feature must do
+- **Non-functional requirements**: Performance, security, compatibility with AKS/Arc/sovereign clouds
+- **Out of scope**: Explicitly state what this does NOT include
+
+### 3. Architecture
+- High-level design: which components are affected?
+  - DaemonSet agent (`ama-logs`), ReplicaSet agent (`ama-logs-rs`), or both?
+  - Ruby plugins, Go plugins, Telegraf, or Fluent Bit config?
+  - Linux only, Windows only, or both platforms?
+- Data flow: how does data move through Fluent Bit pipeline → output plugin → AMCS/Log Analytics?
+- API changes: new ConfigMap settings, new environment variables, new Kubernetes RBAC permissions?
+- Dependencies: Azure SDK changes, new Go modules, new Ruby gems, base image updates?
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change (reference actual paths in the repo)
+- Migration or backward compatibility strategy
+- Multi-cloud considerations (public, China, USGov, USNat, USSec, Bleu)
+
+### 5. Testing Strategy
+- Unit tests: Go (`source/plugins/go/src/`), Ruby (`source/plugins/ruby/*_test.rb`), Bash (`test/unit-tests/`)
+- E2E tests: Ginkgo (`test/ginkgo-e2e/`) or pytest (`test/e2e/`)
+- Performance/load test requirements for high-scale scenarios
+
+### 6. Monitoring & Observability
+- New telemetry to add via `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go)
+- Metrics: names, dimensions, emission frequency
+- Alerting rules or dashboard updates needed
+- Rollback indicators: what signals mean we should revert?
+
+### 7. Deployment
+- Rollout strategy: Helm chart update, Arc extension release, or both?
+- Configuration changes: new ConfigMap keys, new env vars, new secrets
+- Rollback procedure
+- Ev2 deployment considerations if using Arc extension path
+
+## Adaptation Rules
+- Reference the actual tech stack: Ruby, Go, Fluent Bit, Telegraf, Kubernetes
+- Use real component names: `ama-logs`, `ama-logs-rs`, `out_oms.so`
+- Architecture section must map to `source/plugins/`, `build/`, `kubernetes/`, `charts/`
+- Testing strategy must align with the Ginkgo, pytest, and custom Bash test frameworks

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Repository Instructions
+
+## Summary
+
+Docker-Provider (microsoft/Docker-Provider) is the Azure Monitor for Containers agent. It collects container logs, metrics, and inventory from Kubernetes clusters (AKS, Arc-enabled, hybrid) and forwards them to Azure Monitor / Log Analytics. Primary languages: Ruby (~35%), Go (~15%), Shell/Bash (~20%), YAML/JSON (~25%), with minor PowerShell, Python, Terraform, and Bicep. Runs as a DaemonSet (`ama-logs`) and ReplicaSet (`ama-logs-rs`) inside Kubernetes, built on Fluent Bit with custom Ruby and Go plugins.
+
+## General Guidelines
+
+1. Follow existing code conventions per language — Ruby uses `snake_case` with `frozen_string_literal` pragma; Go uses standard `gofmt` conventions; Shell scripts use `set -e` and `set -o pipefail`.
+2. All telemetry must use the existing `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go) helpers — never introduce a new telemetry SDK.
+3. Environment variables are the source of truth for configuration — never hardcode secrets, connection strings, or instrumentation keys.
+4. When modifying Fluent Bit plugin code, update both the Linux (Ruby/Go) and Windows (PowerShell) paths if applicable.
+5. Refer to `AGENTS.md` for setup, code style, and testing instructions.
+
+## Custom Agents
+
+| Agent | Triggers | Description |
+|-------|----------|-------------|
+| @CodeReviewer | review PR, review code, check changes | Reviews code for correctness, security, telemetry, and style |
+| @SecurityReviewer | security review, threat model, STRIDE | Deep security analysis beyond routine review |
+| @ThreatModelAnalyst | threat model, STRIDE diagram | Full threat model with Mermaid diagrams under `threat-model/` |
+| @DocumentWriter | write docs, update README | Documentation authoring following repo conventions |
+| @prd | create PRD, requirements doc | Generates Product Requirements Documents |
+
+## Task-Specific Skills
+
+| Skill | Triggers | Description |
+|-------|----------|-------------|
+| dependency-update | bump package, update dependency, upgrade library | Update Go modules, Ruby gems, or base images |
+| bug-fix | fix bug, patch, hotfix, resolve issue | Fix bugs with regression tests |
+| feature-development | add feature, implement, new plugin | Add new features following repo patterns |
+| ci-cd-pipeline | update pipeline, fix CI, modify workflow | Modify GitHub Actions or Azure Pipelines |
+| infrastructure | update Dockerfile, Helm chart, k8s manifest | Modify container/deployment infrastructure |
+| test-authoring | add test, write test, increase coverage | Add unit, integration, or E2E tests |
+| documentation | update docs, write README, release notes | Update documentation and release notes |
+| security-review | security review, STRIDE, credential check | STRIDE-based security review |
+| telemetry-authoring | add telemetry, add metrics, instrument code | Add Application Insights telemetry |
+| fix-critical-vulnerabilities | fix CVE, patch vulnerability, trivy fix | Fix critical/high vulnerabilities |
+
+## Build Instructions
+
+```bash
+# Prerequisites: Go 1.23+, Ruby 3.3+, Docker, Make
+
+# Build Go Fluent Bit output plugin
+cd source/plugins/go/src && make fbplugin
+
+# Run Go unit tests
+cd source/plugins/go/src && make test
+
+# Run all unit tests (Bash + Go + Ruby)
+./test/unit-tests/test_main.sh
+
+# Build Linux Docker image (requires Docker)
+cd kubernetes/linux/dockerbuild && ./build-and-publish-docker-image.sh --image <name>
+
+# Run Ginkgo E2E tests (requires running cluster)
+cd test/ginkgo-e2e/<suite> && go test -v ./...
+```
+
+## Known Patterns & Gotchas
+
+- The `$in_unit_test` Ruby global variable gates telemetry in tests — always respect it.
+- Go plugins build as C-shared libraries (`.so`) via `buildmode=c-shared` — CGO is required.
+- Windows and Linux agents have separate entry points (`main.sh` / `main.ps1`) and Dockerfiles.
+- Helm charts in `charts/` are for non-AKS clusters; AKS uses the extension deployment path in `deployment/`.
+- The `.trivyignore` file tracks temporarily suppressed CVEs — entries need justification and follow-up dates.
+- CI runs on `ci_dev` and `ci_prod` branches; PRs target these branches.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "**/*.go"
+description: Code style, design patterns, and best practices for Go code in the Docker-Provider agent.
+---
+
+# Go Conventions — Docker-Provider
+
+- Follow standard `gofmt` formatting — no custom style overrides.
+- All public functions, types, and constants must have doc comments.
+- Error handling: Always check `err != nil`; use `Log("message: %s", err.Error())` from the agent's logging utilities.
+- Telemetry: Use the global `TelemetryClient` from `telemetry.go` — call `TelemetryClient.TrackMetric` / `TrackEvent`, never create new clients.
+- Common telemetry properties live in `CommonProperties` map — add to it during initialization, not per-call.
+- The output plugin (`out_oms.go`) uses CGo with `//export` directives — maintain the C-shared calling convention.
+- Use `os.Getenv()` for environment variable access — never hardcode values.
+- Kubernetes client: Use `client-go` with in-cluster config from `rest.InClusterConfig()`.
+- Concurrency: Use `sync.Mutex` or `sync.RWMutex` for shared state — the agent is multi-goroutine.
+- Dependencies are managed via `go.mod` — run `go mod tidy` after changes.
+- Test files use `_test.go` suffix; use `github.com/stretchr/testify` for assertions.
+- For Ginkgo E2E tests in `test/ginkgo-e2e/`, use `Describe`/`Context`/`It` and `Expect` from gomega.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "**/*.ps1,**/*.psm1"
+description: Code style and best practices for PowerShell scripts in the Docker-Provider Windows agent.
+---
+
+# PowerShell Conventions — Docker-Provider
+
+- Use `PascalCase` for function names and `$camelCase` for local variables.
+- Scripts in `build/windows/installer/scripts/` serve as the Windows counterpart to Linux Bash scripts.
+- `kubernetes/windows/main.ps1` is the Windows container entry point — follow its logging and startup patterns.
+- Use `$env:VAR_NAME` for environment variable access.
+- Error handling: Use `try/catch` blocks; log errors before re-throwing.
+- When modifying Windows agent behavior, check if a matching Linux script exists and keep parity.
+- Test scripts follow the pattern in `test/unit-tests/test_framework.ps1` and `test/unit-tests/test_main.ps1`.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.rb"
+description: Code style, design patterns, and best practices for Ruby code in the Docker-Provider agent.
+---
+
+# Ruby Conventions — Docker-Provider
+
+- Always add `# frozen_string_literal: true` as the second line (after shebang if present).
+- Use `require_relative` for local file imports within `source/plugins/ruby/`.
+- Fluent Bit plugins must inherit from the appropriate base class (`Fluent::Plugin::Input`, `Filter`, or `Output`) and call `register_input`/`register_filter`/`register_output`.
+- Use `ApplicationInsightsUtility.sendExceptionTelemetry` for error reporting — never use `puts` or `$stderr` for production error output.
+- Guard telemetry calls with `$in_unit_test` check — do not emit telemetry during unit test execution.
+- Use `@@` class variables for plugin-level state and `@` instance variables for per-instance state.
+- Environment variables are accessed via `ENV["VAR_NAME"]` — always check for nil/empty before use.
+- Use `begin/rescue => e` for error handling; log errors with `@log.warn` or `@log.error` (Fluent logger).
+- Time handling: Use `DateTime.now.to_time.to_i` for epoch timestamps, `Time.now.utc.iso8601` for ISO format.
+- JSON serialization: Use `JSON.parse` / `JSON.generate` from the standard library.
+- Do not introduce new gems without updating the build process in `kubernetes/linux/setup.sh`.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.sh"
+description: Code style and best practices for Shell/Bash scripts in the Docker-Provider agent.
+---
+
+# Shell/Bash Conventions — Docker-Provider
+
+- Start every script with `#!/bin/bash`.
+- Use `set -e` and `set -o pipefail` for fail-fast behavior in build/deployment scripts.
+- Quote all variable expansions: `"$VAR"` not `$VAR` to prevent word splitting.
+- Use `snake_case` for variable names, `camelCase` for function names (matches existing convention).
+- Environment variable checks: Use `[ -n "$VAR" ]` or `[ -z "$VAR" ]` before accessing.
+- Use `echo` for user output; prefer `>&2` for error/warning messages.
+- File existence: Use `[ -f "$path" ]` or `[ -e "$path" ]` before reading files.
+- For installer scripts in `build/linux/installer/scripts/`, follow the existing pattern of sourcing shared functions.
+- Container entry points (`kubernetes/linux/main.sh`): Log startup timestamps and use structured logging patterns.
+- Test scripts in `test/unit-tests/` follow the custom test framework in `test_framework.sh` — use `assert_equals`, `assert_contains`.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,49 @@
+# Bug Fix
+
+## Description
+Fix bugs in the Docker-Provider agent with proper regression testing.
+
+USE FOR: fix bug, resolve issue, patch, hotfix, debug, error fix, resolve crash
+DO NOT USE FOR: feature development, refactoring, performance optimization
+
+## Instructions
+
+### When to Apply
+When a bug is reported or discovered in the agent's log collection, metric forwarding, Kubernetes inventory, or container startup behavior.
+
+### Step-by-Step Procedure
+1. **Reproduce the issue:**
+   - Check if the bug is in Ruby plugins (`source/plugins/ruby/`), Go plugin (`source/plugins/go/src/`), or shell scripts (`build/`, `kubernetes/`)
+   - For Ruby: Run `ruby test/unit-tests/test_driver.rb` to check existing tests
+   - For Go: Run `cd source/plugins/go/src && go test ./...` to check existing tests
+
+2. **Write a regression test FIRST:**
+   - Ruby: Add test in the corresponding `*_test.rb` file
+   - Go: Add test in the corresponding `*_test.go` file
+   - Shell: Add test case in `test/unit-tests/test_cases/`
+
+3. **Implement the fix:**
+   - Follow existing error handling patterns
+   - Add telemetry for the error path if missing
+
+4. **Verify the fix:**
+   - Run unit tests: `./test/unit-tests/test_main.sh`
+   - For Go: `cd source/plugins/go/src && go test -race ./...`
+   - Build Docker image if infrastructure changes involved
+
+### Files Typically Involved
+- `source/plugins/ruby/*.rb` — Ruby plugin fixes
+- `source/plugins/go/src/*.go` — Go plugin fixes
+- `build/linux/installer/scripts/*.sh` — Installer/startup script fixes
+- `kubernetes/linux/main.sh` — Container entry point fixes
+- `test/unit-tests/` — Regression tests
+
+### Validation
+- Regression test fails without the fix, passes with it
+- All existing unit tests pass
+- Docker image builds successfully
+
+## Examples from This Repo
+- `5c0bca0bb` — bug fix (#1593)
+- `fbcc3de37` — fix bug (#1577)
+- `41e880633` — fix amaca liveness probe issue in high scale mode

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,52 @@
+# CI/CD Pipeline
+
+## Description
+Modify GitHub Actions workflows, Azure Pipelines, or build infrastructure for the Docker-Provider agent.
+
+USE FOR: update pipeline, fix CI, modify workflow, update build, migrate pipeline, fix scan
+DO NOT USE FOR: application code changes, documentation updates, dependency bumps (unless CI-specific)
+
+## Instructions
+
+### When to Apply
+When CI/CD workflows need updating for new build requirements, scan configurations, pipeline migrations, or build infrastructure changes.
+
+### Step-by-Step Procedure
+1. **Identify the pipeline type:**
+   - **GitHub Actions**: `.github/workflows/` — unit tests, PR checks, CodeQL, DevSkim
+   - **Azure Pipelines**: `.pipelines/` — build, release, E2E tests, production deployment
+   - **Build scripts**: `build/linux/Makefile`, `source/plugins/go/src/Makefile`
+
+2. **Make the change following existing patterns:**
+   - GitHub Actions: YAML workflow files with standard actions (checkout, setup-go, etc.)
+   - Azure Pipelines: YAML templates with stage/job/step structure
+   - Makefiles: Standard GNU Make with variables from `build/version`
+
+3. **Test the change:**
+   - For GitHub Actions: Push to a feature branch and verify the workflow runs
+   - For Makefiles: Run the modified target locally
+   - For Docker builds: Build the image locally and verify
+
+4. **Verify security scanning:**
+   - CodeQL analysis must remain enabled for Go and Ruby
+   - DevSkim must remain enabled
+   - Trivy scanning must be present in PR check workflow
+
+### Files Typically Involved
+- `.github/workflows/*.yml` — GitHub Actions workflows
+- `.pipelines/*.yaml` — Azure Pipelines configurations
+- `build/linux/Makefile` — Linux build system
+- `source/plugins/go/src/Makefile` — Go plugin build
+- `build/version` — Version numbers
+- `kubernetes/linux/dockerbuild/` — Docker build scripts
+
+### Validation
+- Workflow syntax is valid YAML
+- GitHub Actions workflows pass on feature branch
+- Docker image builds successfully
+- Security scans (CodeQL, DevSkim, Trivy) remain active
+
+## Examples from This Repo
+- `0d5ca4aeb` — Governed release yamls migration
+- `58a1c9436` — Migrate all release pipelines to governed release yaml
+- `f32e2eec4` — Testkube workflow migration

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,53 @@
+# Dependency Update
+
+## Description
+Update Go modules, Ruby gems, or container base images in the Docker-Provider agent.
+
+USE FOR: update dependency, bump package, upgrade library, update go.mod, update base image, bump fluent-bit, upgrade telegraf
+DO NOT USE FOR: adding a brand new dependency, removing a dependency, major framework migration
+
+## Instructions
+
+### When to Apply
+When a dependency needs to be updated for security fixes, new features, or version currency. Common triggers include Dependabot alerts, Trivy scan findings, or upstream release announcements.
+
+### Step-by-Step Procedure
+1. **Identify the dependency type:**
+   - Go modules → modify `go.mod` files in `source/plugins/go/src/` and `source/plugins/go/input/`
+   - Ruby gems → modify gem install in `kubernetes/linux/setup.sh`
+   - Fluent Bit → update version in build scripts and Dockerfile
+   - Telegraf → update version in build scripts
+   - Container base image → update `FROM` line in `kubernetes/linux/Dockerfile.multiarch` or `kubernetes/windows/Dockerfile`
+
+2. **Update the dependency:**
+   - For Go: `cd source/plugins/go/src && go get <package>@<version> && go mod tidy`
+   - Also update any other `go.mod` files that depend on the same package (check `test/ginkgo-e2e/*/go.mod`)
+   - For base images: Update the `FROM` tag/digest in the Dockerfile
+
+3. **Build and verify:**
+   - `cd source/plugins/go/src && make fbplugin` (Go plugin)
+   - `cd source/plugins/go/src && make test` (Go tests)
+   - Docker image build to verify no compilation errors
+
+4. **Run vulnerability scan:**
+   - Verify the update resolves the targeted CVE/vulnerability
+   - Check `.trivyignore` — remove entries for now-fixed CVEs
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/*/go.mod`, `source/plugins/go/input/*/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/linux/setup.sh`
+- `.trivyignore`
+
+### Validation
+- `go mod tidy` completes without errors
+- `make test` passes in `source/plugins/go/src/`
+- Docker image builds successfully
+- Trivy scan shows no new critical/high CVEs
+
+## Examples from This Repo
+- `6f4c31f91` — 3.1.32 CVE fixes
+- `733532d7f` — 3.1.31 CVEs fixes
+- `090c1dd49` — Upgrade Fluent Bit to 4.0.9

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,46 @@
+# Documentation
+
+## Description
+Update documentation, release notes, README files, and configuration guides for the Docker-Provider agent.
+
+USE FOR: update docs, write README, release notes, changelog, configuration guide, onboarding guide
+DO NOT USE FOR: code comments in source files, inline documentation, API doc generation
+
+## Instructions
+
+### When to Apply
+When releasing a new version, adding new features that need user documentation, or updating existing guides.
+
+### Step-by-Step Procedure
+1. **Identify the documentation type:**
+   - **Release notes**: Update `ReleaseNotes.md` with version, date, and changes
+   - **README**: Update `README.md` for repo structure or prerequisite changes
+   - **Feature docs**: Add/update files in `Documentation/` subdirectories
+   - **Onboarding**: Update Terraform/Bicep/ARM templates in `scripts/onboarding/`
+   - **Helm chart docs**: Update `charts/azuremonitor-containers/README.md`
+
+2. **Follow existing format:**
+   - Release notes: `## Release <version> (<date>)` with bullet-point changes
+   - Documentation: ATX headings, fenced code blocks with language tags
+   - Use relative links for cross-references within the repo
+
+3. **Update version references:**
+   - Ensure version numbers in docs match `build/version`
+   - Update Helm chart version references
+
+### Files Typically Involved
+- `ReleaseNotes.md` — Version release history
+- `README.md` — Project overview
+- `Documentation/` — Feature-specific guides
+- `charts/azuremonitor-containers/Chart.yaml` — Helm chart version
+- `scripts/onboarding/` — Onboarding templates
+
+### Validation
+- All file paths referenced in documentation exist
+- Version numbers are consistent across files
+- Markdown renders correctly (no broken links or formatting)
+
+## Examples from This Repo
+- `7410ab3a9` — release notes for 3.1.35
+- `d30c2c4ad` — 3.1.34 release notes and chart update
+- `731a625b6` — add deprecation note for helm chart

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,57 @@
+# Feature Development
+
+## Description
+Add new features to the Docker-Provider agent following established patterns.
+
+USE FOR: add feature, implement, new plugin, new data stream, enable support, add integration
+DO NOT USE FOR: bug fixes, refactoring, documentation-only changes
+
+## Instructions
+
+### When to Apply
+When adding new data collection capabilities, new cloud support, new authentication methods, or new agent functionality.
+
+### Step-by-Step Procedure
+1. **Plan the feature scope:**
+   - Determine if it affects DaemonSet (per-node), ReplicaSet (per-cluster), or both
+   - Determine if it needs Linux only, Windows only, or both platforms
+   - Identify which plugin layer: Ruby input/filter, Go output, Telegraf, or Fluent Bit config
+
+2. **Implement following existing patterns:**
+   - **New Ruby plugin**: Follow `source/plugins/ruby/in_kube_*.rb` pattern — register with Fluent Bit, implement `configure`/`start`/`shutdown`
+   - **New Go functionality**: Add to `source/plugins/go/src/` — follow `out_oms.go` patterns for output, update `Makefile`
+   - **New configuration**: Add ConfigMap parsing in `build/common/installer/scripts/` — Ruby for parsing, shell for environment setup
+   - **New environment variable**: Document in `kubernetes/linux/main.sh` and `kubernetes/windows/main.ps1`
+
+3. **Add telemetry:**
+   - Use `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go)
+   - Track: feature enablement, success/failure counts, error details
+   - Gate with `$in_unit_test` (Ruby) for test isolation
+
+4. **Add tests:**
+   - Unit tests alongside the feature code
+   - Update E2E tests in `test/ginkgo-e2e/` if the feature produces new Log Analytics tables
+
+5. **Update configuration:**
+   - Update `build/linux/installer/conf/` for Fluent Bit config changes
+   - Update Helm chart values if the feature is user-configurable
+
+### Files Typically Involved
+- `source/plugins/ruby/` — New Ruby plugins
+- `source/plugins/go/src/` — Go plugin changes
+- `build/common/installer/scripts/` — ConfigMap parsing
+- `build/linux/installer/conf/` — Fluent Bit configuration
+- `kubernetes/linux/main.sh` — Entry point updates
+- `charts/azuremonitor-containers/` — Helm chart updates
+- `test/` — Test additions
+
+### Validation
+- Unit tests pass for new code
+- Docker image builds and starts successfully
+- Feature can be enabled/disabled via ConfigMap or environment variable
+- Telemetry emits for feature operations
+
+## Examples from This Repo
+- `fb8011ca5` — Enabled OTel logs and traces support
+- `c02975eec` — Adding change for networkflow logs new stream
+- `089b05960` — Added FIC auth support

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,124 @@
+# Fix Critical Vulnerabilities
+
+## Description
+Identify and fix critical and high severity vulnerabilities in the Docker-Provider agent using the repo's own scanning tools.
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure, dependency vulnerability fix, container image vulnerability, OS vulnerability fix
+DO NOT USE FOR: general dependency updates without security motivation, adding new security scanning tools, security architecture review (use security-review), threat modeling
+
+## Instructions
+
+### 1. Vulnerability Discovery
+
+**Scanning tools used in this repo:**
+- **Trivy**: Container image and filesystem scanning — configured in `.github/workflows/pr-checker.yml`
+- **CodeQL**: Static analysis for Go and Ruby — configured in `.github/workflows/codeql-analysis.yml`
+- **DevSkim**: Security pattern matching — configured in `.github/workflows/devskim.yml`
+
+**Run scans locally:**
+```bash
+# Trivy filesystem scan for Go module vulnerabilities
+trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/
+
+# Trivy filesystem scan for all Go modules
+find . -name "go.mod" -exec dirname {} \; | xargs -I{} trivy fs --severity CRITICAL,HIGH --scanners vuln {}
+
+# Go vulnerability check
+cd source/plugins/go/src && govulncheck ./...
+
+# Trivy container image scan (requires built image)
+trivy image --severity CRITICAL,HIGH <image-name>
+```
+
+**Parse scan results — extract:**
+- CVE ID, severity, affected package, current version, fixed version
+- Vulnerability type (Go module, OS package, container base image)
+- File path where the vulnerable dependency is declared
+
+### 2. Vulnerability Triage
+
+**a. Direct Go module vulnerabilities:**
+- Package is in `go.mod` `require` (not `indirect`)
+- Priority: HIGH — directly fixable
+- Check all `go.mod` locations: `source/plugins/go/src/`, `source/plugins/go/input/*/`, `test/ginkgo-e2e/*/`
+
+**b. Transitive Go module vulnerabilities:**
+- Package is `// indirect` in `go.mod`
+- Bump the direct parent dependency that pulls it in
+
+**c. OS/base image vulnerabilities:**
+- Check base image in `kubernetes/linux/Dockerfile.multiarch`
+- Check if a newer CBL-Mariner image is available with the fix
+
+**d. Already-ignored vulnerabilities:**
+- Check `.trivyignore` — if CVE is listed with justification, skip it
+- If listed without justification, flag for review
+
+### 3. Fix Implementation
+
+**Go module vulnerabilities:**
+```bash
+cd source/plugins/go/src
+go get <package>@<fixed-version>
+go mod tidy
+
+# Also update other go.mod files if they share the dependency
+cd source/plugins/go/input/containerinventory && go get <package>@<fixed-version> && go mod tidy
+cd source/plugins/go/input/perf && go get <package>@<fixed-version> && go mod tidy
+cd test/ginkgo-e2e/utils && go get <package>@<fixed-version> && go mod tidy
+```
+
+**Container base image vulnerabilities:**
+- Update the `FROM` line in `kubernetes/linux/Dockerfile.multiarch`
+- For Ruby gem vulnerabilities, update in `kubernetes/linux/setup.sh`
+
+**Unfixable vulnerabilities:**
+- Add to `.trivyignore` with justification:
+  ```
+  # CVE-YYYY-NNNNN: No fix available upstream as of YYYY-MM-DD
+  # Tracked at: <upstream issue URL>
+  CVE-YYYY-NNNNN
+  ```
+
+### 4. Build and Test
+
+```bash
+# Build Go plugin
+cd source/plugins/go/src && make fbplugin
+
+# Run Go tests
+cd source/plugins/go/src && go test -race ./...
+
+# Run all unit tests
+./test/unit-tests/test_main.sh
+
+# Re-run vulnerability scan
+trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/
+```
+
+### 5. Commit and Document
+
+**Commit message format:**
+- Single CVE: `fix: patch CVE-YYYY-NNNNN in <package>`
+- Multiple CVEs: `fix: remediate critical/high vulnerabilities (#NNNN)`
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/*/go.mod`, `source/plugins/go/input/*/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/linux/setup.sh`
+- `.trivyignore`
+
+### Validation
+- Build succeeds for Go plugins
+- All unit tests pass
+- Re-scan shows targeted CVEs resolved
+- No new critical/high vulnerabilities introduced
+- `.trivyignore` entries (if any) have proper justification
+
+## Examples from This Repo
+- `31c5bc4fc` — Longw/3.1.35 address vulnerabilities
+- `6f4c31f91` — 3.1.32 CVE fixes
+- `9dcd86c76` — CVEs Fix
+- `15e97f599` — Fix CVEs and handle intermittent errors in Ginkgo tests

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,55 @@
+# Infrastructure
+
+## Description
+Modify container images, Kubernetes manifests, Helm charts, or deployment configurations for the Docker-Provider agent.
+
+USE FOR: update Dockerfile, modify Helm chart, change k8s manifest, update deployment config, base image upgrade, Mariner upgrade, RBAC change
+DO NOT USE FOR: application logic changes, CI/CD pipeline changes, documentation
+
+## Instructions
+
+### When to Apply
+When modifying container build process, Kubernetes deployment manifests, Helm chart values, or Ev2 deployment configurations.
+
+### Step-by-Step Procedure
+1. **Identify the infrastructure layer:**
+   - **Dockerfiles**: `kubernetes/linux/Dockerfile.multiarch` (Linux), `kubernetes/windows/Dockerfile` (Windows)
+   - **Helm charts**: `charts/azuremonitor-containers/` (public), `charts/azuremonitor-containers-geneva/` (Geneva)
+   - **K8s manifests**: `kubernetes/ama-logs.yaml`, `kubernetes/container-azm-ms-agentconfig.yaml`
+   - **Deployment**: `deployment/` — Ev2 service group definitions for Arc extension releases
+   - **Onboarding scripts**: `scripts/onboarding/` — Terraform, Bicep, ARM templates
+
+2. **Follow security best practices:**
+   - Containers must run as non-root where possible
+   - Set security contexts in Kubernetes manifests
+   - Pin base image versions (no `:latest` tags)
+   - Minimize installed packages in Dockerfiles
+
+3. **Update version and chart metadata:**
+   - Update `build/version` for agent version changes
+   - Update Helm chart `Chart.yaml` version and `appVersion`
+   - Update `values.yaml` defaults if configuration changes
+
+4. **Consider multi-architecture:**
+   - Linux image builds for amd64 and arm64 (`Dockerfile.multiarch`)
+   - Ensure build dependencies are available for both architectures
+
+### Files Typically Involved
+- `kubernetes/linux/Dockerfile.multiarch` — Linux container image
+- `kubernetes/windows/Dockerfile` — Windows container image
+- `kubernetes/linux/setup.sh` — Linux image setup (package installation)
+- `kubernetes/ama-logs.yaml` — Kubernetes deployment manifest
+- `charts/azuremonitor-containers/` — Helm chart
+- `deployment/` — Ev2 deployment configs
+- `build/version` — Version numbers
+
+### Validation
+- Docker image builds for both amd64 and arm64
+- Trivy scan passes with no new critical/high CVEs
+- Helm chart lints successfully: `helm lint charts/azuremonitor-containers/`
+- Kubernetes manifest is valid YAML
+
+## Examples from This Repo
+- `8ac2038cc` — Mariner 3 upgrade
+- `090c1dd49` — Upgrade Fluent Bit to 4.0.9, add missing dependencies
+- `a71f549e0` — Fluent bit 4.0.14

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,99 @@
+# Security Review
+
+## Description
+Perform a STRIDE-based security review of code changes in the Docker-Provider agent.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit, hardening review
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## Instructions
+
+### When to Apply
+Apply to every PR that modifies authentication/authorization logic, network-facing code, data handling, infrastructure (Dockerfiles, Helm charts, scripts), or dependency changes.
+
+### Step-by-Step Procedure
+
+#### 1. STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Authentication checks present at AMCS and Log Analytics endpoints
+- MSI tokens and certificates validated before use (not just checked for presence)
+- FIC (Federated Identity Credential) tokens properly validated
+- Service-to-service calls use managed identity or certificate auth
+
+**Tampering (Data Integrity)**
+- Input validated on Kubernetes API responses (pod lists, node lists, events)
+- ConfigMap values parsed with error handling (malformed YAML/JSON)
+- File permissions on mounted secrets are restrictive (0400/0440)
+- TLS used for all Azure service communication
+
+**Repudiation (Auditability)**
+- Authentication failures logged via Application Insights telemetry
+- Configuration changes tracked (ConfigMap reloads, setting changes)
+- Agent startup and shutdown events logged with context
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets, API keys, or connection strings in source code
+- Instrumentation keys loaded from env vars (`APPLICATIONINSIGHTS_AUTH`) or mounted secrets
+- Error messages do not expose internal file paths or configuration details
+- Container logs forwarded to Log Analytics are not logged locally in plain text
+
+**Denial of Service (Availability)**
+- Resource limits set in Kubernetes manifests (CPU/memory limits)
+- Fluent Bit buffer sizes bounded (`Mem_Buf_Limit` configured)
+- Retry logic uses exponential backoff (not unbounded retries)
+- Kubernetes API client has timeouts configured
+
+**Elevation of Privilege (Authorization)**
+- Containers run as non-root (`USER` directive in Dockerfile)
+- RBAC ClusterRole uses minimal permissions (only what's needed for inventory collection)
+- No `privileged: true`, `hostPID`, or `hostNetwork` without documented justification
+- Security contexts set: `readOnlyRootFilesystem` where possible
+
+#### 2. Credential & Secret Leak Detection
+- Scan changed files for hardcoded strings matching:
+  - Azure connection strings: `Endpoint=...;SharedAccessKey=...`
+  - Application Insights keys: 32-character hex strings
+  - Bearer tokens, API keys, private keys
+  - Passwords in config: `password=`, `secret=`, `key=` followed by literal values
+- Check that `.trivyignore` entries have justification comments
+- Verify `.gitignore` excludes `*.pem`, `*.key`, `.env`
+
+#### 3. Weak Security Patterns
+
+**Go:**
+- `#nosec` annotations without justification comment
+- Unchecked `err` from TLS/auth functions
+- `exec.Command` with unsanitized input
+- HTTP instead of HTTPS in endpoint URLs
+
+**Ruby:**
+- `eval`, `send` with user-controlled input
+- `system()` or backtick execution with unsanitized input
+- `YAML.load` instead of `YAML.safe_load`
+- Disabled SSL verification
+
+**Shell/Bash:**
+- Unquoted variables in commands
+- `chmod 777` or overly permissive permissions
+- Secrets passed as command-line arguments
+- Missing `set -e` in security-critical scripts
+- `curl` without certificate verification
+
+**Infrastructure (Dockerfiles, k8s):**
+- Running as root without justification
+- Using `:latest` tags (non-reproducible builds)
+- Secrets in ENV instead of mounted secrets
+- Exposed ports that should be internal-only
+- Missing security contexts in Kubernetes manifests
+
+#### 4. CI Security Integration
+- CodeQL analysis active: `.github/workflows/codeql-analysis.yml`
+- DevSkim active: `.github/workflows/devskim.yml`
+- Trivy scanning in PR checker: `.github/workflows/pr-checker.yml`
+- `.trivyignore` entries reviewed for validity
+
+### Validation
+- Run existing security CI checks (CodeQL, DevSkim, Trivy)
+- Verify `.gitignore` excludes secret files
+- Confirm `SECURITY.md` exists and describes responsible disclosure

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,83 @@
+# Telemetry Authoring
+
+## Description
+Add Application Insights telemetry to the Docker-Provider agent following existing instrumentation patterns.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add logging, add Application Insights, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+When adding new code paths, error handlers, or entry points that need observability. Also when existing code lacks telemetry coverage.
+
+### Step-by-Step Procedure
+
+#### 1. Telemetry Pattern Discovery
+Before adding ANY telemetry, identify the pattern in use:
+
+**Ruby plugins** (`source/plugins/ruby/`):
+- Helper: `ApplicationInsightsUtility` class in `source/plugins/ruby/ApplicationInsightsUtility.rb`
+- Error telemetry: `ApplicationInsightsUtility.sendExceptionTelemetry(e)`
+- Custom events: `ApplicationInsightsUtility.sendCustomEvent("EventName", properties)`
+- Metrics: `ApplicationInsightsUtility.sendMetricTelemetry("metricName", value, properties)`
+- Initialization: `ApplicationInsightsUtility.initializeUtility()` called at startup
+- Standard properties: `computer`/hostname, `controllerType` (DS/RS), `agentVersion`, `clusterName`
+
+**Go output plugin** (`source/plugins/go/src/`):
+- Client: Global `TelemetryClient` from `telemetry.go` (type `appinsights.TelemetryClient`)
+- Metrics: `TelemetryClient.TrackMetric("MetricName", value)` with `CommonProperties`
+- Events: `TelemetryClient.TrackEvent("EventName")` with properties map
+- Errors: `TelemetryClient.TrackException(err)` with properties
+- Common properties: `CommonProperties` map set during initialization in `telemetry.go`
+- Periodic telemetry: Uses `time.Ticker` for batched metric emission
+
+#### 2. What to Instrument (priority order)
+
+**a. Error paths (highest priority)**
+- Every `rescue => e` (Ruby) or `if err != nil` (Go) block for unexpected failures
+- Include: error type, message, stack trace (Ruby: `e.backtrace`), operation context
+- Pattern: `ApplicationInsightsUtility.sendExceptionTelemetry(e)` or `TelemetryClient.TrackException(err)`
+
+**b. Entry points and boundaries**
+- Fluent Bit plugin `start`/`run`/`emit` methods, HTTP endpoints, timer callbacks
+- Track: operation name, duration, success/failure, record counts
+- Pattern: Capture start time, compute duration, emit metric
+
+**c. External calls**
+- Kubernetes API calls, AMCS/Log Analytics HTTP posts, Azure auth token requests
+- Track: target endpoint, duration, response status/error
+- Pattern: Wrap call with timing; emit success/failure metric
+
+**d. Critical business logic**
+- Log flush operations, inventory collection cycles, config reloads
+- Track: counts, batch sizes, latency
+- Pattern: `TelemetryClient.TrackMetric("flush.count", count)` with dimensions
+
+#### 3. Telemetry Conventions
+- Metric naming: `<component>.<operation>.<measurement>` (e.g., `containerlog.flush.count`, `kubeinventory.collect.duration`)
+- Event naming: `PascalCase` (e.g., `HeartBeatEvent`, `ExceptionEvent`, `ConfigReloaded`)
+- Standard dimensions on all telemetry:
+  - `Computer` — hostname of the node
+  - `ControllerType` — `DS` or `RS`
+  - `AgentVersion` — from `AGENT_VERSION` env var
+  - `ClusterName` / `ClusterId` — from `AKS_RESOURCE_ID`
+
+#### 4. Anti-Patterns to Avoid
+- Do NOT log sensitive data (credentials, tokens, PII, request bodies)
+- Do NOT add telemetry inside tight loops (batch and emit periodically using tickers)
+- Do NOT use `puts`/`$stdout`/`fmt.Println` for production telemetry — use the SDK
+- Do NOT create new `TelemetryClient` instances — reuse the global singleton
+- Do NOT emit telemetry in unit test code paths (respect `$in_unit_test` in Ruby)
+- Do NOT hardcode instrumentation keys — use `APPLICATIONINSIGHTS_AUTH` env var
+
+#### 5. Validation
+- Verify import/require matches existing files
+- Verify metric/event names follow naming convention
+- Verify dimensions match the standard set
+- Run unit tests to ensure telemetry additions don't break test isolation
+- Check that Ruby telemetry is gated with `$in_unit_test`
+
+## References
+- `source/plugins/ruby/ApplicationInsightsUtility.rb` — Ruby telemetry helper
+- `source/plugins/go/src/telemetry.go` — Go telemetry initialization and helpers

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,57 @@
+# Test Authoring
+
+## Description
+Add unit tests, integration tests, or E2E tests for the Docker-Provider agent.
+
+USE FOR: add test, write test, test coverage, add unit test, add integration test, add E2E test, add Ginkgo test
+DO NOT USE FOR: fixing flaky tests, refactoring test infrastructure, test framework changes
+
+## Instructions
+
+### When to Apply
+When adding tests for new features, bug fixes (regression tests), or improving coverage for existing code.
+
+### Step-by-Step Procedure
+1. **Choose the test type:**
+   - **Go unit test**: For Go plugin logic → `source/plugins/go/src/*_test.go`
+   - **Ruby unit test**: For Ruby plugin logic → `source/plugins/ruby/*_test.rb`
+   - **Bash unit test**: For shell script logic → `test/unit-tests/test_cases/test_<name>.sh`
+   - **Ginkgo E2E**: For end-to-end validation against a live cluster → `test/ginkgo-e2e/<suite>/`
+   - **pytest E2E**: For workflow validation → `test/e2e/src/tests/test_<name>.py`
+
+2. **Follow naming conventions:**
+   - Go: `*_test.go` in same package, functions named `Test<Name>(t *testing.T)` or Ginkgo `Describe`/`It`
+   - Ruby: `*_test.rb` alongside the plugin file, using `Minitest::Test`
+   - Bash: `test_<functionName>.sh` in `test/unit-tests/test_cases/`, using `assert_equals`/`assert_contains`
+   - Ginkgo E2E: `*_test.go` with `_suite_test.go` for setup, using `Describe`/`DescribeTable`/`Entry`
+
+3. **Write the test:**
+   - Test both success and error paths
+   - For Ruby: Set `$in_unit_test = true` in test setup (handled by `test_driver.rb`)
+   - For Go: Use `github.com/stretchr/testify` for assertions in unit tests, `gomega` for Ginkgo
+   - For Ginkgo E2E: Use `utils` package from `test/ginkgo-e2e/utils/` for cluster setup
+
+4. **Run the test:**
+   - Go: `cd source/plugins/go/src && go test -race -v ./...`
+   - Ruby: `ruby test/unit-tests/test_driver.rb`
+   - Bash: `./test/unit-tests/test_main.sh`
+   - Ginkgo: `cd test/ginkgo-e2e/<suite> && go test -v ./...`
+
+### Files Typically Involved
+- `source/plugins/go/src/*_test.go` — Go unit tests
+- `source/plugins/ruby/*_test.rb` — Ruby unit tests
+- `test/unit-tests/test_cases/*.sh` — Bash unit tests
+- `test/unit-tests/test_functions/*.sh` — Bash test helper functions
+- `test/ginkgo-e2e/*/` — Ginkgo E2E test suites
+- `test/e2e/src/tests/` — pytest E2E tests
+
+### Validation
+- New test passes when run in isolation
+- All existing tests continue to pass
+- Go tests pass with `-race` flag
+- CI workflow `.github/workflows/run_unit_tests.yml` passes
+
+## Examples from This Repo
+- `f32e2eec4` — Testkube workflow migration
+- `137873158` — Remove custom metrics tests from conformance tests
+- `3268cb2f1` — Update conformance test

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/microsoft/Docker-Provider.git
+cd Docker-Provider
+
+# 2. Install Go (1.23.8+)
+# See https://golang.org/doc/install
+
+# 3. Install Ruby (3.3+)
+# Linux: tdnf install ruby or use ruby-build (see kubernetes/linux/setup.sh)
+
+# 4. Build Go Fluent Bit output plugin
+cd source/plugins/go/src
+go get
+make fbplugin
+cd -
+
+# 5. Run unit tests to verify setup
+./test/unit-tests/test_main.sh
+
+# 6. (Optional) Build Docker image for local testing
+cd kubernetes/linux/dockerbuild
+./build-and-publish-docker-image.sh --image local-test
+```
+
+## Code Style
+
+### Ruby
+- Use `frozen_string_literal: true` pragma at the top of every file.
+- Use `snake_case` for methods, variables, and file names.
+- Use `require_relative` for local imports.
+- Indent with 2 spaces.
+- Fluent Bit plugins follow the `Fluent::Plugin` module pattern with `register_input`/`register_filter`/`register_output`.
+- Telemetry: Use `ApplicationInsightsUtility` class methods — never instantiate `TelemetryClient` directly.
+
+### Go
+- Follow standard `gofmt` formatting.
+- Use `camelCase` for local vars, `PascalCase` for exports.
+- Error handling: Always check `err != nil` and log or return errors.
+- Telemetry: Use the global `TelemetryClient` from `telemetry.go` — emit via `appinsights.TrackMetric` / `TrackEvent`.
+- Fluent Bit plugins use CGo with `//export` directives.
+- Environment variables accessed via `os.Getenv()`.
+
+### Shell/Bash
+- Start scripts with `#!/bin/bash` and use `set -e` / `set -o pipefail` for error safety.
+- Use `snake_case` for variables, `camelCase` for function names.
+- Quote all variable expansions to prevent word splitting.
+
+### PowerShell
+- Use `PascalCase` for function names, `camelCase` for local variables.
+- Scripts in `build/windows/installer/scripts/` and `kubernetes/windows/`.
+
+## Testing Instructions
+
+### Unit Tests
+```bash
+# Run all unit tests (Bash + Go + Ruby)
+./test/unit-tests/test_main.sh
+
+# Run only Go tests
+cd source/plugins/go/src && go test -cover -race -coverprofile=coverage.txt -covermode=atomic
+
+# Run only Ruby tests
+ruby test/unit-tests/test_driver.rb
+
+# Run only Bash tests
+./test/unit-tests/test_framework.sh
+```
+
+### E2E Tests (Ginkgo)
+```bash
+# Requires a running AKS cluster with the agent deployed
+cd test/ginkgo-e2e/<suite>
+go test -v ./...
+```
+
+### E2E Tests (pytest)
+```bash
+cd test/e2e/src
+pytest
+```
+
+### CI Test Pipeline
+- GitHub Actions: `.github/workflows/run_unit_tests.yml` runs Bash and Go unit tests on every PR.
+- GitHub Actions: `.github/workflows/pr-checker.yml` builds the Docker image and runs Trivy scan.
+- Security: CodeQL (`.github/workflows/codeql-analysis.yml`) and DevSkim (`.github/workflows/devskim.yml`).
+
+## Dev Environment Tips
+
+- Use WSL2 on Windows — clone the repo inside Ubuntu, not on the Windows filesystem.
+- Go version must match what CI uses (1.23.8 as of latest workflow config).
+- Ruby version should be 3.3.x (see `kubernetes/linux/setup.sh` for exact version).
+- The `.trivyignore` file suppresses known unfixable CVEs — update it when adding new suppressions.
+- Build version is controlled by `build/version` file.
+
+## PR Instructions
+
+- **Branch naming**: Feature branches typically use `<alias>/<description>` format (e.g., `longw/networkflow-rename`).
+- **Commit messages**: Freeform style with descriptive summary. Reference PR numbers with `(#NNNN)`.
+- **PR targets**: PRs target `ci_dev` or `ci_prod` branches.
+- **Required checks**: Unit tests (Bash + Go), Docker image build, Trivy vulnerability scan, CodeQL, DevSkim.
+- **Merge strategy**: Squash merge with PR title as commit message.
+
+## Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph "Kubernetes Cluster"
+        subgraph "kube-system namespace"
+            DS["ama-logs<br/>(DaemonSet)"]
+            RS["ama-logs-rs<br/>(ReplicaSet)"]
+        end
+        KubeAPI["Kubernetes API Server"]
+    end
+
+    subgraph "Agent Internals"
+        FluentBit["Fluent Bit"]
+        RubyPlugins["Ruby Plugins<br/>(input/filter/output)"]
+        GoPlugin["Go Output Plugin<br/>(out_oms.so)"]
+        Telegraf["Telegraf<br/>(metrics)"]
+    end
+
+    subgraph "Azure Services"
+        LA["Log Analytics<br/>Workspace"]
+        AMCS["Azure Monitor<br/>Collection Service"]
+        AI["Application Insights<br/>(agent telemetry)"]
+        Geneva["Geneva<br/>(internal telemetry)"]
+    end
+
+    DS --> FluentBit
+    RS --> FluentBit
+    FluentBit --> RubyPlugins
+    FluentBit --> GoPlugin
+    DS --> Telegraf
+    GoPlugin --> AMCS
+    GoPlugin --> LA
+    RubyPlugins --> AMCS
+    Telegraf --> AMCS
+    GoPlugin --> AI
+    RubyPlugins --> AI
+    KubeAPI --> RubyPlugins
+    KubeAPI --> GoPlugin
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,102 @@
+# Docker-Provider (Azure Monitor for Containers Agent)
+
+Azure Monitor for Containers agent that collects container logs, metrics, and Kubernetes inventory from AKS and Arc-enabled Kubernetes clusters, forwarding telemetry to Azure Monitor / Log Analytics.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log collection plugins | Ruby (Fluent Bit input/filter plugins) |
+| Output plugin | Go (Fluent Bit output, C-shared library) |
+| Metrics collection | Telegraf |
+| Log pipeline | Fluent Bit |
+| Container runtime | Docker / containerd |
+| Orchestration | Kubernetes (DaemonSet + ReplicaSet) |
+| Container OS (Linux) | CBL-Mariner 3 |
+| Container OS (Windows) | Windows Server Core |
+| Build system | Make, Docker |
+| CI/CD | GitHub Actions, Azure Pipelines |
+| Telemetry | Application Insights (Go + Ruby SDKs) |
+| Infrastructure as Code | Helm, Terraform, Bicep, Ev2 |
+| Unit testing | Go test, Ruby test/unit, Bash (custom framework) |
+| E2E testing | Ginkgo/Gomega (Go), pytest (Python) |
+
+## Architecture Overview
+
+The agent runs as two Kubernetes workloads:
+- **ama-logs (DaemonSet)**: Runs on every node, collects container stdout/stderr logs, node-level metrics via Telegraf, and cAdvisor performance data.
+- **ama-logs-rs (ReplicaSet)**: Single instance per cluster, collects cluster-level Kubernetes inventory (pods, nodes, deployments, events).
+
+Both workloads embed Fluent Bit with custom Ruby input/filter plugins and a Go output plugin (`out_oms.so`). Data flows through Fluent Bit's pipeline and is forwarded to Azure Monitor Collection Service (AMCS) or directly to Log Analytics.
+
+Key source directories:
+- `source/plugins/ruby/` — Fluent Bit Ruby plugins (input, filter, output)
+- `source/plugins/go/src/` — Go output plugin (out_oms)
+- `source/plugins/go/input/` — Go input plugins (container inventory, perf)
+- `build/` — Build scripts, Makefiles, installer configs
+- `kubernetes/` — Dockerfiles, entry point scripts, ACR workflows
+- `charts/` — Helm charts for non-AKS deployment
+- `deployment/` — Ev2 deployment configurations for Arc extension releases
+
+## Functional Requirements
+
+### 1) Container Log Collection
+Collect stdout/stderr logs from all containers on each node, parse multiline formats (Java, Python, Go, .NET), and forward to ContainerLog / ContainerLogV2 tables in Log Analytics.
+
+### 2) Kubernetes Inventory Collection
+Periodically query Kubernetes API for pod, node, deployment, service, and event inventory. Forward to KubePodInventory, KubeNodeInventory, and related tables.
+
+### 3) Performance Metrics Collection
+Collect node and container performance metrics (CPU, memory, disk, network) via cAdvisor and Telegraf. Forward as Perf and InsightsMetrics records.
+
+### 4) Custom Metrics to MDM
+Filter and forward specific inventory and performance data as custom metrics to Azure Monitor Metrics (MDM) for alerting.
+
+### 5) Multi-cloud and Multi-tenant Support
+Support AKS, Arc-enabled Kubernetes, and hybrid clusters across Azure public, sovereign clouds (China, USGov, USNat, USSec), and Bleu.
+
+## Non-Functional Requirements
+
+- **Scalability**: Handle high-scale clusters (5000+ nodes) with batching, backpressure, and configurable resource limits.
+- **Security**: Run as non-root, use managed identity (MSI) or certificate-based auth, scan images with Trivy/CodeQL/DevSkim.
+- **Observability**: Agent self-telemetry via Application Insights — heartbeats, error rates, flush metrics.
+- **Reliability**: Liveness probes, graceful shutdown, retry with exponential backoff for transient failures.
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/ruby/` | Fluent Bit Ruby plugins (in_kube_*, filter_*, out_*) |
+| `source/plugins/go/src/` | Go output plugin and telemetry |
+| `build/linux/Makefile` | Linux build orchestration |
+| `build/version` | Build version numbers |
+| `kubernetes/linux/Dockerfile.multiarch` | Linux container image |
+| `kubernetes/linux/main.sh` | Linux container entry point |
+| `kubernetes/windows/Dockerfile` | Windows container image |
+| `charts/azuremonitor-containers/` | Public Helm chart |
+| `test/unit-tests/` | Unit test framework and cases |
+| `test/ginkgo-e2e/` | Ginkgo E2E test suites |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `APPLICATIONINSIGHTS_AUTH` | Application Insights instrumentation key (telemetry) |
+| `APPLICATIONINSIGHTS_ENDPOINT` | Application Insights ingestion endpoint |
+| `AKS_RESOURCE_ID` | Azure resource ID of the AKS cluster |
+| `AKS_REGION` | Azure region of the cluster |
+| `CONTROLLER_TYPE` | Agent controller type (DaemonSet/ReplicaSet) |
+| `OS_TYPE` | Operating system (linux/windows) |
+| `CONTAINER_RUNTIME` | Container runtime (docker/containerd) |
+| `CLUSTER_CLOUD_ENVIRONMENT` | Cloud environment (azurepubliccloud, azurechinacloud, etc.) |
+| `AGENT_VERSION` | Agent version string |
+| `AAD_MSI_AUTH_MODE` | MSI authentication mode |
+
+## Acceptance Criteria
+
+- All unit tests pass (`./test/unit-tests/test_main.sh`)
+- Go tests pass with race detection (`go test -race ./...`)
+- Docker image builds successfully for linux/amd64 and linux/arm64
+- Trivy scan reports no new critical/high CVEs (or they are documented in `.trivyignore`)
+- CodeQL and DevSkim scans pass
+- Helm chart lints successfully

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,150 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Docker-Provider repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand your codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `.github/copilot-instructions.md` on every session — no action needed.
+3. When you open a file matching a language pattern (`.rb`, `.go`, `.sh`, `.ps1`), the corresponding `.instructions.md` file auto-activates.
+4. Invoke skills by typing their trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them in chat (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically every session | Root router — general rules, skill catalogue |
+| `AGENTS.md` | Root | Automatically (supported tools) | Setup commands, code style, testing, architecture |
+| `ruby.instructions.md` | `.github/instructions/` | Auto on `**/*.rb` match | Ruby coding conventions |
+| `go.instructions.md` | `.github/instructions/` | Auto on `**/*.go` match | Go coding conventions |
+| `shell.instructions.md` | `.github/instructions/` | Auto on `**/*.sh` match | Shell/Bash coding conventions |
+| `powershell.instructions.md` | `.github/instructions/` | Auto on `**/*.ps1` match | PowerShell coding conventions |
+| `Prompt.md` | Root | On demand | Reusable task-spec template |
+| Skill files (`SKILL.md`) | `.github/skills/<name>/` | On keyword trigger | Step-by-step development guides |
+| `CodeReviewer.agent.md` | `.github/agents/` | On @-mention | Structured code review |
+| `SecurityReviewer.agent.md` | `.github/agents/` | On @-mention | Deep security analysis |
+| `ThreatModelAnalyst.agent.md` | `.github/agents/` | On @-mention | STRIDE threat modeling with Mermaid diagrams |
+| `DocumentWriter.agent.md` | `.github/agents/` | On @-mention | Documentation authoring |
+| `prd.agent.md` | `.github/agents/` | On @-mention | PRD generation |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically by VS Code | MCP server configuration |
+| `test/AGENTS.md` | `test/AGENTS.md` | When working in test directory | Test framework guide and decision tree |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: copilot-instructions.md (always loaded)
+  ├── General rules, skill catalogue, build instructions
+  ├── Routes to →
+  │
+Layer 2: .instructions.md files (auto-loaded when you open matching files)
+  ├── Language-specific coding rules (Ruby, Go, Shell, PowerShell)
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+**You don't need to manually load anything.** The system activates automatically based on what file you're editing and what you ask the AI to do.
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Performs structured code reviews covering correctness, style, security (STRIDE), telemetry gaps, and adherence to project conventions.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review my changes for telemetry gaps`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Performs deep security assessments including threat modeling, attack surface analysis, STRIDE deep-dive, and dependency security auditing.
+- **Example prompts:**
+  - `@SecurityReviewer perform a security review of the authentication changes`
+  - `@SecurityReviewer assess the attack surface of our new Kubernetes RBAC changes`
+  - `@SecurityReviewer audit our container security configuration`
+
+### @ThreatModelAnalyst
+- **Invoke:** Type `@ThreatModelAnalyst` in Copilot Chat.
+- **What it does:** Generates comprehensive, persistent threat model artifacts — Mermaid architecture diagrams with security boundaries, full STRIDE analysis matrices, and prioritized threat catalogues under `threat-model/YYYY-MM-DD/`.
+- **Example prompts:**
+  - `@ThreatModelAnalyst perform a full threat model analysis`
+  - `@ThreatModelAnalyst threat model the log ingestion pipeline`
+  - `@ThreatModelAnalyst analyze the Kubernetes RBAC and secrets management`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates and maintains documentation following this repo's conventions.
+- **Example prompts:**
+  - `@DocumentWriter write release notes for version 3.1.36`
+  - `@DocumentWriter update the README with new prerequisites`
+
+### @prd (PRD Generator)
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **What it does:** Generates structured Product Requirements Documents tailored to this project's architecture.
+- **Example prompts:**
+  - `@prd create a PRD for adding OpenTelemetry trace export`
+  - `@prd write requirements for the new multi-tenant logging feature`
+
+## Using Skills
+
+Skills are invoked automatically when you describe a task using natural language. Available skills:
+
+| Skill | Trigger Phrases | Description |
+|-------|----------------|-------------|
+| `dependency-update` | "bump package", "update go.mod", "upgrade fluent-bit" | Update Go modules, Ruby gems, or base images |
+| `bug-fix` | "fix bug", "patch", "hotfix", "debug" | Fix bugs with regression tests |
+| `feature-development` | "add feature", "implement", "new plugin" | Add new features following repo patterns |
+| `ci-cd-pipeline` | "update pipeline", "fix CI", "migrate workflow" | Modify CI/CD workflows |
+| `infrastructure` | "update Dockerfile", "Helm chart", "k8s manifest" | Modify container/deployment infrastructure |
+| `test-authoring` | "add test", "write test", "increase coverage" | Add unit, E2E, or Ginkgo tests |
+| `documentation` | "update docs", "release notes", "write README" | Update documentation |
+| `security-review` | "security review", "STRIDE", "credential check" | STRIDE-based security review |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Add Application Insights telemetry |
+| `fix-critical-vulnerabilities` | "fix CVE", "patch vulnerability", "trivy fix" | Fix critical/high vulnerabilities |
+
+## Using Prompt.md for New Work
+
+`Prompt.md` is a reusable template for describing new tasks or features. Use it when:
+- Starting a new feature and want to give the AI full context
+- Creating a structured brief for a complex change
+
+**How to use:**
+1. Copy `Prompt.md` to a new file (e.g., `feature-xyz-prompt.md`)
+2. Fill in the sections with your specific requirements
+3. Reference it in Copilot Chat: "Implement the feature described in feature-xyz-prompt.md"
+
+## MCP Server Integration
+
+The `.vscode/mcp.json` file configures connections to external data sources:
+- **GitHub MCP:** Enables PR creation, issue management, and branch operations from chat.
+- **Microsoft Docs MCP:** Enables validation of Azure patterns against official documentation.
+
+MCP servers use `${input:variable}` prompts — you'll be asked for credentials on first use.
+
+## Tips for Maximum Productivity
+
+1. **Let auto-loading work** — Just open the file you're editing. Language-specific rules activate automatically.
+2. **Use natural language for skills** — Just describe the task: "add a test for the liveness probe handler".
+3. **Start reviews with @CodeReviewer** — It knows the repo's review patterns, linter rules, and security requirements.
+4. **Use @prd before big features** — A structured PRD helps plan the implementation scope.
+5. **Check test/AGENTS.md for test patterns** — The test decision tree helps choose the right test type.
+6. **Check AGENTS.md for setup** — If the AI struggles with build commands, verify Setup Commands are accurate.
+
+## Customizing These Artifacts
+
+These files evolve with your project:
+- **Add rules** to `.instructions.md` when new coding conventions are established.
+- **Add skills** for new recurring workflows (create `SKILL.md` in `.github/skills/<name>/`).
+- **Update `copilot-instructions.md`** when project structure or build commands change.
+- **Update `AGENTS.md`** when setup commands or test strategies change.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow coding conventions | Verify `.instructions.md` `applyTo` glob matches your file |
+| Skill not activating | Use trigger phrases from the skills table above |
+| Agent not available | Ensure `.agent.md` file is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` and provide credentials when prompted |
+| Build/test commands fail | Update Setup Commands in `AGENTS.md` |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,61 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Pure Go logic with no external dependencies?** → Go unit test (`go test` + `testify`)
+2. **Pure Ruby plugin logic with no external dependencies?** → Ruby unit test (`test/unit-tests/test_driver.rb` + `Minitest`)
+3. **Shell script function logic?** → Bash unit test (`test/unit-tests/test_cases/` + custom framework)
+4. **Tests log table queries against a live cluster?** → Ginkgo E2E test (`test/ginkgo-e2e/querylogs/`)
+5. **Tests container/pod status on a live cluster?** → Ginkgo E2E test (`test/ginkgo-e2e/containerstatus/`)
+6. **Tests agent liveness on a live cluster?** → Ginkgo E2E test (`test/ginkgo-e2e/livenessprobe/`)
+7. **Tests end-to-end workflow scenarios?** → pytest E2E test (`test/e2e/src/tests/`)
+
+## Test Patterns in This Repo
+
+### Go Unit Tests
+- **Framework**: `testing` + `github.com/stretchr/testify` for assertions, `github.com/golang/mock` for mocking
+- **Location**: Alongside source in `source/plugins/go/src/*_test.go`
+- **Run**: `cd source/plugins/go/src && go test -cover -race ./...`
+- **Naming**: `Test<FunctionName>` functions in `*_test.go` files
+
+### Ruby Unit Tests
+- **Framework**: `Minitest::Test`
+- **Location**: `source/plugins/ruby/*_test.rb`
+- **Run**: `ruby test/unit-tests/test_driver.rb` (aggregates all `*_test.rb` files)
+- **Key pattern**: Tests set `$in_unit_test = true` globally to gate telemetry calls
+- **Naming**: `test_<description>` methods in `*_test.rb` files
+
+### Bash Unit Tests
+- **Framework**: Custom framework in `test/unit-tests/test_framework.sh`
+- **Location**: `test/unit-tests/test_cases/test_<name>.sh`
+- **Run**: `./test/unit-tests/test_main.sh`
+- **Assertions**: `assert_equals`, `assert_contains`, `assert_not_contains`
+- **Helper functions**: `test/unit-tests/test_functions/`
+- **Naming**: `test_<functionName>.sh` files
+
+### Ginkgo E2E Tests
+- **Framework**: Ginkgo v2 + Gomega
+- **Location**: `test/ginkgo-e2e/<suite>/` (querylogs, containerstatus, livenessprobe)
+- **Prerequisites**: Running AKS cluster with agent deployed, Azure credentials
+- **Run**: `cd test/ginkgo-e2e/<suite> && go test -v ./...`
+- **Shared utilities**: `test/ginkgo-e2e/utils/` (Kubernetes client setup, Log Analytics query helpers)
+- **Naming**: `Describe`/`DescribeTable` with `Entry` for table-driven tests
+
+### pytest E2E Tests
+- **Framework**: pytest
+- **Location**: `test/e2e/src/tests/`
+- **Config**: `test/e2e/src/core/pytest.ini`, `test/e2e/src/core/conftest.py`
+- **Run**: `cd test/e2e/src && pytest`
+- **Naming**: `test_<workflow>.py` files with `test_<name>` functions
+
+## Common Test Utilities
+- `test/ginkgo-e2e/utils/` — Shared Go utilities for E2E tests (K8s client, Log Analytics queries)
+- `test/unit-tests/test_framework.sh` — Bash test assertion functions
+- `test/unit-tests/test_functions/` — Shared Bash helper functions for test setup
+
+## Test Data
+- `test/scenario/yamls/` — Kubernetes YAML manifests for test pods
+- `test/scenario/multiline/` — Multiline log test scenarios (Java, Python, .NET, Go)
+- `test/containerlog-scale-tests/` — Scale testing configurations


### PR DESCRIPTION
## Summary

Auto-generated AI agent artifacts for coding assistants (GitHub Copilot, Gemini CLI, Cursor, etc.).

### What's included (25 files)

**Core files:**
- `.github/copilot-instructions.md` — root instructions with skill catalogue and build commands
- `AGENTS.md` — setup commands, code style, testing instructions, architecture diagram
- `Prompt.md` — structured task-spec template

**Language-specific instructions (.github/instructions/):**
- `ruby.instructions.md` — Ruby conventions (frozen_string_literal, ApplicationInsightsUtility, Fluent Bit plugin patterns)
- `go.instructions.md` — Go conventions (gofmt, error handling, TelemetryClient, CGo)
- `shell.instructions.md` — Shell/Bash conventions (set -e, quoting, test framework)
- `powershell.instructions.md` — PowerShell conventions (Windows agent scripts)

**Skills (.github/skills/\<name\>/SKILL.md) — 10 total:**
- 7 commit-history-driven: dependency-update, bug-fix, feature-development, ci-cd-pipeline, infrastructure, test-authoring, documentation
- 3 always-generated: security-review (STRIDE), telemetry-authoring (Application Insights), fix-critical-vulnerabilities (Trivy/CVE)

**Agents (.github/agents/):**
- `CodeReviewer.agent.md` — structured code review with STRIDE security + telemetry gap detection
- `SecurityReviewer.agent.md` — deep security analysis and threat modeling
- `ThreatModelAnalyst.agent.md` — STRIDE threat models with Mermaid diagrams
- `DocumentWriter.agent.md` — documentation authoring following repo conventions
- `prd.agent.md` — PRD generation tailored to Docker-Provider architecture

**Infrastructure:**
- `.vscode/mcp.json` — GitHub and Microsoft Docs MCP server configuration
- `test/AGENTS.md` — test framework guide with decision tree (Go, Ruby, Bash, Ginkgo, pytest)
- `coding-agent-instructions.md` — comprehensive user guide for all artifacts

### How to verify
1. Open the repo in VS Code / GitHub Codespaces
2. Start a Copilot Chat session
3. Verify agents respond correctly: `@CodeReviewer`, `@SecurityReviewer`, `@ThreatModelAnalyst`, `@DocumentWriter`, `@prd`
4. Check that `.instructions.md` files activate for matching file types
5. Test skills with natural language: "add a test", "fix CVE", "security review"

> Auto-generated by the agentify prompt. Review before merging.