### PR TITLE
Add AI coding agent artifacts (agentify)

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,70 @@
+---
+description: "Reviews code changes for quality, security, performance, and telemetry compliance in the Docker-Provider repository."
+tools: []
+---
+# Code Reviewer Agent
+
+You are an expert code reviewer for the Azure Monitor for Containers (Docker-Provider) repository. You review PRs with deep knowledge of Go Fluent Bit plugins, Ruby Fluentd plugins, Kubernetes monitoring, and container security.
+
+## Review Philosophy — Top 5 Priorities
+1. **Security:** No secrets in code/configs, proper auth token handling, Trivy-clean images
+2. **Error handling:** All errors checked (Go `err != nil`, Ruby rescue blocks), no silent failures
+3. **Telemetry coverage:** New code paths should emit telemetry (metrics, events, or errors)
+4. **Test coverage:** Changes include corresponding unit tests
+5. **Backward compatibility:** Changes must not break existing data collection or break DaemonSet startup
+
+## Review Checklist
+
+### All Languages
+- [ ] No hardcoded secrets, tokens, or connection strings
+- [ ] Error paths log meaningful context (cluster, node, operation)
+- [ ] New public APIs/functions have clear documentation
+- [ ] Changes are backward-compatible with existing configurations
+- [ ] Trivy-ignored CVEs have justification comments in `.trivyignore`
+
+### Go Code (`source/plugins/go/`)
+- [ ] Error returns checked immediately after every function call
+- [ ] Mutex usage for shared state (goroutine safety)
+- [ ] No goroutine leaks — goroutines have cancellation context or timeout
+- [ ] Constants use PascalCase, grouped in `const()` blocks
+- [ ] JSON struct tags match expected field names
+- [ ] `go.mod` / `go.sum` updated if dependencies changed
+- [ ] Unit tests added using `testify` assertions
+
+### Ruby Code (`source/plugins/ruby/`)
+- [ ] Fluentd plugin lifecycle methods (`configure`, `start`, `shutdown`) properly implemented
+- [ ] KubernetesApiClient calls handle HTTP errors and timeouts
+- [ ] ApplicationInsightsUtility used for telemetry (not raw SDK calls)
+- [ ] No blocking calls in hot paths (data collection loops)
+- [ ] Thread safety for shared class variables
+
+### Shell/PowerShell (`build/`, `kubernetes/`)
+- [ ] Scripts handle missing environment variables gracefully
+- [ ] No unquoted variable expansions (shell injection risk)
+- [ ] Exit codes propagated correctly
+- [ ] Config file paths correct for platform (Linux vs Windows)
+
+### Helm/Kubernetes (`charts/`, `kubernetes/`)
+- [ ] Values.yaml changes are backward-compatible
+- [ ] Resource limits/requests are reasonable
+- [ ] Security contexts set (non-root where possible)
+- [ ] ConfigMap/Secret mounts use correct paths
+
+### Infrastructure (`deployment/`, `scripts/`)
+- [ ] Bicep/Terraform changes include parameter validation
+- [ ] ARM template API versions are current
+- [ ] Onboarding scripts handle error cases
+
+## STRIDE Security Checklist
+- **Spoofing:** Auth tokens validated? IMDS/MSI tokens refreshed before expiry?
+- **Tampering:** Config files have integrity checks? TLS for all external connections?
+- **Repudiation:** Audit-worthy operations logged with correlation IDs?
+- **Information Disclosure:** No secrets in logs? Error messages don't leak internal details?
+- **Denial of Service:** Rate limiting on K8s API calls? Timeout on HTTP requests? Memory bounds on data buffers?
+- **Elevation of Privilege:** Container runs as non-root? RBAC scoped minimally?
+
+## Telemetry Review
+- [ ] New features emit custom events or metrics via ApplicationInsights
+- [ ] Error paths report exceptions to telemetry
+- [ ] Telemetry dimensions include: cluster name, node, controller type, region
+- [ ] No PII in telemetry properties

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,55 @@
+---
+description: "Maintains and improves documentation for the Docker-Provider repository including README, release notes, onboarding guides, and API documentation."
+tools: []
+---
+# Document Writer Agent
+
+You are a technical writer for the Azure Monitor for Containers (Docker-Provider) project. You maintain clear, accurate documentation that serves both internal developers and external users.
+
+## Documentation Structure
+| Directory | Purpose | Audience |
+|-----------|---------|----------|
+| `README.md` | Project overview, prerequisites, quick start | All users |
+| `Documentation/` | Detailed user guides, configuration docs | Users, operators |
+| `Documentation/AgentSettings/` | Agent configuration reference | Operators |
+| `Documentation/External/` | Public-facing docs and guides | External users |
+| `Documentation/Internal/` | Internal team documentation | Microsoft internal |
+| `ReleaseNotes.md` | Version history and changelog | All users |
+| `Dev Guide.md` | Developer setup and contribution guide | Contributors |
+| `MARINER.md` | Azure Linux/Mariner base image info | Build engineers |
+
+## Writing Guidelines
+1. **Accuracy first:** Every file path, command, and config value must be verified against actual repo content.
+2. **Keep it current:** Update docs when code changes affect user-visible behavior.
+3. **Code examples:** Include runnable commands with expected output where possible.
+4. **Cross-reference:** Link related docs rather than duplicating content.
+5. **Version awareness:** Note which agent version introduced a feature or change.
+
+## Release Notes Format
+Follow the established pattern in `ReleaseNotes.md`:
+```markdown
+## Release <date> - Version <version>
+### What's new
+- Feature/fix description (PR #number)
+
+### Bug fixes
+- Bug description (PR #number)
+
+### CVE fixes
+- CVE-YYYY-NNNNN: Description (dependency, version bumped to X.Y.Z)
+```
+
+## Documentation Conventions
+- Use Markdown for all documentation
+- Code blocks with language hints (```bash, ```go, ```ruby, ```yaml)
+- Tables for structured data (config options, environment variables, endpoints)
+- Headings: sentence case (e.g., "Agent configuration reference")
+- Kubernetes resource names in backticks
+- Azure service names as proper nouns (Azure Monitor, Azure Arc, AKS)
+
+## Key Topics to Document
+- **Onboarding:** AKS, Arc-enabled K8s, ARO cluster setup
+- **Configuration:** Agent settings, data collection rules, custom metrics
+- **Troubleshooting:** Common issues, log collection, health diagnostics
+- **Architecture:** Data flow diagrams, component interactions
+- **Security:** Authentication modes, RBAC requirements, network requirements

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,73 @@
+---
+description: "Performs deep security analysis of code changes using STRIDE methodology, focused on container security, Kubernetes RBAC, and Azure authentication patterns."
+tools: []
+---
+# Security Reviewer Agent
+
+You are a security specialist reviewing the Azure Monitor for Containers (Docker-Provider) codebase. You focus on container security, Kubernetes RBAC, Azure authentication, and supply chain security.
+
+## Security Review Scope
+
+### Authentication & Authorization
+- **IMDS token management** (`ingestion_token_utils.go`): Token refresh logic, expiration handling, secure storage
+- **Arc K8s MSI** (`arc_k8s_cluster_identity.rb`): Cluster identity requests, token secret access
+- **Federated Identity Credentials (FIC)**: JWT validation, audience checks
+- **Geneva workload identity**: Service account token mounting, OIDC validation
+- **K8s RBAC**: ClusterRole/ClusterRoleBinding scope — verify minimal permissions
+
+### Container Security
+- **Dockerfile analysis**: Non-root USER directive, minimal base image, no unnecessary packages
+- **Secret handling**: Environment variables for secrets (never baked into image layers)
+- **Network exposure**: Exposed ports, healthcheck endpoints, API listeners
+- **Image provenance**: Base images from `mcr.microsoft.com/`, pinned versions
+
+### Supply Chain
+- **Dependency scanning**: Go modules, Ruby gems — check for known CVEs
+- **Trivy integration**: `.trivyignore` entries justified and temporary
+- **CodeQL/DevSkim**: Static analysis findings addressed
+- **Build reproducibility**: Deterministic builds, pinned tool versions
+
+### STRIDE Deep Analysis
+
+**Spoofing:**
+- IMDS endpoint validation (169.254.169.254 only)
+- TLS certificate verification for ODS/MDSD connections
+- Kubernetes API server authentication (ServiceAccount tokens, in-cluster config)
+
+**Tampering:**
+- Config file integrity (`/etc/amalogsagent/` contents)
+- Helm chart value injection — validate all user-supplied values
+- Fluent Bit/Fluentd config template injection risks
+
+**Repudiation:**
+- Agent telemetry provides audit trail for data collection operations
+- Container startup/shutdown events logged with timestamps
+
+**Information Disclosure:**
+- Log output sanitization — no tokens, keys, or connection strings in logs
+- Error messages don't expose internal Azure endpoints or resource IDs to stdout
+- Kubernetes API responses filtered before logging (strip secrets, configmaps with sensitive data)
+
+**Denial of Service:**
+- K8s API rate limiting and backoff (`KubernetesApiClient.rb`)
+- Memory-bounded buffers for Fluent Bit/Fluentd processing
+- HTTP request timeouts on all outbound calls
+- Liveness probe checks prevent zombie containers
+
+**Elevation of Privilege:**
+- Container security context review (capabilities, read-only filesystem)
+- Volume mounts scoped minimally (host paths read-only where possible)
+- Service account token auto-mounting disabled where not needed
+
+## Credential Leak Detection Patterns
+- Azure connection strings: `InstrumentationKey=`, `Endpoint=`
+- Bearer tokens: `Authorization: Bearer`, `access_token`
+- Kubernetes secrets: base64-encoded values in YAML
+- Certificates: PEM blocks in source or config files
+- Environment variables: hardcoded values matching `*KEY*`, `*SECRET*`, `*TOKEN*`, `*PASSWORD*`
+
+## Weak Security Patterns to Flag
+- **Go:** `http.Get()` without timeout context, `ioutil.ReadAll` without size limit, `InsecureSkipVerify: true`
+- **Ruby:** `open()` with user input (command injection), `eval()`, unvalidated URI construction
+- **Shell:** Unquoted `$variables`, `eval`, `curl` without `--fail`, world-readable file permissions
+- **YAML:** Kubernetes Pod with `privileged: true`, `hostNetwork: true`, `hostPID: true`

--- a/.github/agents/ThreatModelAnalyst.agent.md
+++ b/.github/agents/ThreatModelAnalyst.agent.md
@@ -1,0 +1,96 @@
+---
+description: "Generates STRIDE-based threat models for the Docker-Provider monitoring agent architecture."
+tools: []
+---
+# Threat Model Analyst Agent
+
+You are a threat modeling specialist for the Azure Monitor for Containers agent. You create comprehensive STRIDE-based threat models analyzing the agent's attack surfaces, trust boundaries, and data flows.
+
+## Output Directory
+All threat model artifacts are output to `threat-model/YYYY-MM-DD/` (e.g., `threat-model/2026-03-09/`).
+
+## Threat Model Structure
+
+### 1. System Context Diagram (Mermaid)
+Generate a Mermaid diagram showing:
+
+```mermaid
+graph TB
+    subgraph "Trust Boundary: Kubernetes Node"
+        subgraph "Trust Boundary: Agent Container"
+            FB[Fluent Bit]
+            FD[Fluentd]
+            TEL[Telegraf]
+            AMA[AMACore Agent]
+        end
+        KUBELET[Kubelet API]
+        CADVISOR[cAdvisor]
+    end
+    
+    subgraph "Trust Boundary: Kubernetes Control Plane"
+        APISERVER[K8s API Server]
+    end
+    
+    subgraph "Trust Boundary: Azure Backend"
+        ODS[ODS Endpoint]
+        MDSD[MDSD Endpoint]
+        MDM[MDM Endpoint]
+        IMDS[IMDS 169.254.169.254]
+        AMCS[AMCS Config Service]
+    end
+    
+    FB -->|Container Logs| ODS
+    FB -->|Network Flow Logs| MDSD
+    FD -->|K8s Inventory| ODS
+    FD -->|Metrics| MDM
+    TEL -->|Perf Metrics| MDM
+    AMA -->|Telemetry| ODS
+    
+    FD -->|REST API| APISERVER
+    FB -->|Metrics| CADVISOR
+    FB -->|Token Request| IMDS
+    FB -->|Config Fetch| AMCS
+```
+
+### 2. Component Inventory
+For each component, document:
+- **Data processed:** What data types flow through it
+- **External connections:** Endpoints contacted, protocols used
+- **Authentication:** How it authenticates to other components
+- **Permissions:** Kubernetes RBAC, file system access, network access
+
+### 3. STRIDE Analysis Per Component
+
+For each component crossing a trust boundary, analyze all six STRIDE categories:
+
+| Component | Threat | Category | Severity | Mitigation |
+|-----------|--------|----------|----------|------------|
+| Fluent Bit → ODS | Spoofed ODS endpoint | Spoofing | High | TLS + certificate pinning |
+| IMDS Token Fetch | Token interception on wire | Info Disclosure | Medium | IMDS is link-local only |
+| K8s API Calls | Excessive API calls causing throttling | DoS | Medium | Rate limiting + backoff |
+| Config from AMCS | Tampered configuration | Tampering | High | TLS + config signature validation |
+| Container Logs | Sensitive data in logs forwarded | Info Disclosure | High | Log filtering rules |
+
+### 4. Severity Rating (DREAD-aligned)
+- **Critical:** Remote code execution, credential theft, complete data exfiltration
+- **High:** Authentication bypass, significant data leakage, persistent DoS
+- **Medium:** Information disclosure (non-credential), temporary DoS, privilege escalation within container
+- **Low:** Minor information leakage, non-exploitable weaknesses
+
+### 5. Threat Model Index
+Maintain `threat-model/README.md` as an append-only index:
+```markdown
+# Threat Model History
+| Date | Scope | Author | Key Findings |
+|------|-------|--------|-------------|
+| YYYY-MM-DD | Full agent architecture | AI-generated | <summary> |
+```
+
+## Key Attack Surfaces
+1. **Kubernetes API Server** — Agent has ClusterRole with read access to pods, nodes, events, etc.
+2. **IMDS endpoint** — Token acquisition for Azure authentication
+3. **AMCS Configuration Service** — Agent configuration fetch (could be tampered)
+4. **ODS/MDSD ingest endpoints** — Outbound data transmission
+5. **Kubelet/cAdvisor APIs** — Local node metrics collection
+6. **Container filesystem** — Config files, certificates, token files
+7. **Network listeners** — Fluent Bit HTTP input (if enabled), health check ports

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,60 @@
+---
+description: "Generates product requirements documents for Docker-Provider features and improvements."
+tools: []
+---
+# PRD Agent
+
+You are a product manager for Azure Monitor for Containers. You create structured product requirements documents (PRDs) for new features, improvements, and architectural changes.
+
+## PRD Template
+
+### Feature Name
+_Clear, descriptive name_
+
+### Problem Statement
+_What customer or operational problem does this solve? Include data/evidence._
+
+### Target Users
+- AKS cluster operators
+- Azure Arc-enabled Kubernetes operators
+- ARO cluster operators
+- Microsoft internal (Geneva/AMCS integration)
+
+### Requirements
+
+#### Functional Requirements
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|------------|----------|-------------------|
+| FR-1 | ... | P0/P1/P2 | ... |
+
+#### Non-Functional Requirements
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-1 | Performance | ... |
+| NFR-2 | Security | ... |
+| NFR-3 | Reliability | ... |
+
+### Architecture Context
+Reference the repo structure:
+- **Go plugins** (`source/plugins/go/`): Data routing, telemetry, auth
+- **Ruby plugins** (`source/plugins/ruby/`): K8s API scraping, metrics generation
+- **Helm charts** (`charts/`): Deployment configuration
+- **Infrastructure** (`deployment/`): Release pipelines
+
+### Dependencies
+- Azure Monitor backend services (ODS, MDSD, MDM, AMCS)
+- Kubernetes API server
+- Fluent Bit / Fluentd / Telegraf
+- Azure Identity (IMDS, MSI, FIC)
+
+### Success Metrics
+- Agent startup time
+- Data collection latency
+- Memory/CPU usage on node
+- CVE scan pass rate
+- Telemetry completeness
+
+### Release Plan
+- Target version: 3.1.x
+- Release cadence: every 2-4 weeks
+- CI checks: CodeQL, DevSkim, Trivy, unit tests (4 languages)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Repository Instructions
+
+## Summary
+Azure Monitor for Containers (Docker-Provider) is a multi-language monitoring agent that collects container logs, metrics, and inventory data from Kubernetes clusters (AKS, Arc-enabled, ARO). Primary languages: Go (~17%), Ruby (~38%), Shell (~21%), PowerShell (~12%), Python (tests). Built with Fluent Bit (Go output plugin), Fluentd (Ruby input/filter plugins), and Telegraf. Deployed as a DaemonSet via Docker containers on Linux (Azure Linux/Mariner) and Windows (Server Core). Requires Go 1.23+, Ruby with Fluentd 1.14, and Docker for builds.
+
+## General Guidelines
+1. **Build:** Run `cd build/linux && make` for Linux, `cd build/windows && .\Makefile.ps1` for Windows.
+2. **Test:** Run `./test/unit-tests/test_main.sh` (Bash), `./test/unit-tests/run_go_tests.sh` (Go), `./test/unit-tests/run_ruby_tests.sh` (Ruby), `./test/unit-tests/test_main.ps1` (PowerShell/Pester).
+3. **Docker image:** `cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag>`.
+4. **Trivy scan:** All images must pass `trivy --severity CRITICAL,HIGH` with no unfixed vulnerabilities.
+5. **Commit messages:** Use freeform descriptive messages with PR number suffix, e.g., `Fix endpoint name for bleu (#1496)`.
+6. **Branch naming:** Use `<alias>/<feature-description>` pattern (e.g., `longw/networkflow-rename`).
+7. If newer commits make prior changes unnecessary, revert them rather than leaving dead code.
+8. Always validate changes against the existing CI checks: CodeQL, DevSkim, Trivy scanning, and unit tests.
+
+## Prompting Best Practices
+1. Break complex tasks into smaller, focused prompts — one plugin, one test file, one config change at a time.
+2. Be specific: reference actual file paths like `source/plugins/go/src/oms.go` or `source/plugins/ruby/in_kube_events.rb`.
+3. Provide examples of expected log formats, metric names, or Kubernetes resource shapes when asking for implementations.
+4. Open relevant source files before prompting — the agent uses open files as context. Close unrelated files.
+5. Start new chat sessions for unrelated tasks to avoid context pollution.
+6. Use the explore → plan → code → commit workflow for complex changes (see `AGENTS.md`).
+7. Always validate AI-generated code: review for correctness, run unit tests, check Trivy scan results.
+
+## Architecture Overview
+- **Go plugins** (`source/plugins/go/src/`): Fluent Bit output plugin — handles ODS/MDSD data routing, network flow logs, ingestion token management, telemetry.
+- **Go input plugins** (`source/plugins/go/input/`): Fluent Bit input plugins — container inventory, perf metrics via Calyptia plugin framework.
+- **Ruby plugins** (`source/plugins/ruby/`): Fluentd input/filter/output plugins — Kubernetes API scraping (pods, nodes, events, PV, deployments, HPA), cAdvisor metrics, MDM metric generation.
+- **Shell scripts** (`build/`, `kubernetes/linux/`): Build system, container setup, agent startup.
+- **PowerShell** (`kubernetes/windows/`, `build/windows/`): Windows agent build and setup.
+- **Helm charts** (`charts/`): Deployment charts for AKS and Arc clusters.
+- **Deployment** (`deployment/`): EV2 / Arc extension release pipelines.
+- **Tests** (`test/`): Unit tests (Bash, Go, Ruby, PowerShell), E2E tests (Python/pytest), Ginkgo integration tests.
+
+## Custom Agents
+| Agent | Triggers | Description |
+|-------|----------|-------------|
+| @CodeReviewer | review PR, review code | Reviews code for quality, security, telemetry |
+| @SecurityReviewer | security review, threat assessment | Deep security analysis with STRIDE |
+| @ThreatModelAnalyst | threat model, security architecture | Generates STRIDE threat models |
+| @DocumentWriter | write docs, update documentation | Maintains repo documentation |
+
+## Task-Specific Skills
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| `dependency-update` | update dependencies, bump versions | Update Go modules, Ruby gems, or system packages |
+| `bug-fix` | fix bug, resolve issue | Diagnose and fix bugs with proper test coverage |
+| `ci-cd-pipeline` | update pipeline, fix CI | Modify GitHub Actions or Azure Pipelines configs |
+| `infrastructure` | update helm, modify deployment | Change Helm charts, Bicep, Terraform, or K8s manifests |
+| `security-review` | security check, CVE scan | Review code for security issues using STRIDE |
+| `fix-critical-vulnerabilities` | fix CVE, patch vulnerability | Patch critical/high CVEs in dependencies or base images |
+| `telemetry-authoring` | add telemetry, add metrics | Instrument code with Application Insights telemetry |
+| `test-authoring` | write tests, add test coverage | Create unit/integration tests following repo patterns |
+| `release-management` | prepare release, update version | Prepare release notes, chart versions, and image tags |

--- a/.github/instructions/build-container.instructions.md
+++ b/.github/instructions/build-container.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: "build/**/*,kubernetes/**/*,charts/**/*"
+---
+# Build & Container Instructions
+
+## Linux Build
+- Entry point: `build/linux/Makefile`
+- Compiles Go plugins, packages Ruby plugins, builds installer
+- Run: `cd build/linux && make` (optionally `make arch=arm64` for ARM)
+- Requires: Go 1.23+, build-essential, Make
+
+## Windows Build
+- Entry point: `build/windows/Makefile.ps1`
+- Compiles Go plugins and .NET certificate generator
+- Requires: Go, .NET Core SDK, gcc for Windows
+
+## Docker Images
+- **Linux:** `kubernetes/linux/Dockerfile.multiarch` — multi-arch (amd64/arm64), based on Azure Linux/Mariner 3.0
+- **Windows:** `kubernetes/windows/Dockerfile` — based on Windows Server Core (ltsc2019/ltsc2022)
+- Build arg: `IMAGE_TAG` for telemetry tagging, `WINDOWS_VERSION` for Windows base
+
+## Container Setup
+- `kubernetes/linux/setup.sh` — Main Linux container entry point (agent config, cert setup, service startup)
+- `kubernetes/windows/setup.ps1` / `main.ps1` — Windows container entry point
+- Config directory: `/etc/amalogsagent/` (Linux), `c:/etc/amalogsagent/` (Windows)
+
+## Helm Charts
+- `charts/azuremonitor-containers/` — Standard deployment chart
+- `charts/azuremonitor-containerinsights-for-prod-clusters/` — Production cluster chart
+- `charts/azuremonitor-containers-geneva/` — Geneva integration chart
+
+## Security
+- All images must pass Trivy scan: `trivy image --severity CRITICAL,HIGH --exit-code 1 --ignore-unfixed`
+- CVE exceptions tracked in `.trivyignore` (use sparingly, with comment explaining why)
+- No secrets in Dockerfiles — use environment variables or mounted secrets

--- a/.github/instructions/go-plugins.instructions.md
+++ b/.github/instructions/go-plugins.instructions.md
@@ -1,0 +1,41 @@
+---
+applyTo: "source/plugins/go/**/*.go"
+---
+# Go Plugin Development Instructions
+
+## Code Style
+- Package `main` for Fluent Bit output plugins in `source/plugins/go/src/`
+- Use PascalCase for exported identifiers, camelCase for unexported
+- Constants: PascalCase grouped in `const()` blocks
+- Structs: always include JSON tags (`json:"fieldName"`) and msgpack tags where needed
+- Error handling: always check `err != nil` immediately, never ignore errors
+- Thread safety: use `sync.Mutex` for shared state (see `NetworkFlowTelemetryMutex` pattern)
+
+## Dependencies
+- Fluent Bit Go SDK: `github.com/fluent/fluent-bit-go`
+- Calyptia plugin: `github.com/calyptia/plugin` (for input plugins)
+- Kubernetes client: `k8s.io/client-go`, `k8s.io/api`, `k8s.io/apimachinery`
+- Telemetry: `github.com/microsoft/ApplicationInsights-Go`
+- Testing: `github.com/stretchr/testify`, `github.com/golang/mock`
+- Serialization: `github.com/tinylib/msgp`, `github.com/ugorji/go/codec`
+
+## Module Structure
+- `source/plugins/go/src/go.mod` — output plugin module
+- `source/plugins/go/input/go.mod` — input plugin module (uses `replace` directive for `../src`)
+- When adding dependencies, update the correct `go.mod` and run `go mod tidy`
+
+## Testing
+- Test files: `*_test.go` in the same package
+- Run: `cd source/plugins/go/src && go test -v ./...`
+- Use `testify/assert` for assertions, `golang/mock` for mocking
+- Platform-specific files: `*_linux.go`, `*_windows.go`
+
+## Build
+- Linux: `cd build/linux && make`
+- The Makefile compiles Go plugins into shared libraries loaded by Fluent Bit
+
+## Patterns
+- Data flows through Fluent Bit: input plugin → filter → output plugin (`out_oms.go`)
+- Network flow logs: `PostNetworkFlowRecords()` in `network_flow_logs.go`
+- Token management: IMDS, Arc K8s MSI, FIC auth in `ingestion_token_utils.go`
+- Telemetry: `telemetry.go` for App Insights integration

--- a/.github/instructions/ruby-plugins.instructions.md
+++ b/.github/instructions/ruby-plugins.instructions.md
@@ -1,0 +1,37 @@
+---
+applyTo: "source/plugins/ruby/**/*.rb"
+---
+# Ruby Plugin Development Instructions
+
+## Code Style
+- Fluentd plugin classes inherit from `Fluent::Input`, `Fluent::Filter`, or `Fluent::Output`
+- File naming: `in_*.rb` (input), `filter_*.rb` (filter), `out_*.rb` (output)
+- PascalCase for class names, snake_case for methods and variables
+- Use `require_relative` for local imports
+
+## Key Utilities
+- `KubernetesApiClient.rb` — Wraps Kubernetes REST API calls for pod, node, event, PV, deployment, HPA queries
+- `ApplicationInsightsUtility.rb` — Telemetry helper for sending metrics and events to App Insights
+- `oms_common.rb` — Shared OMS utility functions
+- `constants.rb` — Shared constants
+- `proxy_utils.rb` — HTTP proxy configuration
+- `kubelet_utils.rb` — Kubelet API interaction
+
+## Plugin Types
+| File Pattern | Type | Purpose |
+|-------------|------|---------|
+| `in_kube_*.rb` | Input | Scrapes K8s API (pods, nodes, events, PV, deployments, HPA) |
+| `in_cadvisor_perf.rb` | Input | Collects cAdvisor performance metrics |
+| `in_containerinventory.rb` | Input | Container inventory collection |
+| `filter_*2mdm.rb` | Filter | Transforms data for MDM metric emission |
+| `out_mdm.rb` | Output | Sends metrics to MDM endpoint |
+
+## Testing
+- Test files: `*_test.rb` alongside source files
+- Run: `./test/unit-tests/run_ruby_tests.sh`
+- Ruby tests require Fluentd gem: `gem install fluentd -v 1.14.2`
+
+## Telemetry
+- Use `ApplicationInsightsUtility.sendMetricTelemetry()` for metrics
+- Use `ApplicationInsightsUtility.sendExceptionTelemetry()` for errors
+- Include cluster, region, and controller type as custom dimensions

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "test/**/*"
+---
+# Testing Instructions
+
+## Test Framework Overview
+| Framework | Language | Location | Command |
+|-----------|----------|----------|---------|
+| Bash test framework | Shell | `test/unit-tests/test_cases/*.sh` | `./test/unit-tests/test_main.sh` |
+| Go testing + testify | Go | `source/plugins/go/src/*_test.go` | `cd source/plugins/go/src && go test ./...` |
+| Ruby test (Fluentd) | Ruby | `source/plugins/ruby/*_test.rb` | `./test/unit-tests/run_ruby_tests.sh` |
+| Pester 5.3 | PowerShell | `test/unit-tests/test_cases/*.ps1` | `./test/unit-tests/test_main.ps1` |
+| pytest | Python | `test/e2e/src/tests/` | `cd test/e2e/src && python -m pytest tests/` |
+| Ginkgo | Go | `test/ginkgo-e2e/` | `cd test/ginkgo-e2e/<suite> && go test ./...` |
+
+## Test Naming Conventions
+- **Bash:** `test/unit-tests/test_cases/test_*.sh` with functions from `test/unit-tests/test_functions/`
+- **Go:** `*_test.go` in same package, function names `Test<Description>(t *testing.T)`
+- **Ruby:** `*_test.rb` alongside source files
+- **PowerShell:** `test/unit-tests/test_cases/Test-<FunctionName>.ps1` using `Describe`/`Context`/`It`
+- **Python E2E:** `test/e2e/src/tests/test_*_workflows.py`
+
+## Writing New Tests
+1. Place test files alongside the source they test (Go, Ruby) or in `test/unit-tests/test_cases/` (Bash, PowerShell)
+2. For PowerShell: add test function to `test/unit-tests/test_functions/`, test cases to `test/unit-tests/test_cases/`
+3. For Go: use `testify/assert` for assertions, `golang/mock` for mocking external dependencies
+4. For Bash: follow existing pattern in `test_framework.sh` with assert functions
+5. Ensure CI will pick up new tests — check `test_main.sh` / `run_go_tests.sh` / `run_ruby_tests.sh` include paths
+
+## Ginkgo E2E Tests
+- `test/ginkgo-e2e/livenessprobe/` — Agent liveness probe validation
+- `test/ginkgo-e2e/querylogs/` — Log query validation
+- `test/ginkgo-e2e/containerstatus/` — Container status checks
+- Each suite has its own `go.mod` — update dependencies independently

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,61 @@
+# Bug Fix Skill
+
+## Name
+bug-fix
+
+## Description
+Diagnose and fix bugs in the Docker-Provider monitoring agent with proper test coverage and validation.
+
+## Triggers
+- "fix bug", "resolve issue", "debug", "fix error", "troubleshoot"
+
+## Workflow
+
+### 1. Reproduce & Understand
+- Identify the affected component: Go plugin, Ruby plugin, Shell script, PowerShell, or Helm chart
+- Check recent commits in the affected area for context
+- Review related test files for existing coverage
+
+### 2. Locate Root Cause
+- **Go plugins:** Check error handling in `source/plugins/go/src/`, especially `oms.go`, `ingestion_token_utils.go`, `network_flow_logs.go`
+- **Ruby plugins:** Check `source/plugins/ruby/` — KubernetesApiClient, ApplicationInsightsUtility
+- **Startup scripts:** Check `kubernetes/linux/setup.sh`, `kubernetes/windows/setup.ps1`
+- **Build issues:** Check `build/linux/Makefile`, `build/windows/Makefile.ps1`
+
+### 3. Fix
+- Apply minimal, targeted fix
+- Ensure error handling covers the new case
+- Add telemetry for the error condition if not already present
+
+### 4. Test
+- Add or update unit test that covers the bug scenario
+- Run relevant test suite:
+  ```bash
+  # Go
+  cd source/plugins/go/src && go test -v -run TestName ./...
+  # Ruby
+  ./test/unit-tests/run_ruby_tests.sh
+  # Bash
+  ./test/unit-tests/test_main.sh
+  # PowerShell
+  ./test/unit-tests/test_main.ps1
+  ```
+
+### 5. Validate
+- Build: `cd build/linux && make`
+- Verify no regressions in existing tests
+
+## Supporting Commits (12 months)
+- bug fix (#1593)
+- fix bug (#1577)
+- fix: bleu cloud name is azurebleucloud (#1598)
+- Cosmic replicaset Kubernetes API client large scale issue (#1590)
+- fix amaca liveness probe issue in high scale mode (#1530)
+- Fix AMCS endpoint (#1501)
+- fix endpoint name for bleu (#1496)
+- Fix FIC Auth support issues (#1547)
+- fix fluentd startup failure in legacy cluster (#1467)
+- Cert mount fix for AGC (#1518)
+- Fix arc prod pipeline timeout issue (#1564)
+- Fix geneva resource optimization (#1447)
+- Fix testkube mongodb issue (#1584)

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,58 @@
+# CI/CD Pipeline Skill
+
+## Name
+ci-cd-pipeline
+
+## Description
+Modify GitHub Actions workflows, Azure Pipelines, or build scripts for the Docker-Provider CI/CD system.
+
+## Triggers
+- "update pipeline", "fix CI", "modify workflow", "update build", "pipeline change"
+
+## Workflow
+
+### 1. Understand CI Architecture
+- **GitHub Actions** (`.github/workflows/`):
+  - `run_unit_tests.yml` — Unit tests (Bash, Go, Ruby, PowerShell) on PR
+  - `pr-checker.yml` — Build + Trivy scan on PR (Linux + Windows)
+  - `codeql-analysis.yml` — CodeQL security analysis
+  - `devskim.yml` — DevSkim security scanning
+  - `stale.yml` — Stale issue management
+- **Azure Pipelines** (`.pipelines/`):
+  - Production release pipelines
+  - Helm deploy templates
+
+### 2. Make Changes
+- Validate YAML syntax before committing
+- Ensure workflow triggers match intended branches (`ci_dev`, `ci_prod`)
+- Use pinned action versions (e.g., `actions/checkout@v2`)
+- Keep build matrix consistent across platforms (Linux + Windows)
+
+### 3. Test
+- For GitHub Actions: changes are validated on PR
+- For build scripts: run locally with `cd build/linux && make`
+- Verify Trivy scan configuration matches severity requirements
+
+### 4. Key Files
+- `.github/workflows/run_unit_tests.yml` — Test runner configuration
+- `.github/workflows/pr-checker.yml` — PR build and scan
+- `build/linux/Makefile` — Linux build targets
+- `build/windows/Makefile.ps1` — Windows build script
+- `kubernetes/linux/Dockerfile.multiarch` — Linux container build
+- `kubernetes/windows/Dockerfile` — Windows container build
+
+## Supporting Commits (12 months)
+- Testkube workflow migration (#1589)
+- TAF pipeline fix (#1541)
+- Longw/fix pipeline nodepool (#1522)
+- Fix arc prod pipeline timeout issue (#1564)
+- Pipeline scanner and drop adjustment (#1453)
+- Governed release yamls migration (#1448)
+- Migrate all release pipelines to governed release yaml (#1443)
+- Migrate merged build pipeline to governed pipeline template (#1442)
+- migrate esrp signing (#1438)
+- Zane/windows 2019 pipeline fix 3 (#1437)
+- Zane/windows 2019 pipeline fix 4 (#1456)
+- TAF: Check errors in process files (#1460)
+- Longw/update arc pipeline (#1461)
+- let trivy fail when cves are detected (#1591)

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,55 @@
+# Dependency Update Skill
+
+## Name
+dependency-update
+
+## Description
+Update Go modules, Ruby gems, system packages, or base image versions in the Docker-Provider repository.
+
+## Triggers
+- "update dependencies", "bump versions", "upgrade go modules", "update gems", "update base image"
+
+## DO NOT USE FOR
+- CVE/vulnerability fixes — use `fix-critical-vulnerabilities` skill instead
+- Fluent Bit or Telegraf version upgrades (these are major component changes, not dependency bumps)
+
+## Workflow
+
+### 1. Identify What to Update
+- **Go modules:** `source/plugins/go/src/go.mod`, `source/plugins/go/input/go.mod`, `test/ginkgo-e2e/*/go.mod`
+- **Ruby gems:** Check gems used in `source/plugins/ruby/` (fluentd, ipaddress, etc.)
+- **System packages:** `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- **Base images:** Mariner/Azure Linux version in Dockerfile ARG
+- **.NET SDK:** `build/windows/installer/certificategenerator/CertificateGenerator.csproj`
+
+### 2. Update Dependencies
+```bash
+# Go modules
+cd source/plugins/go/src && go get -u ./... && go mod tidy
+cd source/plugins/go/input && go get -u ./... && go mod tidy
+
+# Verify build
+cd build/linux && make
+```
+
+### 3. Test
+```bash
+cd source/plugins/go/src && go test ./...
+./test/unit-tests/run_go_tests.sh
+./test/unit-tests/run_ruby_tests.sh
+```
+
+### 4. Security Scan
+Build the Docker image and run Trivy to ensure no new vulnerabilities are introduced.
+
+### 5. Commit
+Use descriptive message: `Update <dependency> to <version> (#PR)`
+
+## Supporting Commits (12 months)
+- Fluent bit 4.0.14 (#1601)
+- Upgrade Fluent Bit to 4.0.9 (#1535)
+- Upgrade Telegraf 1.34.3 (#1434)
+- update dotnet8 (#1565)
+- mdsd version upgrade 1.35.7 (#1492)
+- Upgraded fluent-bit for windows with latest (#1479)
+- Mariner 3 upgrade (#1439)

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,71 @@
+# Fix Critical Vulnerabilities Skill
+
+## Name
+fix-critical-vulnerabilities
+
+## Description
+Patch critical and high severity CVEs in dependencies, base images, or system packages.
+
+## Triggers
+- "fix CVE", "patch vulnerability", "trivy failure", "security bump", "critical vulnerability"
+
+## Workflow
+
+### 1. Identify Vulnerabilities
+- Check Trivy scan output from CI (`pr-checker.yml`)
+- Review `.trivyignore` for temporarily suppressed CVEs
+- Check GitHub Security tab for Dependabot/CodeQL alerts
+
+### 2. Determine Fix Strategy
+
+**Go module vulnerabilities:**
+```bash
+cd source/plugins/go/src
+go get <module>@<fixed-version>
+go mod tidy
+```
+Also check and update `source/plugins/go/input/go.mod` and `test/ginkgo-e2e/*/go.mod`.
+
+**Ruby gem vulnerabilities:**
+- Update gem version in Dockerfile or setup scripts
+- Example: `CVE-202543857: uninstall net-imap gem (#1480)`
+
+**Base image vulnerabilities:**
+- Update `MARINER_BASE_IMAGE` or `MARINER_DISTROLESS_IMAGE` in `kubernetes/linux/Dockerfile.multiarch`
+- Update Windows base image tag in `kubernetes/windows/Dockerfile`
+
+**System package vulnerabilities:**
+- Update package versions in Dockerfile `RUN` commands
+- Pin specific versions to avoid regression
+
+### 3. Handle Unfixable CVEs
+If no fix is available:
+1. Add CVE to `.trivyignore` with justification comment
+2. Example: `# to merge trivy scan PR, temporarily ignore CVE-2026-24051 until a fix is available`
+3. Create tracking issue for follow-up
+
+### 4. Validate
+```bash
+# Build image
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t test-image
+
+# Run Trivy scan
+trivy image --severity CRITICAL,HIGH --vuln-type os,library --exit-code 1 --ignore-unfixed test-image
+```
+
+### 5. Test
+```bash
+# Ensure no regressions
+./test/unit-tests/run_go_tests.sh
+./test/unit-tests/test_main.sh
+cd source/plugins/go/src && go test ./...
+```
+
+## Supporting Commits (12 months)
+- let trivy fail when cves are detected (#1591)
+- Longw/3.1.35 address vulnerabilties (#1605)
+- 3.1.32 CVE fixes (#1596)
+- 3.1.31 CVEs fixes (#1572)
+- Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)
+- CVEs Fix (#1526)
+- CVE 202543857: uninstall net-imap gem (#1480)

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,62 @@
+# Infrastructure Skill
+
+## Name
+infrastructure
+
+## Description
+Modify Helm charts, Kubernetes manifests, Bicep/Terraform templates, or deployment configurations.
+
+## Triggers
+- "update helm chart", "modify deployment", "change kubernetes manifest", "update terraform", "modify bicep"
+
+## DO NOT USE FOR
+- CI/CD pipeline changes — use `ci-cd-pipeline` skill
+- Application code changes — use appropriate language-specific approach
+
+## Workflow
+
+### 1. Identify Scope
+- **Helm charts** (`charts/`):
+  - `azuremonitor-containers/` — Standard AKS deployment
+  - `azuremonitor-containerinsights-for-prod-clusters/` — Production clusters
+  - `azuremonitor-containers-geneva/` — Geneva integration
+- **Kubernetes manifests** (`kubernetes/`):
+  - `ama-logs.yaml` — DaemonSet/ReplicaSet manifest
+  - Linux and Windows Dockerfiles
+- **Terraform** (`scripts/onboarding/aks/onboarding-msi-terraform/`): AKS onboarding
+- **Bicep** (`scripts/onboarding/aks/onboarding-msi-bicep/`): AKS onboarding
+- **Deployment** (`deployment/`):
+  - `arc-k8s-extension-release-v2/` — Arc extension release
+  - `mergebranch-multiarch-agent-deployment/` — Multi-arch deployment
+- **ARM templates** (`alerts/recommended_alerts_ARM/`): Alert definitions
+
+### 2. Make Changes
+- Ensure backward compatibility with existing deployments
+- Update `values.yaml` defaults when adding new chart parameters
+- Validate Helm templates render correctly: `helm template <chart-path>`
+- For Terraform: run `terraform validate` and `terraform plan`
+- For Bicep: run `az bicep build` to validate
+
+### 3. Test
+- Helm lint: `helm lint <chart-path>`
+- Template rendering: `helm template <chart-path> --debug`
+- Check chart version is bumped if user-facing changes
+
+### 4. Cross-References
+- Chart version updates should align with release notes in `ReleaseNotes.md`
+- Deployment ServiceGroup parameters must match environment-specific configs
+
+## Supporting Commits (12 months)
+- Longw/high scale and networkflow logs Bicep templates (#1470)
+- Longw/high scale terraform (#1488)
+- Longw/multi tenant templates (#1502)
+- Longw/multi tenant templates with Terraform (#1505)
+- Add high logs scale support for ARC (#1491)
+- Add private link support for high log scale (#1512)
+- Longw/high scale policy (#1497)
+- Multi-tenant support for ARC (#1506)
+- deploy new image to prod clusters using helm chart
+- add deprecation note for helm chart (#1546)
+- update api versions (#1419)
+- Longw/retina networkflow logs: Update ARM template parameter check (#1421)
+- Longw/arc openshift (#1511)

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -1,0 +1,59 @@
+# Release Management Skill
+
+## Name
+release-management
+
+## Description
+Prepare a new release of the Docker-Provider agent including version bumps, release notes, and chart updates.
+
+## Triggers
+- "prepare release", "update version", "release notes", "bump chart version"
+
+## Workflow
+
+### 1. Determine Version
+- Current versioning: `3.1.x` (check latest in `ReleaseNotes.md`)
+- Increment patch version for bug fixes and minor updates
+- Release cadence: every 2-4 weeks
+
+### 2. Update Release Notes
+Edit `ReleaseNotes.md` following the established format:
+```markdown
+## Release <date> - Version 3.1.XX
+### What's new
+- Feature description (PR #number)
+
+### Bug fixes
+- Fix description (PR #number)
+
+### CVE fixes
+- CVE-YYYY-NNNNN: Description (PR #number)
+```
+
+### 3. Update Helm Chart Versions
+- `charts/azuremonitor-containers/Chart.yaml` — bump `version` and `appVersion`
+- `charts/azuremonitor-containerinsights-for-prod-clusters/Chart.yaml` — same
+- `charts/azuremonitor-containers-geneva/Chart.yaml` — same (if applicable)
+
+### 4. Update Image Tags
+- `kubernetes/linux/Dockerfile.multiarch` — verify base image versions
+- Agent telemetry tag references across configs
+
+### 5. Validate
+- Build Linux and Windows images
+- Run full test suite
+- Trivy scan passes
+- Helm lint passes
+
+### 6. Commit Pattern
+Typical commit: `3.1.XX release notes and chart update (#PR_NUMBER)`
+
+## Supporting Commits (12 months)
+- release notes for 3.1.35 (#1608)
+- 3.1.34 release notes and chart update (#1603)
+- 3.1.32 release note and chart update (#1583)
+- container insights 3.1.31 release notes and chart version upgrade (#1558)
+- 3.1.30 Release notes and chart changes (#1537)
+- 3.1.29 release notes and version updates (#1524)
+- 3.1.28 Release notes and chart updates (#1504)
+- 3.1.27 release charts and Release Note update (#1435)

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,85 @@
+# Security Review Skill
+
+## Name
+security-review
+
+## Description
+Review code for security issues using STRIDE methodology, credential detection, and dependency vulnerability analysis.
+
+## Triggers
+- "security check", "security review", "STRIDE analysis", "check for vulnerabilities"
+
+## Workflow
+
+### 1. STRIDE Checklist
+
+**Spoofing:**
+- [ ] Auth tokens validated before use (IMDS, MSI, FIC)
+- [ ] TLS certificate verification enabled for all outbound connections
+- [ ] Kubernetes ServiceAccount tokens scoped minimally
+
+**Tampering:**
+- [ ] Configuration files loaded from trusted paths only
+- [ ] Helm values validated/sanitized before template rendering
+- [ ] No user-controlled input in shell command construction
+
+**Repudiation:**
+- [ ] Security-relevant operations logged with correlation IDs
+- [ ] Agent startup/shutdown events captured in telemetry
+
+**Information Disclosure:**
+- [ ] No secrets, tokens, or connection strings in source code or logs
+- [ ] Error messages don't expose internal Azure endpoints
+- [ ] Kubernetes API responses filtered before logging
+
+**Denial of Service:**
+- [ ] HTTP request timeouts on all outbound calls
+- [ ] Rate limiting on Kubernetes API calls (KubernetesApiClient)
+- [ ] Memory-bounded buffers for data processing
+- [ ] Liveness probes configured to detect hung processes
+
+**Elevation of Privilege:**
+- [ ] Container runs as non-root where possible
+- [ ] Kubernetes RBAC uses minimal required permissions
+- [ ] No `privileged: true` in security context
+- [ ] Host volume mounts are read-only where possible
+
+### 2. Credential Detection Rules
+Scan for these patterns:
+- `InstrumentationKey=` followed by GUID
+- `Bearer ` followed by token string
+- `access_token` in JSON responses logged to stdout
+- Base64-encoded Kubernetes secrets in YAML
+- PEM certificate blocks in source files
+- Hardcoded values matching `*_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD`
+
+### 3. Weak Pattern Catalog
+
+**Go:**
+- `http.Get()` without timeout context → use `http.Client{Timeout: ...}`
+- `ioutil.ReadAll()` without size limit → use `io.LimitReader()`
+- `tls.Config{InsecureSkipVerify: true}` → never skip TLS verification
+- Ignored error returns → always check `err != nil`
+
+**Ruby:**
+- `open()` with user input → command injection risk
+- `eval()` or `instance_eval()` → code injection risk
+- Unvalidated URI construction → SSRF risk
+- `Net::HTTP` without TLS verification → MitM risk
+
+**Shell:**
+- Unquoted `$variable` expansions → word splitting/injection
+- `eval` usage → command injection
+- `curl` without `--fail` → silent HTTP errors
+- World-readable file permissions on sensitive configs
+
+**PowerShell:**
+- `Invoke-Expression` with dynamic input → code injection
+- Credentials in plain text variables → use SecureString
+- `-SkipCertificateCheck` → TLS bypass
+
+### 4. Security Tool Integration
+- **CodeQL:** `.github/workflows/codeql-analysis.yml` — runs on push to `ci_prod` and PRs
+- **DevSkim:** `.github/workflows/devskim.yml` — security pattern matching
+- **Trivy:** Used in `pr-checker.yml` for container image scanning
+- **`.trivyignore`:** CVE exceptions — verify each has justification comment

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,69 @@
+# Telemetry Authoring Skill
+
+## Name
+telemetry-authoring
+
+## Description
+Add or modify telemetry instrumentation (metrics, events, traces, error reporting) in the Docker-Provider agent.
+
+## Triggers
+- "add telemetry", "add metrics", "instrument code", "add monitoring", "track event"
+
+## Workflow
+
+### 1. Identify Telemetry SDK
+
+**Go plugins** (`source/plugins/go/src/`):
+- SDK: `github.com/microsoft/ApplicationInsights-Go`
+- Helper: `telemetry.go` — centralized telemetry functions
+- Pattern: `SendCustomEvent()`, `SendMetricTelemetry()`, `SendExceptionTelemetry()`
+- Connection: Uses `TELEMETRY_APPLICATIONINSIGHTS_KEY` environment variable
+
+**Ruby plugins** (`source/plugins/ruby/`):
+- Helper: `ApplicationInsightsUtility.rb`
+- Pattern: `ApplicationInsightsUtility.sendMetricTelemetry(name, value, props)`
+- Pattern: `ApplicationInsightsUtility.sendExceptionTelemetry(exception, props)`
+- Pattern: `ApplicationInsightsUtility.sendCustomEvent(name, props)`
+
+### 2. Naming Conventions
+- **Metrics:** PascalCase descriptive name (e.g., `NetworkFlowLogsMDSDClientCreateErrors`)
+- **Events:** PascalCase with action verb (e.g., `ContainerLogSent`, `IngestionTokenRefreshed`)
+- **Custom dimensions:** Include `Cluster`, `Node`, `ControllerType`, `Region` where applicable
+
+### 3. Standard Dimensions
+All telemetry should include these dimensions where available:
+| Dimension | Source | Description |
+|-----------|--------|-------------|
+| `Computer` | `HOSTNAME` env var | Node hostname |
+| `ClusterName` | `CLUSTER` env var | Cluster identifier |
+| `ControllerType` | `CONTROLLER_TYPE` env var | DaemonSet or ReplicaSet |
+| `Region` | `AKSREGION` env var | Azure region |
+
+### 4. Telemetry Gating
+- Check `ISTEST` environment variable — skip telemetry in test mode
+- Use `DISABLE_TELEMETRY` flag if available
+- Rate-limit high-frequency metrics to avoid cost impact
+
+### 5. Error Telemetry
+- All error paths should report to telemetry with:
+  - Exception type and message
+  - Stack trace (if available)
+  - Operation context (what was being attempted)
+  - Relevant identifiers (cluster, node, container)
+
+### 6. Validate
+- Verify telemetry code compiles: `cd source/plugins/go/src && go build ./...`
+- Run unit tests to ensure telemetry calls don't break existing behavior
+- Check that telemetry properties don't contain PII or secrets
+
+## Existing Telemetry Inventory
+| Component | Has Telemetry | Type | Helper |
+|-----------|--------------|------|--------|
+| `out_oms.go` | Yes | Events, Errors | `telemetry.go` |
+| `network_flow_logs.go` | Yes | Metrics, Errors | Direct counters |
+| `ingestion_token_utils.go` | Yes | Events, Errors | `telemetry.go` |
+| `in_kube_nodes.rb` | Yes | Metrics | `ApplicationInsightsUtility` |
+| `in_kube_events.rb` | Yes | Metrics | `ApplicationInsightsUtility` |
+| `in_kube_podinventory.rb` | Yes | Metrics | `ApplicationInsightsUtility` |
+| `filter_cadvisor2mdm.rb` | Yes | Metrics | `ApplicationInsightsUtility` |
+| `in_containerinventory.rb` | Yes | Metrics | `ApplicationInsightsUtility` |

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,103 @@
+# Test Authoring Skill
+
+## Name
+test-authoring
+
+## Description
+Create unit tests, integration tests, or E2E tests following the Docker-Provider testing patterns.
+
+## Triggers
+- "write tests", "add test coverage", "create unit test", "add integration test"
+
+## Workflow
+
+### 1. Determine Test Type
+
+| Question | Answer → Test Type |
+|----------|-------------------|
+| Pure logic with no external dependencies? | Unit test |
+| Needs to mock K8s API, HTTP, or file system? | Unit test with mocks |
+| Tests container startup/liveness? | Ginkgo integration test |
+| Tests end-to-end data flow? | E2E test (Python/pytest) |
+
+### 2. Test Patterns by Language
+
+**Go Unit Tests:**
+- Location: same directory as source (e.g., `source/plugins/go/src/oms_test.go`)
+- Framework: `testing` + `testify/assert` + `golang/mock`
+- Naming: `func Test<Description>(t *testing.T)`
+- Example structure:
+```go
+func TestNetworkFlowRecordProcessing(t *testing.T) {
+    // Arrange
+    records := []map[interface{}]interface{}{...}
+    
+    // Act
+    result := PostNetworkFlowRecords(records)
+    
+    // Assert
+    assert.Equal(t, output.FLB_OK, result)
+}
+```
+
+**Bash Unit Tests:**
+- Location: `test/unit-tests/test_cases/test_*.sh`
+- Functions: `test/unit-tests/test_functions/`
+- Framework: Custom (`test_framework.sh` with assert functions)
+- Register test in `test/unit-tests/test_main.sh`
+
+**PowerShell Unit Tests (Pester 5.3):**
+- Location: `test/unit-tests/test_cases/Test-<FunctionName>.ps1`
+- Functions under test: `test/unit-tests/test_functions/<FunctionName>.ps1`
+- Pattern:
+```powershell
+Describe "Get-McsEndpoint" {
+    Context "When given valid input" {
+        It "Should return correct endpoint" {
+            $result = Get-McsEndpoint -Region "eastus"
+            $result | Should -Be "expected-value"
+        }
+    }
+}
+```
+
+**Ruby Unit Tests:**
+- Location: alongside source in `source/plugins/ruby/*_test.rb`
+- Run with: `./test/unit-tests/run_ruby_tests.sh`
+
+**Ginkgo Integration Tests:**
+- Location: `test/ginkgo-e2e/<suite>/`
+- Each suite has own `go.mod`
+- Tests: liveness probe, query logs, container status
+
+**Python E2E Tests (pytest):**
+- Location: `test/e2e/src/tests/test_*_workflows.py`
+- Utilities: `test/e2e/src/common/` (K8s clients, Helm, ARM REST)
+
+### 3. Validate
+```bash
+# Run all tests
+./test/unit-tests/test_main.sh
+./test/unit-tests/run_go_tests.sh
+./test/unit-tests/run_ruby_tests.sh
+# PowerShell (Windows)
+./test/unit-tests/test_main.ps1
+```
+
+### 4. CI Integration
+New tests are automatically picked up by:
+- `test_main.sh` — scans `test/unit-tests/test_cases/` for `*.sh` files
+- `run_go_tests.sh` — runs `go test` in Go source directories
+- `run_ruby_tests.sh` — runs Ruby test files
+- `test_main.ps1` — discovers Pester test files
+
+## Supporting Commits (12 months)
+- Testkube workflow migration (#1589)
+- Fix CVEs and handle intermittent errors in Ginkgo tests (#1556)
+- Fix testkube mongodb issue (#1584)
+- Update conformnace test (#1452)
+- Test Automation Framework improvements (#1449)
+- Remove custom metrics tests from conformance tests (#1528)
+- Updated Conf test image (#1540)
+- Longw/networkflow testkube (#1499)
+- TAF: Check errors in process files (#1460)

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp"],
+      "type": "stdio",
+      "description": "GitHub MCP server for PR management, issues, and code search"
+    }
+  },
+  "inputs": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md — Docker-Provider (Azure Monitor for Containers)
+
+## Project Overview
+Azure Monitor for Containers agent collects logs, metrics, and inventory from Kubernetes clusters. It runs as a DaemonSet on Linux (Azure Linux/Mariner) and Windows (Server Core) nodes, supporting AKS, Azure Arc-enabled Kubernetes, and ARO clusters.
+
+## Repository Structure
+```
+Docker-Provider/
+├── source/plugins/
+│   ├── go/src/          # Fluent Bit output plugin (Go) — ODS routing, MDSD, telemetry
+│   ├── go/input/        # Fluent Bit input plugins (Go) — container inventory, perf
+│   └── ruby/            # Fluentd plugins (Ruby) — K8s API scraping, cAdvisor, MDM
+├── build/
+│   ├── linux/           # Linux build system (Makefile, installer scripts)
+│   ├── windows/         # Windows build system (PowerShell, .NET cert generator)
+│   └── common/          # Shared installer configs and scripts
+├── kubernetes/
+│   ├── linux/           # Linux Dockerfile, setup.sh, agent config
+│   └── windows/         # Windows Dockerfile, setup.ps1, agent config
+├── charts/              # Helm charts (prod clusters, standard, geneva)
+├── deployment/          # EV2 / Arc extension release pipelines
+├── scripts/             # Onboarding, troubleshooting, and preview scripts
+├── test/
+│   ├── unit-tests/      # Bash, Go, Ruby, PowerShell unit tests
+│   ├── e2e/             # Python/pytest E2E tests
+│   ├── ginkgo-e2e/      # Ginkgo integration tests (Go)
+│   └── scenario/        # Scenario test configs
+├── alerts/              # Recommended alert ARM templates
+└── Documentation/       # User and internal docs
+```
+
+## Setup Commands
+
+### Prerequisites
+- Go 1.23+ (`go version`)
+- Ruby with Fluentd 1.14 (`gem install fluentd -v 1.14.2`)
+- Docker for image builds
+- Make and build-essential (Linux)
+- .NET Core SDK (Windows certificate generator)
+- PowerShell 7+ with Pester 5.3 (Windows tests)
+
+### Build
+```bash
+# Linux build
+cd build/linux && make
+
+# Windows build (PowerShell)
+cd build/windows && .\Makefile.ps1
+
+# Docker image (Linux)
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag>
+
+# Docker image (Windows)
+cd kubernetes/windows && docker build . --file Dockerfile -t <tag> --build-arg WINDOWS_VERSION=ltsc2019
+```
+
+## Testing Instructions
+
+### Unit Tests
+```bash
+# Run all unit tests (CI command)
+./test/unit-tests/test_main.sh       # Bash tests
+./test/unit-tests/run_go_tests.sh    # Go tests
+./test/unit-tests/run_ruby_tests.sh  # Ruby tests
+
+# PowerShell tests (Windows)
+./test/unit-tests/test_main.ps1
+```
+
+### Go Tests (standalone)
+```bash
+cd source/plugins/go/src && go test -v ./...
+cd source/plugins/go/input && go test -v ./...
+```
+
+### E2E Tests
+```bash
+cd test/e2e/src && python -m pytest tests/ -v
+```
+
+### Ginkgo Integration Tests
+```bash
+cd test/ginkgo-e2e/livenessprobe && go test -v ./...
+cd test/ginkgo-e2e/querylogs && go test -v ./...
+cd test/ginkgo-e2e/containerstatus && go test -v ./...
+```
+
+### Security Scanning
+```bash
+# Trivy container scan (used in CI)
+trivy image --severity CRITICAL,HIGH --vuln-type os,library --exit-code 1 --ignore-unfixed <image-tag>
+```
+
+## Code Style
+
+### Go (`source/plugins/go/`)
+- Package `main` for Fluent Bit plugins
+- PascalCase for exported types and functions, camelCase for unexported
+- Constants use PascalCase (e.g., `MaxRetries`, `ContainerNetworkLogsStreamName`)
+- Structs use JSON tags with `json:"fieldName"` and msgpack tags where applicable
+- Error handling: check `err != nil` immediately after each call
+- Use `sync.Mutex` for concurrent access to shared state
+- Logging via custom `Log()` function or `fmt.Fprintf(os.Stderr, ...)`
+- Tests use `testify` assertions (`assert`, `require`)
+
+### Ruby (`source/plugins/ruby/`)
+- Fluentd plugin pattern: `class <Name> < Fluent::Input` / `Fluent::Filter` / `Fluent::Output`
+- PascalCase for class names, snake_case for methods and variables
+- ApplicationInsightsUtility for telemetry
+- KubernetesApiClient for K8s API interactions
+- File naming: `in_*.rb` (input), `filter_*.rb` (filter), `out_*.rb` (output)
+
+### Shell (`build/`, `kubernetes/linux/`)
+- Bash scripts with error checking
+- Environment variables in UPPER_SNAKE_CASE
+- Functions use snake_case
+- Config files in `/etc/amalogsagent/` (Linux) or `c:/etc/amalogsagent/` (Windows)
+
+### PowerShell (`build/windows/`, `kubernetes/windows/`)
+- PascalCase for function names (Verb-Noun pattern)
+- Pester 5.3 for unit tests with `Describe`/`Context`/`It` blocks
+- PSScriptAnalyzer for linting
+
+### YAML/Helm (`charts/`, `kubernetes/`)
+- 2-space indentation
+- Helm chart values follow standard Kubernetes naming
+
+## PR Instructions
+- PRs target `ci_dev` or `ci_prod` branches
+- Commit messages: freeform descriptive with PR number suffix, e.g., `Fix endpoint name for bleu (#1496)`
+- Branch naming: `<alias>/<feature-description>`
+- CI checks must pass: CodeQL, DevSkim, Trivy scan, unit tests (Bash, Go, Ruby, PowerShell)
+- Image versioning follows `3.1.x` pattern with release notes in `ReleaseNotes.md`
+
+## Recommended AI Workflow
+1. **Explore:** Understand the affected area — which plugin type (Go/Ruby), which platform (Linux/Windows), which deployment target (AKS/Arc/ARO).
+2. **Plan:** Identify all files that need changes. For Go plugins, check both `src/` and `input/` modules. For Ruby plugins, check related input/filter/output files.
+3. **Code:** Make changes following the code style above. Add or update unit tests.
+4. **Build:** Run `cd build/linux && make` to verify compilation.
+5. **Test:** Run the appropriate unit test suite. For Go: `cd source/plugins/go/src && go test ./...`. For Ruby: `./test/unit-tests/run_ruby_tests.sh`.
+6. **Validate:** Build Docker image and run Trivy scan for security compliance.
+7. **Commit:** Use descriptive commit message with context about what changed and why.
+
+### Tool Selection Guidance
+| Task | Recommended Tool |
+|------|-----------------|
+| Understand code flow | Copilot Chat (Ask mode) with relevant files open |
+| Find usages of a function | grep/ripgrep across `source/plugins/` |
+| Generate boilerplate plugin code | Copilot inline suggestions with existing plugin as context |
+| Write unit tests | Copilot Chat (Edit mode) with source + test file open |
+| Debug CI failures | Read CI workflow YAML + build logs |
+| Security review | CodeQL + DevSkim + Trivy results |
+
+## Key Configuration Files
+- `kubernetes/linux/setup.sh` — Linux container agent startup and configuration
+- `kubernetes/windows/setup.ps1` — Windows container agent startup
+- `build/common/installer/conf/` — Fluentd/Fluent Bit configuration templates
+- `charts/azuremonitor-containers/values.yaml` — Helm chart defaults
+- `.github/workflows/` — CI/CD workflows (CodeQL, DevSkim, unit tests, PR build+scan)
+
+## Important Patterns
+- **Telemetry:** ApplicationInsights-Go SDK (`microsoft/ApplicationInsights-Go`) for Go plugins, `ApplicationInsightsUtility.rb` for Ruby plugins
+- **Kubernetes API:** `KubernetesApiClient.rb` wraps K8s REST API calls, `k8s.io/client-go` used in Go
+- **Data routing:** Fluent Bit → Go output plugin → ODS/MDSD/AMACore. Fluentd → Ruby plugins → MDM/ODS
+- **Multi-tenancy:** Supported for Arc clusters with tenant-specific configuration
+- **Network flow logs:** Retina integration via `network_flow_logs.go`
+- **Auth modes:** IMDS tokens, Arc K8s MSI, Federated Identity Credentials (FIC), Geneva workload identity

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,50 @@
+# Docker-Provider — Project Prompt
+
+## Tech Stack
+- **Go 1.23+** — Fluent Bit output/input plugins for data routing, telemetry, container inventory
+- **Ruby** — Fluentd input/filter/output plugins for Kubernetes API scraping, cAdvisor metrics, MDM
+- **Shell/Bash** — Linux build system, installer scripts, container setup
+- **PowerShell** — Windows build system, agent setup, Pester unit tests
+- **Python** — E2E test framework (pytest)
+- **Docker** — Container images (Azure Linux/Mariner 3.0 for Linux, Windows Server Core)
+- **Kubernetes** — DaemonSet deployment, Helm charts, K8s API integration
+- **Terraform/Bicep** — Infrastructure-as-code for onboarding and deployment
+- **Azure Pipelines + GitHub Actions** — CI/CD (build, scan, test, release)
+
+## Architecture
+Azure Monitor for Containers agent runs as a Kubernetes DaemonSet collecting:
+- **Container logs** via Fluent Bit (Go plugins) → ODS/MDSD/AMACore
+- **Kubernetes inventory** via Fluentd (Ruby plugins) → ODS
+- **Performance metrics** via cAdvisor + Telegraf → MDM
+- **Network flow logs** via Retina integration → MDSD
+
+Data pipeline: Fluent Bit/Fluentd → Go/Ruby plugins → ODS/MDSD endpoints → Azure Monitor backend
+
+## Environment Variables
+- `CONTROLLER_TYPE` — Agent controller type (DaemonSet, ReplicaSet)
+- `CONTAINER_RUNTIME` — Container runtime (docker, containerd)
+- `ISTEST` — Test mode flag
+- `TELEMETRY_APPLICATIONINSIGHTS_KEY` — App Insights instrumentation key
+- `DOMAIN` — Azure cloud domain (opinsights.azure.com, etc.)
+- `customRegion` / `customResourceId` — Custom cluster identification
+- `AKSREGION` — AKS cluster region
+- `CLUSTER` — Cluster name for telemetry dimensions
+- `NODE_IP` — Node IP address
+- `HOSTNAME` — Node hostname
+
+## Conventions
+- Commit messages: freeform descriptive with `(#PR_NUMBER)` suffix
+- Branch naming: `<alias>/<feature-description>`
+- Release versioning: `3.1.x` semver-like pattern
+- Release cadence: every 2-4 weeks
+- PR targets: `ci_dev` (development) or `ci_prod` (production)
+- Trivy scanning mandatory on all container images
+- CodeQL and DevSkim security analysis on all PRs
+
+## Key Entry Points
+- `source/plugins/go/src/out_oms.go` — Main Fluent Bit output plugin entry
+- `source/plugins/go/input/containerinventory/` — Container inventory input plugin
+- `source/plugins/go/input/perf/` — Performance metrics input plugin
+- `kubernetes/linux/setup.sh` — Linux container startup script
+- `kubernetes/windows/main.ps1` — Windows container entry point
+- `build/linux/Makefile` — Linux build entry point

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,158 @@
+# Coding Agent Instructions — Docker-Provider
+
+This guide explains the AI coding assistant artifacts generated for the Docker-Provider (Azure Monitor for Containers) repository. These files help AI assistants (GitHub Copilot, etc.) understand and contribute to this codebase effectively.
+
+## Artifact Overview
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Root instructions — repo summary, architecture, skill routing |
+| `AGENTS.md` | Root | Setup commands, build/test instructions, code style, AI workflow |
+| `Prompt.md` | Root | Tech stack, architecture, conventions, entry points |
+| `go-plugins.instructions.md` | `.github/instructions/` | Go plugin development guidelines (auto-loaded for `*.go`) |
+| `ruby-plugins.instructions.md` | `.github/instructions/` | Ruby plugin guidelines (auto-loaded for `*.rb`) |
+| `build-container.instructions.md` | `.github/instructions/` | Build, Docker, Helm guidelines |
+| `testing.instructions.md` | `.github/instructions/` | Test framework guide (auto-loaded for `test/**`) |
+| `test/AGENTS.md` | `test/` | Nested test-specific instructions |
+| `CodeReviewer.agent.md` | `.github/agents/` | Code review agent with STRIDE security checklist |
+| `SecurityReviewer.agent.md` | `.github/agents/` | Deep security analysis agent |
+| `ThreatModelAnalyst.agent.md` | `.github/agents/` | STRIDE threat model generator |
+| `DocumentWriter.agent.md` | `.github/agents/` | Documentation maintenance agent |
+| `prd.agent.md` | `.github/agents/` | Product requirements document generator |
+| `.vscode/mcp.json` | `.vscode/` | MCP server configuration |
+
+## Agents
+
+### @CodeReviewer
+Reviews code for quality, security, performance, and telemetry compliance. Includes:
+- Language-specific checklists (Go, Ruby, Shell, PowerShell, Helm)
+- STRIDE security checklist populated with repo-specific patterns
+- Telemetry coverage verification
+- Backward compatibility checks
+
+### @SecurityReviewer
+Deep security analysis with:
+- Authentication pattern review (IMDS, MSI, FIC, Geneva)
+- Container security (Dockerfiles, security contexts, RBAC)
+- Supply chain analysis (dependencies, Trivy, CodeQL)
+- Credential leak detection patterns
+- Weak security pattern catalog per language
+
+### @ThreatModelAnalyst
+Generates comprehensive STRIDE threat models with:
+- Mermaid architecture diagrams with trust boundaries
+- Component-level STRIDE analysis
+- DREAD-aligned severity ratings
+- Output to `threat-model/YYYY-MM-DD/` directory
+
+### @DocumentWriter
+Maintains documentation following repo conventions:
+- Release notes format
+- Architecture documentation
+- Onboarding guides
+
+### @prd (PRD Agent)
+Generates structured product requirements documents for new features.
+
+## Skills
+
+| Skill | Trigger Phrases | Commits (12mo) |
+|-------|----------------|----------------|
+| `dependency-update` | "update dependencies", "bump versions" | 7 |
+| `bug-fix` | "fix bug", "resolve issue", "debug" | 13 |
+| `ci-cd-pipeline` | "update pipeline", "fix CI" | 14 |
+| `infrastructure` | "update helm", "modify deployment" | 13 |
+| `security-review` | "security check", "STRIDE analysis" | Always generated |
+| `fix-critical-vulnerabilities` | "fix CVE", "patch vulnerability" | 7 |
+| `telemetry-authoring` | "add telemetry", "add metrics" | Always generated |
+| `test-authoring` | "write tests", "add test coverage" | 9 |
+| `release-management` | "prepare release", "release notes" | 8 |
+
+## Prompt Engineering Best Practices
+
+### Structuring Effective Prompts
+1. **Be specific about scope:** Reference exact file paths (e.g., "modify `source/plugins/go/src/oms.go`") rather than vague descriptions.
+2. **Provide context:** Mention the target platform (Linux/Windows), cluster type (AKS/Arc/ARO), and data flow (logs/metrics/inventory).
+3. **One task per prompt:** Break complex changes into focused steps — one plugin, one test, one config file.
+4. **Include acceptance criteria:** Specify what success looks like (e.g., "tests pass", "Trivy scan clean", "backward compatible").
+
+### Anti-Patterns
+- ❌ "Fix the agent" — too vague, no scope
+- ❌ "Update everything" — no clear deliverable
+- ❌ Changing multiple unrelated systems in one prompt
+- ✅ "Add error telemetry to the IMDS token refresh failure path in `ingestion_token_utils.go`"
+- ✅ "Write a Go unit test for `PostNetworkFlowRecords()` in `network_flow_logs.go` testing the empty records case"
+
+## Choosing the Right Copilot Tool
+
+| Task | Tool | Why |
+|------|------|-----|
+| Understand code flow | Copilot Chat (Ask) | Synthesizes information from multiple files |
+| Find function usages | grep/ripgrep | Fast, precise text search |
+| Generate boilerplate | Copilot inline | Context-aware code completion |
+| Write/modify tests | Copilot Chat (Edit) | Can see both source and test context |
+| Debug CI failures | Read CI logs + Copilot Chat | Needs external log context |
+| Security review | @SecurityReviewer agent | Specialized STRIDE analysis |
+| Code review | @CodeReviewer agent | Comprehensive quality checklist |
+
+## Context Management
+- **Open relevant files** before prompting — Copilot uses open files as context
+- **Close unrelated files** to reduce noise in suggestions
+- **Start fresh sessions** for unrelated tasks to avoid context pollution
+- **Reference `.github/instructions/` files** — they auto-load based on file type
+
+## Recommended Workflow
+
+### explore → plan → code → commit
+1. **Explore:** Open relevant source files, read tests, understand the current behavior
+2. **Plan:** Identify all files that need changes, estimate scope
+3. **Code:** Make changes following code style in `AGENTS.md`
+4. **Test:** Run appropriate test suite (Go/Ruby/Bash/PowerShell)
+5. **Build:** Verify compilation with `cd build/linux && make`
+6. **Commit:** Descriptive message with PR reference
+
+### Use-Case Table
+| Scenario | Explore | Plan | Code | Test |
+|----------|---------|------|------|------|
+| Bug fix | Read error logs, find related code | Identify root cause file | Apply minimal fix | Add regression test |
+| New feature | Understand existing plugin pattern | List files to create/modify | Implement following patterns | Add unit + integration tests |
+| CVE fix | Check Trivy output, find vulnerable dep | Determine update strategy | Update dependency version | Build + scan |
+| Config change | Read Helm chart, understand values | Check all chart variants | Update values + templates | Helm lint + template |
+
+## Validating AI-Generated Code
+1. **Understand:** Read the generated code — don't blindly accept
+2. **Build:** Run `cd build/linux && make` (or Windows equivalent)
+3. **Test:** Run the appropriate test suite for the changed language
+4. **Lint:** Check CodeQL and DevSkim findings on the PR
+5. **Security:** Run Trivy scan on built container image
+6. **Pattern match:** Compare against existing code in the same directory for style consistency
+
+## Test-Driven Development with AI
+1. Write the test first (using `test-authoring` skill patterns)
+2. Run it — verify it fails
+3. Ask the agent to implement the code to make the test pass
+4. Run the test — verify it passes
+5. Ask for refactoring if needed
+
+## Codebase Onboarding with AI
+Example questions to ask Copilot Chat:
+- "How does the Fluent Bit output plugin route data to ODS vs MDSD?"
+- "What Kubernetes resources does the Ruby KubernetesApiClient query?"
+- "How does IMDS token refresh work in `ingestion_token_utils.go`?"
+- "What's the difference between the three Helm charts in `charts/`?"
+- "How does the agent startup sequence work in `kubernetes/linux/setup.sh`?"
+
+## Security When Using AI Assistants
+- **Never paste secrets** into prompts — use environment variable names instead
+- **Review security-sensitive code** manually — auth, crypto, TLS configuration
+- **Run security scans** (CodeQL, DevSkim, Trivy) on all AI-generated code
+- **Check for credential leaks** in generated code before committing
+- **Verify RBAC scope** if AI suggests Kubernetes resource access changes
+
+## Measuring AI-Assisted Productivity
+Track these metrics to evaluate effectiveness:
+- **PR cycle time:** Time from first commit to merge
+- **Test coverage delta:** Coverage change per PR
+- **CVE fix turnaround:** Time from Trivy alert to fix merged
+- **CI pass rate:** First-run CI success percentage
+- **Review iterations:** Number of review rounds before approval

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,53 @@
+# Testing — AGENTS.md
+
+## Overview
+The Docker-Provider test suite spans 4 languages and multiple test types.
+
+## Test Suites
+
+### Bash Unit Tests
+- **Location:** `test/unit-tests/test_cases/*.sh`
+- **Framework:** Custom framework (`test/unit-tests/test_framework.sh`)
+- **Functions under test:** `test/unit-tests/test_functions/*.sh`
+- **Run:** `./test/unit-tests/test_main.sh`
+- **CI:** `run_unit_tests.yml` → `Linux-Bash-Tests` job
+
+### Go Unit Tests
+- **Location:** `source/plugins/go/src/*_test.go`
+- **Framework:** `testing` + `testify/assert` + `golang/mock`
+- **Run:** `./test/unit-tests/run_go_tests.sh` or `cd source/plugins/go/src && go test ./...`
+- **CI:** `run_unit_tests.yml` → `Golang-Tests` job (Go 1.23.8)
+
+### Ruby Unit Tests
+- **Location:** `source/plugins/ruby/*_test.rb`
+- **Framework:** Fluentd test framework
+- **Run:** `./test/unit-tests/run_ruby_tests.sh`
+- **CI:** `run_unit_tests.yml` → `Ruby-Tests` job (Fluentd 1.14.2)
+
+### PowerShell Unit Tests
+- **Location:** `test/unit-tests/test_cases/Test-*.ps1`
+- **Framework:** Pester 5.3 + PSScriptAnalyzer
+- **Run:** `./test/unit-tests/test_main.ps1`
+- **CI:** `run_unit_tests.yml` → `Windows-PowerShell-Tests` job
+
+### Ginkgo Integration Tests
+- **Location:** `test/ginkgo-e2e/`
+- **Suites:** `livenessprobe/`, `querylogs/`, `containerstatus/`
+- **Run:** `cd test/ginkgo-e2e/<suite> && go test -v ./...`
+
+### Python E2E Tests
+- **Location:** `test/e2e/src/tests/`
+- **Framework:** pytest
+- **Utilities:** `test/e2e/src/common/` (K8s, Helm, ARM REST clients)
+- **Run:** `cd test/e2e/src && python -m pytest tests/ -v`
+
+## Adding New Tests
+1. Determine the appropriate test type and language
+2. Follow naming conventions for that language
+3. Ensure CI script discovers the new test file automatically
+4. Run the full test suite to verify no regressions
+
+## Test Data
+- **Canned API responses:** `test/unit-tests/canned-api-responses/`
+- **Scenario configs:** `test/scenario/`
+- **Scale test configs:** `test/containerlog-scale-tests/`, `test/networkflow-scale-tests/`


### PR DESCRIPTION
Generate comprehensive set of coding agent artifacts to make this repo
agent-ready for AI coding assistants (GitHub Copilot, etc.):

Core files:
- .github/copilot-instructions.md — repo summary, architecture, skill routing
- AGENTS.md — setup, build, test, code style, AI workflow guide
- Prompt.md — tech stack, conventions, entry points

Instruction files (.github/instructions/):
- go-plugins.instructions.md — Go Fluent Bit plugin guidelines
- ruby-plugins.instructions.md — Ruby Fluentd plugin guidelines
- build-container.instructions.md — build, Docker, Helm guidelines
- testing.instructions.md — multi-language test framework guide

Agent files (.github/agents/):
- CodeReviewer.agent.md — code quality + STRIDE security checklist
- SecurityReviewer.agent.md — deep security analysis
- ThreatModelAnalyst.agent.md — STRIDE threat model generator
- DocumentWriter.agent.md — documentation maintenance
- prd.agent.md — product requirements generator

Skill files (.github/skills/):
- dependency-update, bug-fix, ci-cd-pipeline, infrastructure
- security-review, fix-critical-vulnerabilities, telemetry-authoring
- test-authoring, release-management

Other:
- .vscode/mcp.json — MCP server configuration
- test/AGENTS.md — nested test-specific instructions
- coding-agent-instructions.md — comprehensive usage guide

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
