### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,98 @@
+# CodeReviewer Agent
+
+## Description
+
+You are a code reviewer for the Docker-Provider repository (Azure Monitor Container Insights agent). Review pull requests for correctness, style, security, telemetry coverage, and adherence to project conventions across Go, Ruby, Bash, PowerShell, and Python.
+
+## Review Philosophy
+
+1. **Error handling completeness** — Every error path must be handled; Go `if err != nil`, Ruby `rescue`, Bash exit codes
+2. **Telemetry coverage** — New code paths must have Application Insights instrumentation matching existing patterns
+3. **Security & credential safety** — No hardcoded secrets, keys, or connection strings; CVE awareness for dependency changes
+4. **Multi-platform consistency** — Changes affecting both Linux/Windows agents must be reflected in both paths
+5. **Kubernetes API compatibility** — API version changes must be validated against supported K8s versions
+
+## Scope
+
+- **Review:** Go (`source/plugins/go/`), Ruby (`source/plugins/ruby/`), Bash/PowerShell (`kubernetes/`, `build/`, `scripts/`), Python (`test/`), Helm charts (`charts/`), Dockerfiles, CI configs
+- **Skip:** Auto-generated baselines, `.trivyignore` (unless CVE justification missing), lock files
+
+## PR Diff Method
+
+Use `gh pr diff <number>` (preferred). To get the base SHA, run `gh pr view <number> --json baseRefOid -q .baseRefOid` as a separate command, then use `git diff <base-sha>...HEAD`.
+
+## Review Checklist
+
+- [ ] Code follows naming conventions per language (see `.github/instructions/`)
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded configuration values
+- [ ] Error handling follows repo patterns (`if err != nil` + telemetry in Go, `rescue` in Ruby)
+- [ ] Logging uses project conventions (`Log()` in Go, `$log` in Ruby, `echo` in Bash)
+- [ ] Imports follow grouping style (stdlib → external → internal)
+- [ ] CI checks would pass (CodeQL, DevSkim, unit tests)
+- [ ] Helm chart version bumped if chart templates changed
+
+### Security Review Checklist (STRIDE)
+
+- [ ] **Spoofing** — Auth tokens validated, not just checked for presence; mTLS for service calls
+- [ ] **Tampering** — Input from Kubernetes API validated; config file permissions restrictive
+- [ ] **Repudiation** — Security-relevant actions logged with context
+- [ ] **Information Disclosure** — No secrets in logs/errors; env vars used for sensitive config
+- [ ] **Denial of Service** — Resource limits set; no unbounded loops; chunk sizes configurable
+- [ ] **Elevation of Privilege** — Containers run as non-root; RBAC follows least-privilege
+- [ ] **Credential Leak Scan** — No API keys, tokens, or connection strings in changed files
+- [ ] **Weak Pattern Scan** — No disabled TLS (`InsecureSkipVerify`), no weak crypto, no `eval`/`exec` with user input
+
+### Telemetry Review Checklist
+
+- [ ] New error paths emit telemetry via `SendException` (Go) or `ApplicationInsightsUtility` (Ruby)
+- [ ] New entry points are instrumented (operation name, duration, success/failure)
+- [ ] New external calls track target, duration, and status
+- [ ] Telemetry follows existing SDK and naming conventions
+- [ ] No telemetry regressions (existing calls not removed without explanation)
+- [ ] No sensitive data in telemetry dimensions or properties
+- [ ] Telemetry gated for unit test environments
+
+## Language-Specific Best Practices
+
+### Go
+
+- **Enforced by tooling:** CodeQL analysis catches common Go issues in CI
+- **Reviewer focus:** Error handling completeness, goroutine/context management, CGo boundary safety
+- **Idiomatic:** Use `if err != nil` (never ignore), named returns for clarity, `defer` for cleanup
+- **Common mistakes:** Missing telemetry on error paths, unbounded Kubernetes API list calls, forgetting to close HTTP response bodies
+
+### Ruby
+
+- **Enforced by tooling:** CodeQL analysis for Ruby
+- **Reviewer focus:** Plugin lifecycle compliance (`initialize`/`configure`/`start`/`shutdown`), exception specificity
+- **Idiomatic:** `begin/rescue` with specific exception types, `$log.warn` for recoverable errors
+- **Common mistakes:** Catching broad `Exception` instead of specific types, missing `ensure` blocks for cleanup, not chunking large API responses
+
+### Bash
+
+- **Reviewer focus:** Unquoted variables (injection risk), missing error checking, portability
+- **Idiomatic:** Quote all variables, use `[ -e ]` guards, check command existence before use
+- **Common mistakes:** Unquoted `$VAR` in `[ ]` conditions, missing `set -e` in critical scripts
+
+### PowerShell
+
+- **Enforced by tooling:** PSScriptAnalyzer in CI
+- **Reviewer focus:** Error action handling, parameter typing, Windows-specific paths
+- **Common mistakes:** Missing `-ErrorAction` on commands that can fail silently
+
+## Testing Expectations
+
+- Go changes: Run `./test/unit-tests/run_go_tests.sh`; add `*_test.go` for new functions
+- Ruby changes: Run `./test/unit-tests/run_ruby_tests.sh`; ensure Fluentd lifecycle tests pass
+- Bash changes: Run `./test/unit-tests/test_main.sh`; add test cases in `test/unit-tests/test_cases/`
+- PowerShell changes: Run `./test/unit-tests/test_main.ps1`; ensure Pester tests pass
+- Dockerfile changes: Verify multi-arch build succeeds; run Trivy scan
+
+## Common Issues to Flag
+
+- Dependency updates without running full test suite
+- Helm chart template changes without version bump
+- CVE suppressions in `.trivyignore` without justification comment
+- New environment variables not documented in ConfigMap examples
+- Cloud-specific code paths missing for all supported clouds (Public, China, Gov, USNat, USSec, Bleu)

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,66 @@
+# DocumentWriter Agent
+
+## Description
+
+You are a technical writer for the Docker-Provider repository. Create and maintain documentation that is accurate, consistent, and follows the project's existing documentation conventions.
+
+## Audience & Tone
+
+- **Primary audience:** DevOps engineers, SREs, and developers deploying Azure Monitor Container Insights
+- **Writing tone:** Technical, concise, action-oriented
+- **Person:** Imperative ("Run this command") or second person ("You can configure...")
+- **Assumed knowledge:** Kubernetes basics, container concepts, Azure Monitor familiarity
+
+## Documentation Structure
+
+| Location | Content Type |
+|----------|-------------|
+| `README.md` | Repo overview, quick start, architecture |
+| `Dev Guide.md` | Development workflow and build instructions |
+| `ReleaseNotes.md` | Version history and changes per release |
+| `ReleaseProcess.md` | Release procedures and checklist |
+| `MARINER.md` | Azure Linux (Mariner) build notes |
+| `Documentation/` | Grafana dashboards, agent settings, multi-tenancy configs |
+| `test/README.md` | Test folder overview |
+| `charts/*/README.md` | Helm chart usage |
+
+## Writing Conventions
+
+- **Headings:** ATX style (`#`, `##`, `###`)
+- **Lists:** Unordered with `-` for items, ordered with `1.` for sequential steps
+- **Code blocks:** Triple backticks with language annotation (```bash, ```go, ```yaml)
+- **Links:** Inline style `[text](url)`
+- **Commands:** Always in code blocks; include working directory context when relevant
+- **File paths:** Use backtick-wrapped paths (`source/plugins/go/src/`)
+
+## Templates
+
+### Release Notes Entry
+
+```markdown
+## <Version> — <Date>
+- <Category>: <Description> (#<PR number>)
+```
+
+### README Section
+
+```markdown
+## <Section Title>
+
+<Brief description of purpose>
+
+### Prerequisites
+- <Requirement 1>
+- <Requirement 2>
+
+### Steps
+1. <Step 1>
+2. <Step 2>
+```
+
+## Validation
+
+- All file paths referenced in documentation must exist in the repo
+- All code examples must be syntactically valid
+- Build/test commands must match what CI actually runs
+- Version numbers must match `build/version` and `charts/*/Chart.yaml`

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,67 @@
+# SecurityReviewer Agent
+
+## Description
+
+You are a security specialist for the Docker-Provider repository. You perform deep security assessments that go beyond routine code review. You are invoked explicitly when a thorough security analysis is needed — for example, before major releases, after architecture changes, or when introducing new external attack surfaces.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+
+- **CodeReviewer** → Lightweight STRIDE checklist applied to every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR introduces or modifies authentication/authorization logic (FIC auth, managed identity, token refresh)
+- New external-facing APIs or network endpoints are added
+- Infrastructure changes modify security boundaries (RBAC, secrets, network policies)
+- Dependency updates address known CVEs
+- Preparing for a security audit or compliance review
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+
+- **Entry points:** Kubernetes API clients, Fluent Bit input/output, Fluentd plugins, HTTP endpoints, Unix sockets
+- **Trust boundaries:** Cluster network → agent pod, agent pod → Azure Monitor, agent → Kubernetes API, host → container
+- **Data flows:** Container logs → Fluent Bit → Log Analytics, K8s API → Ruby plugins → output, secrets → agent config
+- **Secrets:** `APPLICATIONINSIGHTS_AUTH`, `TELEMETRY_APPLICATIONINSIGHTS_KEY`, workspace keys, certificates in `/etc/ama-logs-secret/`
+
+### 2. STRIDE Deep Analysis
+
+**Spoofing:** Token validation in `ingestion_token_utils.go`, FIC auth in `source/plugins/go/`, managed identity in Geneva integration. Verify tokens are validated (not just present).
+
+**Tampering:** Input validation for Kubernetes API responses, config file integrity, Helm values validation. Check that deserialized data from K8s API is validated before processing.
+
+**Repudiation:** Telemetry logging via Application Insights, audit trails for configuration changes.
+
+**Information Disclosure:** Secrets in environment variables (not files), log sanitization, error message content. Check that `Log()` and `$log` calls do not include sensitive data.
+
+**Denial of Service:** Chunk size limits (`PODS_CHUNK_SIZE`), resource limits in DaemonSet, liveness probes, high-scale mode handling. Check for unbounded API list operations.
+
+**Elevation of Privilege:** Container `USER` directive in Dockerfile, RBAC ClusterRole/ClusterRoleBinding in Helm templates, `nodes/proxy` permission scope.
+
+### 3. Dependency Security Assessment
+
+- **Go modules:** 6 `go.mod` files — check all for known vulnerabilities with `govulncheck`
+- **Ruby gems:** Installed in Dockerfile — verify versions against known CVEs
+- **Container base image:** Mariner (CBL-Mariner) — verify image currency
+- **Scanning tools in CI:** CodeQL (Go/Python/Ruby), DevSkim, Trivy (`.trivyignore` for suppressions)
+
+### 4. Infrastructure Security Review
+
+- **Dockerfiles:** `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile` — check USER directive, minimal base, no secrets in layers
+- **Helm charts:** `charts/azuremonitor-containers/` — RBAC, SecurityContext, resource limits
+- **Secret management:** Mounted via Kubernetes secrets (`/etc/ama-logs-secret/`), env vars for AI keys
+- **Network exposure:** Agent communicates outbound to Azure Monitor — verify no inbound listeners
+
+## Output Format
+
+### Findings Summary
+
+| # | Severity | STRIDE | Finding | Location | Recommendation |
+|---|----------|--------|---------|----------|----------------|
+
+### Positive Security Patterns
+
+Note security practices the repo does well — secret management via K8s secrets, CodeQL scanning, DevSkim analysis, Trivy CVE scanning, multi-cloud domain validation.
+
+For the procedural STRIDE checklist, invoke the `security-review` skill.

--- a/.github/agents/ThreatModelAnalyst.agent.md
+++ b/.github/agents/ThreatModelAnalyst.agent.md
@@ -1,0 +1,120 @@
+# ThreatModelAnalyst Agent
+
+## Description
+
+You are a threat model analyst for the Docker-Provider repository (Azure Monitor Container Insights agent). You generate comprehensive, artifact-based threat models following the Microsoft Threat Modeling methodology. Your output is persistent, timestamped artifacts — Mermaid architecture diagrams with security boundaries, full STRIDE analysis matrices, and prioritized threat catalogues — stored under the `threat-model/` directory.
+
+## When to Use
+
+- Before major releases to assess overall security posture
+- After architecture changes (new data flows, new cloud support, auth changes)
+- When adding new Kubernetes permissions or network exposure
+- For quarterly security reviews or compliance audits
+- After security incidents to assess exposure
+
+## Methodology
+
+### Step 1: Component Inventory
+
+Enumerate all components from the codebase:
+
+| Component | Type | Location | Risk Level |
+|-----------|------|----------|------------|
+| Fluent Bit Go Plugin | DaemonSet container process | `source/plugins/go/src/` | High — processes all container logs |
+| Fluentd Ruby Plugins | DaemonSet container process | `source/plugins/ruby/` | High — accesses Kubernetes API |
+| MDSD (Geneva) | Sidecar process | Installed in container | Medium — telemetry forwarding |
+| main.sh / main.ps1 | Container entrypoint | `kubernetes/linux/`, `kubernetes/windows/` | Medium — service orchestration |
+| Helm Charts | Deployment config | `charts/` | High — defines RBAC, secrets, resources |
+| Certificate Generator | Windows installer util | `build/windows/installer/certificategenerator/` | Low — build-time only |
+
+### Step 2: Architecture Diagram with Security Boundaries
+
+Generate a Mermaid diagram showing trust boundaries:
+
+```mermaid
+graph TB
+    subgraph "Trust Boundary: External Network"
+        User["Cluster Admin / Portal"]
+    end
+
+    subgraph "Trust Boundary: Kubernetes Cluster"
+        KubeAPI["Kubernetes API Server"]
+        subgraph "Trust Boundary: Agent Namespace"
+            subgraph "Trust Boundary: DaemonSet Pod"
+                FluentBit["Fluent Bit<br/>Go Output Plugin"]
+                Fluentd["Fluentd<br/>Ruby Input/Filter"]
+                MDSD["MDSD<br/>Geneva Telemetry"]
+                MainSh["main.sh<br/>Entrypoint"]
+            end
+            subgraph "Trust Boundary: ReplicaSet Pod"
+                FluentBitRS["Fluent Bit RS<br/>Cluster-wide queries"]
+                FluentdRS["Fluentd RS<br/>Cluster inventory"]
+            end
+            Secrets["K8s Secrets<br/>/etc/ama-logs-secret/"]
+            ConfigMap["ConfigMap<br/>Agent Config"]
+        end
+        CRI["Container Runtime<br/>Log Files"]
+    end
+
+    subgraph "Trust Boundary: Azure Cloud Services"
+        LA["Log Analytics<br/>Workspace"]
+        AI["Application Insights"]
+        Geneva["Geneva<br/>Metrics Pipeline"]
+    end
+
+    MainSh --> FluentBit
+    MainSh --> Fluentd
+    MainSh --> MDSD
+    CRI -->|"Log files<br/>Data: container stdout/stderr"| FluentBit
+    KubeAPI -->|"HTTPS/443<br/>Data: K8s objects"| Fluentd
+    KubeAPI -->|"HTTPS/443<br/>Data: K8s objects"| FluentdRS
+    Secrets -->|"Volume mount<br/>Data: keys, certs"| MainSh
+    ConfigMap -->|"Volume mount<br/>Data: agent config"| MainSh
+    FluentBit -->|"HTTPS/443<br/>Data: logs, metrics"| LA
+    Fluentd -->|"IPC<br/>Data: records"| FluentBit
+    MDSD -->|"HTTPS/443<br/>Data: telemetry"| AI
+    MDSD -->|"HTTPS/443<br/>Data: metrics"| Geneva
+
+    style FluentBit stroke:#ff0000,stroke-width:3px
+    style Fluentd stroke:#ff0000,stroke-width:3px
+    style Secrets stroke:#ff8800,stroke-width:2px
+    style LA stroke:#00aa00,stroke-width:2px
+```
+
+Save as `threat-model-diagram.mmd`.
+
+### Step 3: STRIDE Analysis
+
+For every component and data flow crossing a trust boundary, evaluate all six STRIDE categories. Use the DREAD-aligned severity scale:
+
+| Severity | Score | Criteria |
+|----------|-------|----------|
+| Critical | 9–10 | Remote exploitation, no auth required, full system compromise |
+| High | 7–8 | Requires some access but leads to privilege escalation or data access |
+| Medium | 4–6 | Requires significant access, limited blast radius |
+| Low | 1–3 | Theoretical risk, complex preconditions |
+
+### Step 4: Generate Artifacts
+
+Create date-stamped directory `threat-model/YYYY-MM-DD/` containing:
+1. `threat-model-report.md` — Full report with executive summary
+2. `stride-analysis.md` — Detailed STRIDE matrix per component
+3. `threat-catalogue.md` — Prioritized threat list by severity
+4. `threat-model-diagram.mmd` — Mermaid source file
+
+### Step 5: Update Index
+
+After generating, update (or create) `threat-model/README.md` to index the run. Append new rows — never overwrite previous entries.
+
+## Anti-Patterns
+
+- Do NOT generate generic threats — every threat must reference a specific component or data flow in this repo
+- Do NOT skip components because they seem low-risk — assess everything crossing a trust boundary
+- Do NOT assume mitigations work without verifying in Dockerfiles, Helm templates, and code
+- Do NOT place artifacts outside `threat-model/` directory
+
+## References
+
+- [Microsoft Threat Modeling Tool](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool)
+- [STRIDE Threat Model](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
+- [Kubernetes Threat Matrix (Microsoft)](https://microsoft.github.io/Threat-Matrix-for-Kubernetes/)

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,52 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or changes to the Docker-Provider repository."
+---
+
+# PRD Agent
+
+## Description
+
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider repository (Azure Monitor Container Insights agent). You follow a consistent template tailored to this project's architecture, tech stack, and conventions.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring, collection, or operational pain does this solve?
+- Success criteria: how do we know this is working? (metrics, log verification, dashboard checks)
+
+### 2. Requirements
+- **Functional requirements:** What the feature must do (data collection, transformation, forwarding)
+- **Non-functional requirements:** Scale (10,000+ pods), latency, resource consumption, multi-cloud support
+- **Out of scope:** Explicitly state what this does NOT include
+
+### 3. Architecture
+- **Affected components:** Which plugins (Go output, Ruby input/filter), scripts, Helm templates
+- **Data flow:** How data moves: source → Fluentd/Fluent Bit → Log Analytics/Geneva
+- **API changes:** New Kubernetes API permissions, new ConfigMap options, new env vars
+- **Dependencies:** Azure services, Kubernetes versions, base image changes
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change (Go, Ruby, Bash, PowerShell, Helm, Dockerfile)
+- Multi-platform considerations (Linux AMD64/ARM64, Windows LTSC2019/2022)
+- Backward compatibility and upgrade path
+
+### 5. Testing Strategy
+- **Unit tests:** Go `*_test.go`, Ruby tests, Bash `test_cases/`, PowerShell Pester
+- **E2E tests:** Python pytest or Go Ginkgo scenarios
+- **Scale testing:** High-scale mode validation
+- **Multi-cloud testing:** Azure Public, China, Government clouds
+
+### 6. Monitoring & Observability
+- New Application Insights telemetry (metrics, events, exceptions)
+- Existing telemetry patterns to follow (`SendException`, `ApplicationInsightsUtility`)
+- Alerting and dashboard updates
+- Rollback indicators: what signals mean we should revert
+
+### 7. Deployment
+- Helm chart changes (version bump, new values, template updates)
+- Docker image build (Dockerfile changes, base image updates)
+- Azure DevOps pipeline updates for release
+- Rollout strategy (canary → production)
+- ConfigMap changes for customer-facing configuration

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Repository Instructions
+
+## Summary
+
+Docker-Provider is the Azure Monitor Container Insights agent. It collects container logs, metrics, and inventory from Kubernetes clusters (AKS, Arc-enabled, hybrid) and forwards telemetry to Azure Monitor / Log Analytics. Primary languages are **Ruby** (Fluentd input/filter plugins), **Go** (Fluent Bit output plugin + Kubernetes API clients), **Bash** (Linux build/deployment scripts), **PowerShell** (Windows build/test), and **Python** (E2E tests). Runs as a DaemonSet/ReplicaSet on Linux (Mariner) and Windows (Server Core).
+
+## General Guidelines
+
+1. Follow the existing code conventions per language — see `.github/instructions/` for language-specific rules.
+2. Break complex tasks into smaller, focused prompts (one module, one function, one test at a time).
+3. Be specific: reference actual file paths, function names, and patterns from this repo.
+4. Always validate AI-generated code: review for correctness, run tests, and check CI.
+5. If newer commits make prior changes unnecessary, revert them.
+6. Use the explore → plan → code → commit workflow for multi-file changes (see `AGENTS.md`).
+7. Open relevant files before prompting — Copilot uses open files as context.
+
+## Build Instructions
+
+```bash
+# Linux Build (requires build-essential, Go 1.23.8+)
+cd build/linux && make
+
+# Unit Tests
+./test/unit-tests/test_main.sh          # Bash tests
+./test/unit-tests/run_go_tests.sh       # Go tests (Go 1.23.8)
+./test/unit-tests/run_ruby_tests.sh     # Ruby tests (Fluentd 1.14.2)
+./test/unit-tests/test_main.ps1         # PowerShell tests (Pester 5.3.3)
+
+# Docker Image Build
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag>
+```
+
+## Custom Agents
+
+| Agent | Triggers | Description |
+|-------|----------|-------------|
+| @CodeReviewer | review PR, review code | Code review against repo conventions, STRIDE security, telemetry gaps |
+| @SecurityReviewer | security review, threat model | Deep STRIDE security analysis, attack surface review |
+| @ThreatModelAnalyst | threat model analysis | Generate persistent threat model artifacts with Mermaid diagrams |
+| @DocumentWriter | write docs, update README | Documentation following repo conventions |
+| @prd | create PRD, write requirements | Generate Product Requirements Documents |
+
+## Task-Specific Skills
+
+| Skill | Triggers | Description |
+|-------|----------|-------------|
+| security-review | security review, STRIDE analysis, credential scan | STRIDE-based security review with credential detection |
+| telemetry-authoring | add telemetry, add metrics, instrument code | Add telemetry following existing ApplicationInsights patterns |
+| fix-critical-vulnerabilities | fix CVE, trivy fix, patch vulnerability | Fix critical/high CVEs using repo scanning tools |
+| dependency-update | update dependency, bump package | Safe dependency updates (go.mod, gems) with testing |
+| bug-fix | fix bug, resolve issue, hotfix | Structured bug fix with regression test |
+| feature-development | add feature, implement, new plugin | New feature scaffolding with tests |
+| test-authoring | add test, write test | Create tests following multi-framework conventions |
+| ci-cd-pipeline | update pipeline, CI change | Modify GitHub Actions or Azure DevOps pipelines |
+| infrastructure | update Helm, update Dockerfile, update Bicep | Infrastructure and deployment changes |
+
+## Known Patterns & Gotchas
+
+- Local computer build may be broken — see README note. CI build is the source of truth.
+- Ruby plugins require Fluentd 1.14.2 gem installed for local testing.
+- Go plugins use CGo (Fluent Bit plugin SDK) — requires `build-essential` on Linux.
+- Windows builds use a separate `build/windows/Makefile.ps1` path.
+- Helm chart is in `charts/azuremonitor-containers/` — version must be bumped in `Chart.yaml`.
+- Multiple `go.mod` files exist — ensure the right one is updated for dependency changes.
+- `.trivyignore` must include justification comments for any new CVE suppressions.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "**/*.go"
+description: "Go code style, patterns, and conventions for Fluent Bit plugins in this repository."
+---
+
+# Go Conventions — Docker-Provider
+
+1. Use `PascalCase` for exported functions and `camelCase` for unexported. Constants use `UPPER_CASE`.
+2. Group imports: stdlib first, then external packages, then internal `Docker-Provider/source/plugins/go/src/...`.
+3. Always check errors with `if err != nil` — never ignore returned errors.
+4. Send errors to telemetry via `SendException(err.Error())` before returning.
+5. Use the `Log()` function for structured logging — never raw `fmt.Println` in production code.
+6. Kubernetes API clients use `k8s.io/client-go` — follow existing patterns in `extension/` and `oms.go`.
+7. Plugin entry points follow CGo conventions — exported functions use `//export` directives.
+8. Serialization uses `msgp` or `ugorji/go/codec` — match the existing pattern for the data type.
+9. Environment variables drive configuration — use `os.Getenv()` and check for empty strings.
+10. Unit tests use `testing` package and `testify/assert` — place `*_test.go` alongside source files.
+11. The Go plugin compiles to a shared library (`libcontainer.so`) — CGo constraints apply.
+12. Do not introduce new telemetry SDKs — use existing `ApplicationInsights-Go` patterns in `telemetry.go`.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**/*.ps1,**/*.psm1"
+description: "PowerShell conventions for Windows build, deployment, and test scripts."
+---
+
+# PowerShell Conventions — Docker-Provider
+
+1. Functions use `PascalCase-WithHyphens` (e.g., `Confirm-WindowsServiceExists`).
+2. Variables use `$PascalCase` or `$camelCase`; parameters use `-PascalCase`.
+3. Use typed parameters: `[int]`, `[string]`, `[bool]` for function inputs.
+4. Error handling: use `-ErrorAction SilentlyContinue` for optional checks; `try/catch` for critical paths.
+5. Logging: use `Write-Host` for console output in scripts.
+6. Windows container setup installs Ruby 3.1.1.1 + Fluentd 1.16.3 — match these versions.
+7. Unit tests use Pester v5.3.3 — follow existing test patterns in `test/unit-tests/test_main.ps1`.
+8. PSScriptAnalyzer runs in CI — ensure scripts pass static analysis.

--- a/.github/instructions/python-test.instructions.md
+++ b/.github/instructions/python-test.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "test/e2e/**/*.py,test/**/*.py"
+description: "Python conventions for E2E testing in this repository."
+---
+
+# Python Test Conventions — Docker-Provider
+
+1. Functions use `snake_case`, classes `PascalCase`, constants `UPPER_CASE`.
+2. Test framework is pytest with session-scoped fixtures in `conftest.py`.
+3. Use `pytest.fail("message")` for assertion failures — not bare `assert` in utility functions.
+4. Error handling: wrap Kubernetes API calls in `try/except` with descriptive error messages.
+5. Kubernetes utilities live in `test/e2e/src/common/` — reuse existing helpers (`kubernetes_pod_utility.py`, etc.).
+6. Constants for cloud endpoints are in `test/e2e/src/common/constants.py`.
+7. Environment variables (`TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`) drive E2E auth — never hardcode.
+8. Use `subprocess.Popen` with `.communicate()` for shell commands in tests.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "**/*.rb"
+description: "Ruby code style and Fluentd plugin conventions for this repository."
+---
+
+# Ruby Conventions — Docker-Provider
+
+1. Classes use `PascalCase`, methods use `snake_case`, constants use `UPPER_CASE` or `@@camelCase` class vars.
+2. All plugins inherit from `Fluent::Plugin::Input`, `Filter`, or `Output` — register with `Fluent::Plugin.register_*`.
+3. Implement the full plugin lifecycle: `initialize`, `configure`, `start`, `shutdown`.
+4. Use `config_param` DSL for configuration parameters — do not parse configs manually.
+5. Emit records via `router.emit(tag, time, record)` — never write directly to output streams.
+6. Error handling: wrap API calls in `begin/rescue/ensure` blocks; log via `$log.warn`/`$log.error`.
+7. Telemetry: use `ApplicationInsightsUtility.sendCustomEvent` or `sendMetricTelemetry` — never create raw AI clients.
+8. Kubernetes API calls go through `KubernetesApiClient` utility class — do not call the API directly.
+9. Use `require_relative` for local dependencies, `require` for gems.
+10. Environment variables: read via `ENV["VAR_NAME"]`; never hardcode cluster-specific values.
+11. Include `# frozen_string_literal: true` at the top of new files.
+12. Keep chunk sizes configurable (e.g., `PODS_CHUNK_SIZE` env var) for large-scale clusters.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.sh"
+description: "Bash/Shell script conventions for build, deployment, and testing scripts."
+---
+
+# Shell Script Conventions — Docker-Provider
+
+1. Functions use `camelCase` naming; environment variables use `UPPER_CASE`.
+2. Always quote variable references: `"$VAR"` not `$VAR` — prevents word splitting.
+3. Use `[ -e path ]` or `[ -f file ]` guards before reading files or accessing paths.
+4. Check command exit codes — do not assume success for critical operations.
+5. Use `echo` with color codes (`\033[0;34m` blue, `\033[0;31m` red, `\033[0m` reset) for test output.
+6. Container entry points (`main.sh`) orchestrate service startup — `crond`, `fluentd`, `fluent-bit`, `mdsd`.
+7. Cloud environment detection uses domain-based `case` matching (azure.com, azure.cn, etc.).
+8. Test scripts in `test/unit-tests/` use a custom framework (`test_framework.sh`) — follow its patterns.
+9. Build scripts in `build/linux/installer/scripts/` handle installation — never modify directly.
+10. Use `source` or `.` for sourcing utility functions — keep functions reusable.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,44 @@
+# Bug Fix
+
+## Description
+
+Structured workflow for fixing bugs in the Docker-Provider agent.
+
+USE FOR: fix bug, resolve issue, patch, hotfix, debug, error fix
+DO NOT USE FOR: feature development, refactoring, performance optimization
+
+## Instructions
+
+### When to Apply
+
+When a bug is reported or discovered in container log collection, Kubernetes inventory, metrics, or agent startup.
+
+### Step-by-Step Procedure
+
+1. **Reproduce:** Identify the affected component (Go plugin, Ruby plugin, startup script, Helm config).
+2. **Locate:** Find the relevant source file. Use directory mapping:
+   - Log collection issues → `source/plugins/go/src/oms.go`
+   - Kubernetes inventory → `source/plugins/ruby/in_kube_*.rb`
+   - Startup failures → `kubernetes/linux/main.sh` or `kubernetes/windows/main.ps1`
+   - Configuration → `charts/*/templates/` or `build/linux/installer/conf/`
+3. **Fix:** Apply the minimal change to resolve the issue.
+4. **Add regression test:** Write a test that would have caught this bug.
+5. **Test:** Run the appropriate test suite for the language.
+6. **Commit:** Use descriptive message, e.g., `fix amaca liveness probe issue in high scale mode (#1530)`.
+
+### Files Typically Involved
+
+- `source/plugins/go/src/*.go` — Go plugin bugs
+- `source/plugins/ruby/*.rb` — Ruby plugin bugs
+- `kubernetes/linux/main.sh` — Linux startup bugs
+- `kubernetes/windows/main.ps1` — Windows startup bugs
+
+### Validation
+
+- Unit tests pass, regression test added, build succeeds.
+
+## Examples from This Repo
+
+- `5c0bca0bb` — bug fix (#1593)
+- `41e880633` — fix amaca liveness probe issue in high scale mode (#1530)
+- `8867998cf` — Fixed containerInventory image issue for digest image format (#1374)

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,43 @@
+# CI/CD Pipeline
+
+## Description
+
+Modify GitHub Actions workflows and Azure DevOps pipelines for Docker-Provider.
+
+USE FOR: update pipeline, CI change, workflow change, add CI step, fix pipeline, migrate pipeline
+DO NOT USE FOR: source code changes, dependency updates, documentation
+
+## Instructions
+
+### When to Apply
+
+When CI/CD workflows need updating, migrating, or fixing.
+
+### Step-by-Step Procedure
+
+1. **Identify the pipeline type:**
+   - GitHub Actions: `.github/workflows/*.yml`
+   - Azure DevOps: `.pipelines/*.yml`
+2. **Make changes following existing patterns** — match YAML structure and naming.
+3. **For GitHub Actions:** Validate YAML syntax. Key workflows:
+   - `run_unit_tests.yml` — Multi-language unit tests
+   - `codeql-analysis.yml` — Security scanning (Go, Python, Ruby)
+   - `devskim.yml` — DevSkim security analysis
+   - `pr-checker.yml` — PR build and scan
+4. **For Azure DevOps:** Follow governed release YAML templates. Pipeline files are in `.pipelines/`.
+5. **Test:** Push to a feature branch and verify CI runs correctly.
+
+### Files Typically Involved
+
+- `.github/workflows/*.yml`
+- `.pipelines/*.yml`, `.pipelines/*.yaml`
+
+### Validation
+
+- YAML is valid, pipeline runs successfully on feature branch.
+
+## Examples from This Repo
+
+- `0d5ca4aeb` — Governed release yamls migration (#1448)
+- `58a1c9436` — Migrate all release pipelines to governed release yaml (#1443)
+- `05c46f5f7` — Migrate merged build pipeline to governed pipeline template (#1442)

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,51 @@
+# Dependency Update
+
+## Description
+
+Safely update Go modules, Ruby gems, and container base images in Docker-Provider.
+
+USE FOR: update dependency, bump package, upgrade library, update go.mod, update gems, update base image
+DO NOT USE FOR: adding a brand new dependency, removing a dependency, major version migration
+
+## Instructions
+
+### When to Apply
+
+When dependencies need updating for security patches, new features, or compatibility.
+
+### Step-by-Step Procedure
+
+1. Identify which dependency files to modify:
+   - **Go modules:** `source/plugins/go/src/go.mod`, `source/plugins/go/input/go.mod`, `test/ginkgo-e2e/*/go.mod`
+   - **Ruby gems:** Version pinned in `kubernetes/linux/Dockerfile.multiarch` and `kubernetes/windows/Dockerfile`
+   - **Base images:** `FROM` lines in Dockerfiles
+   - **Helm chart deps:** `charts/*/Chart.yaml`
+
+2. Update the specific dependency:
+   - Go: `cd <module-dir> && go get <package>@<version> && go mod tidy`
+   - Ruby: Update version in Dockerfile `gem install` commands
+   - Base image: Update tag/digest in `FROM` line
+
+3. Run tests:
+   - `./test/unit-tests/run_go_tests.sh`
+   - `./test/unit-tests/run_ruby_tests.sh`
+   - `cd build/linux && make`
+
+4. Verify no new vulnerabilities: `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+
+### Files Typically Involved
+
+- `source/plugins/go/src/go.mod`, `go.sum`
+- `source/plugins/go/input/go.mod`, `go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/windows/Dockerfile`
+
+### Validation
+
+- Build succeeds, all unit tests pass, no new CVEs introduced.
+
+## Examples from This Repo
+
+- `a71f549e0` — Fluent bit 4.0.14 (#1601)
+- `df85af818` — Upgrade Telegraf 1.34.3 (#1434)
+- `388f83c97` — mdsd version upgrade 1.35.7 (#1492)

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,47 @@
+# Feature Development
+
+## Description
+
+Add new features to the Docker-Provider agent (new data streams, cloud support, authentication methods).
+
+USE FOR: add feature, implement, new plugin, new data stream, new cloud support, new auth method
+DO NOT USE FOR: bug fixes, refactoring, documentation-only changes
+
+## Instructions
+
+### When to Apply
+
+When adding new data collection capabilities, cloud environment support, or agent functionality.
+
+### Step-by-Step Procedure
+
+1. **Plan:** Identify affected components and create implementation plan.
+2. **Implement plugin code:**
+   - Go output plugin changes: `source/plugins/go/src/`
+   - Ruby input/filter plugins: `source/plugins/ruby/`
+   - New environment support: Update cloud detection in `kubernetes/linux/main.sh`
+3. **Update configuration:**
+   - Add new ConfigMap options if needed (`container-azm-ms-agentconfig.yaml`)
+   - Update Helm chart values and templates if deploying new resources
+4. **Add tests:**
+   - Unit tests per language (Go `*_test.go`, Bash test cases, Ruby tests)
+   - E2E scenarios if user-facing (Python pytest or Go Ginkgo)
+5. **Update documentation:** Release notes, README if architecture changes.
+6. **Build and verify:** `cd build/linux && make`, run all test suites.
+
+### Files Typically Involved
+
+- `source/plugins/go/src/*.go` or `source/plugins/ruby/*.rb` — New plugin code
+- `kubernetes/linux/main.sh` — Startup orchestration updates
+- `charts/azuremonitor-containers/templates/` — Helm template updates
+- `build/linux/installer/conf/` — Configuration file updates
+
+### Validation
+
+- Build succeeds for Linux and Windows, all unit tests pass, E2E tests pass.
+
+## Examples from This Repo
+
+- `fb8011ca5` — Enabled OTel logs and traces support (#1527)
+- `089b05960` — Added FIC auth support (#1539)
+- `c02975eec` — Adding change for networkflow logs new stream (#1551)

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,81 @@
+# Fix Critical Vulnerabilities
+
+## Description
+
+Identify and fix critical/high severity vulnerabilities in Docker-Provider using the repo's own scanning tools (Trivy, CodeQL, DevSkim).
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure, dependency vulnerability fix, container image vulnerability
+DO NOT USE FOR: general dependency updates without security motivation, adding new security tools, security architecture review (use security-review skill), low/medium severity unless explicitly requested
+
+## Instructions
+
+### When to Apply
+
+When Trivy scans, CodeQL, or dependency audits report critical/high CVEs, or when `.trivyignore` suppressions need to be reviewed.
+
+### Step-by-Step Procedure
+
+1. **Discover vulnerabilities using repo scanning tools:**
+   - Trivy (container + filesystem): `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+   - Trivy on Go modules: `trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/go.mod`
+   - Go vulnerability check: `govulncheck ./...` in each Go module directory
+   - CodeQL: `.github/workflows/codeql-analysis.yml` (Go, Python, Ruby)
+   - DevSkim: `.github/workflows/devskim.yml`
+
+2. **Parse scan results and categorize:**
+   - **Direct Go module vulnerabilities:** Package in `go.mod` `require` (not indirect)
+   - **Transitive Go dependencies:** Indirect entries — bump the parent dependency
+   - **Ruby gem vulnerabilities:** Gems installed in Dockerfile — update version in Dockerfile `RUN gem install` commands
+   - **Container base image vulnerabilities:** Update `FROM` line in Dockerfiles
+   - **Already-ignored:** Check `.trivyignore` — if CVE is listed with justification, skip
+
+3. **Apply fixes by type:**
+
+   a. **Go module vulnerabilities:**
+   - `cd source/plugins/go/src && go get <package>@<fixed-version> && go mod tidy`
+   - Check ALL `go.mod` locations: `source/plugins/go/src/`, `source/plugins/go/input/`, `test/ginkgo-e2e/*/`
+   - Verify: `go mod graph | grep <vulnerable-package>` — old version should be gone
+
+   b. **Ruby gem vulnerabilities:**
+   - Update gem version in `kubernetes/linux/Dockerfile.multiarch` and `kubernetes/windows/Dockerfile`
+   - For removal: add `gem uninstall <gem>` step (as done for `net-imap`)
+
+   c. **Container base image vulnerabilities:**
+   - Update base image tag/digest in `kubernetes/linux/Dockerfile.multiarch`
+   - Rebuild and re-scan
+
+   d. **Unfixable vulnerabilities:**
+   - Add to `.trivyignore` with CVE ID, date, reason, and upstream issue link
+
+4. **Build and test:**
+   - `cd build/linux && make` — verify build succeeds
+   - `./test/unit-tests/run_go_tests.sh` — Go tests pass
+   - `./test/unit-tests/run_ruby_tests.sh` — Ruby tests pass
+   - Re-run Trivy scan to confirm CVEs resolved
+   - Verify no new critical/high CVEs introduced
+
+5. **Commit:** `fix: patch CVE-YYYY-NNNNN in <package>` or `fix: remediate critical/high vulnerabilities`
+
+### Files Typically Involved
+
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+- `.trivyignore`
+- `.github/workflows/codeql-analysis.yml` (reference for scan config)
+
+### Validation
+
+- Build succeeds for all affected components
+- All unit tests pass
+- Re-scan shows targeted CVEs resolved
+- No new critical/high vulnerabilities introduced
+- `.trivyignore` entries (if any) have proper justification
+
+## Examples from This Repo
+
+- `6f4c31f91` — 3.1.32 CVE fixes (#1596)
+- `733532d7f` — 3.1.31 CVEs fixes (#1572)
+- `30c4efb11` — Fix CVEs through updating go packages and ruby gem (#1414)
+- `a1a39074e` — CVE 202543857: uninstall net-imap gem (#1480)

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,49 @@
+# Infrastructure
+
+## Description
+
+Modify Helm charts, Dockerfiles, Kubernetes manifests, Bicep templates, and Terraform configs for Docker-Provider.
+
+USE FOR: update Helm chart, update Dockerfile, update Bicep, update Terraform, update K8s manifest, change deployment, update ARM template
+DO NOT USE FOR: source code logic changes, test code, documentation
+
+## Instructions
+
+### When to Apply
+
+When deployment configuration, container images, or infrastructure-as-code needs changes.
+
+### Step-by-Step Procedure
+
+1. **Identify the infrastructure component:**
+   - Helm charts: `charts/azuremonitor-containers/`, `charts/azuremonitor-containers-geneva/`
+   - Dockerfiles: `kubernetes/linux/Dockerfile.multiarch`, `kubernetes/windows/Dockerfile`
+   - Kubernetes manifests: `kubernetes/*.yaml`
+   - Bicep: `deployment/*.bicep` files
+   - Terraform: `deployment/*.tf` files
+   - ARM templates: `deployment/` JSON files
+
+2. **Make changes following existing patterns.**
+
+3. **For Helm chart changes:** Bump version in `Chart.yaml` and update `values.yaml` if adding new parameters.
+
+4. **For Dockerfile changes:** Ensure multi-arch compatibility (AMD64/ARM64 for Linux), verify base image security.
+
+5. **Build and test:** `docker build` for Dockerfile changes, `helm template` for chart changes.
+
+### Files Typically Involved
+
+- `charts/azuremonitor-containers/Chart.yaml`, `values.yaml`, `templates/`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/windows/Dockerfile`
+- `deployment/` (Bicep, Terraform, ARM)
+
+### Validation
+
+- Docker image builds, Helm chart renders correctly, Trivy scan passes.
+
+## Examples from This Repo
+
+- `1669d2526` — high scale and networkflow logs Bicep templates (#1470)
+- `4cb3207d3` — multi tenant templates with Terraform (#1505)
+- `8ac2038cc` — Mariner 3 upgrade (#1439)

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,73 @@
+# Security Review
+
+## Description
+
+Perform a STRIDE-based security review of code changes in the Docker-Provider repository, with credential leak detection and weak pattern scanning.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit, attack surface review
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## Instructions
+
+### When to Apply
+
+Apply to every PR that modifies: authentication logic, network-facing code, data handling, Dockerfiles, Helm charts, Kubernetes manifests, dependency changes, or scripts handling secrets.
+
+### STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Auth tokens validated at all entry points (not just presence-checked)
+- Service-to-service calls authenticated (managed identity, FIC auth)
+- Token refresh logic handles expiry correctly (`ingestion_token_utils.go`)
+
+**Tampering (Data Integrity)**
+- Input from Kubernetes API validated before processing
+- Config files have restrictive permissions
+- Helm values validated (no injection via template rendering)
+
+**Repudiation (Auditability)**
+- Security-relevant actions logged via Application Insights
+- Logs include context (who/what/when) without sensitive data
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets, API keys, tokens, or connection strings
+- Secrets loaded from K8s secrets (`/etc/ama-logs-secret/`) or env vars
+- Error messages and logs do not contain credentials or workspace keys
+- `.gitignore` excludes secret files
+
+**Denial of Service (Availability)**
+- Resource limits set in Helm chart DaemonSet/ReplicaSet specs
+- Chunk sizes configurable (`PODS_CHUNK_SIZE`, high-scale mode)
+- Liveness probes configured for agent health
+- No unbounded Kubernetes API list operations
+
+**Elevation of Privilege (Authorization)**
+- Containers run as non-root (check `USER` in Dockerfiles)
+- RBAC ClusterRole follows least-privilege (check `charts/*/templates/`)
+- `nodes/proxy` permission scoped appropriately
+- Security contexts set in pod specs
+
+### Credential & Secret Leak Detection
+
+Scan changed files for:
+- API keys: `AKIA[0-9A-Z]{16}`, hex strings > 32 chars
+- Connection strings: `Server=...;Password=...`
+- Tokens: `Bearer <token>`, `ghp_`, `github_pat_`
+- Private keys: `-----BEGIN PRIVATE KEY-----`
+- Passwords in config: `password=`, `secret=`, `api_key=` followed by non-variable values
+- Base64-encoded credential blobs
+
+### Weak Security Patterns
+
+**Go:** `#nosec` annotations (verify justified), unchecked `err` from crypto/auth functions, `fmt.Sprintf` for query building, `exec.Command` with unsanitized input
+**Ruby:** `eval`/`send` with user input, `YAML.load` instead of `YAML.safe_load`, broad `rescue Exception`
+**Bash:** Unquoted variables, `curl | sh` patterns, `chmod 777`, secrets as command-line args, missing `set -e`
+**PowerShell:** `Invoke-Expression` with user input, `-ExecutionPolicy Bypass` without justification
+**Dockerfiles:** Running as root, `latest` tags, secrets in ENV, privileged containers, missing security contexts
+
+### Validation
+
+- Run CodeQL analysis for Go/Python/Ruby: check `.github/workflows/codeql-analysis.yml`
+- Run DevSkim scan: check `.github/workflows/devskim.yml`
+- Verify `.gitignore` excludes `*.pem`, `*.key`, `.env`
+- Confirm `SECURITY.md` exists and describes responsible disclosure

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,69 @@
+# Telemetry Authoring
+
+## Description
+
+Add telemetry instrumentation to Docker-Provider code following existing Application Insights patterns in Go and Ruby.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add logging, add Application Insights, telemetry gap, missing telemetry
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+
+When adding new code paths, error handlers, entry points, or external calls that need observability.
+
+### Step-by-Step Procedure
+
+1. **Identify the telemetry SDK for the language:**
+   - **Go:** `github.com/microsoft/ApplicationInsights-Go` via `telemetry.go` helpers (`SendException`, `SendEvent`, `SendMetric`)
+   - **Ruby:** `ApplicationInsightsUtility` class in `source/plugins/ruby/ApplicationInsightsUtility.rb`
+
+2. **Sample 3-5 existing files with telemetry in the same module** to learn the exact pattern:
+   - Go: `source/plugins/go/src/oms.go`, `source/plugins/go/src/telemetry.go`
+   - Ruby: `source/plugins/ruby/in_kube_podinventory.rb`, `source/plugins/ruby/KubernetesApiClient.rb`
+
+3. **Add telemetry to these code areas (by priority):**
+
+   a. **Error paths** (highest priority)
+   - Go: `if err != nil { SendException(err.Error()) }`
+   - Ruby: `rescue => e; ApplicationInsightsUtility.sendExceptionTelemetry(e)`
+
+   b. **Entry points and API boundaries**
+   - Track operation name, duration, success/failure
+   - Go: Use `SendMetric` with operation timing
+   - Ruby: Use `ApplicationInsightsUtility.sendMetricTelemetry`
+
+   c. **External calls** (Kubernetes API, HTTP, Azure services)
+   - Track target service, operation, duration, response status
+   - Wrap call with timing and error tracking
+
+   d. **Critical business logic** (data collection, parsing, forwarding)
+   - Track custom events with relevant dimensions
+   - Ruby: `ApplicationInsightsUtility.sendCustomEvent(eventName, properties)`
+
+4. **Follow naming conventions:**
+   - Metric names: `<component>.<operation>.<measurement>` (e.g., `container_log.flush.duration`)
+   - Event names: `<ComponentAction>` (e.g., `KubeInventoryCollected`, `FlushFailed`)
+   - Standard dimensions: `computer`/hostname, `controller_type` (DaemonSet/ReplicaSet), `os_type`
+
+5. **Anti-patterns to avoid:**
+   - Do NOT log sensitive data (credentials, tokens, workspace keys)
+   - Do NOT add telemetry inside tight loops
+   - Do NOT use `fmt.Println` or `puts` for production telemetry
+   - Do NOT create new TelemetryClient instances — reuse existing singletons
+   - Do NOT emit telemetry in unit test code paths
+   - Do NOT hardcode instrumentation keys — use env vars (`APPLICATIONINSIGHTS_AUTH`)
+
+### Files Typically Involved
+
+- `source/plugins/go/src/telemetry.go` — Go telemetry helpers
+- `source/plugins/ruby/ApplicationInsightsUtility.rb` — Ruby telemetry utility
+- Target source files receiving instrumentation
+
+### Validation
+
+- Verify telemetry import/require matches existing files
+- Verify metric/event names follow the repo naming convention
+- Run unit tests to ensure telemetry additions don't break test isolation
+- Check that telemetry is gated for unit test environments

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,53 @@
+# Test Authoring
+
+## Description
+
+Create tests for Docker-Provider across the multi-framework test infrastructure.
+
+USE FOR: add test, write test, test coverage, add unit test, add integration test, add E2E test
+DO NOT USE FOR: fixing flaky tests, refactoring test infrastructure, test pipeline changes
+
+## Instructions
+
+### When to Apply
+
+When adding new functionality, fixing bugs (regression tests), or improving coverage.
+
+### Step-by-Step Procedure
+
+1. **Choose the right test framework:**
+   - Pure Go logic → Go `*_test.go` with `testing` + `testify/assert`
+   - Bash script logic → Shell test in `test/unit-tests/test_cases/`
+   - Ruby plugin logic → Ruby test via `test/unit-tests/run_ruby_tests.sh`
+   - PowerShell logic → Pester test in `test/unit-tests/test_main.ps1`
+   - End-to-end Kubernetes → Go Ginkgo in `test/ginkgo-e2e/` or Python pytest in `test/e2e/`
+
+2. **Follow naming conventions:**
+   - Go: `<name>_test.go` alongside source file
+   - Bash: `test_<name>.sh` in `test/unit-tests/test_cases/`
+   - Ginkgo: `<name>_suite_test.go` + `<name>_test.go`
+
+3. **Write the test:** Follow TDD — write failing test first, then implement.
+
+4. **Run tests:**
+   - Go: `./test/unit-tests/run_go_tests.sh`
+   - Bash: `./test/unit-tests/test_main.sh`
+   - Ruby: `./test/unit-tests/run_ruby_tests.sh`
+   - PowerShell: `./test/unit-tests/test_main.ps1`
+
+### Files Typically Involved
+
+- `source/plugins/go/src/*_test.go`
+- `test/unit-tests/test_cases/*.sh`
+- `test/ginkgo-e2e/*`
+- `test/e2e/src/core/`
+
+### Validation
+
+- New test passes, existing tests still pass, CI green.
+
+## Examples from This Repo
+
+- `f32e2eec4` — Testkube workflow migration (#1589)
+- `ba381243c` — Test Automation Framework improvements (#1449)
+- `660ab8547` — fix conformance test (#1350)

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token for PR management and issue operations",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,149 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Prerequisites: Go 1.23.8+, Ruby with Fluentd 1.14.2, build-essential, Docker, Helm
+# Install Go 1.23.8
+# Install build dependencies
+sudo apt-get install build-essential -y
+
+# Build Linux agent
+cd build/linux && make
+
+# Install Ruby test dependencies
+sudo gem install fluentd -v "1.14.2" --no-document
+sudo gem install ipaddress --no-document
+
+# Build Docker image (Linux multi-arch)
+cd kubernetes/linux
+docker build . --file Dockerfile.multiarch -t containerinsights:dev
+```
+
+## Code Style
+
+### Go (`source/plugins/go/`)
+- **Naming:** Exported functions `PascalCase`, internal `camelCase`, constants `UPPER_CASE`
+- **Imports:** Grouped (stdlib, external, internal). Use `require_relative` sparingly.
+- **Error handling:** Always check `if err != nil`; send to telemetry via `SendException(err.Error())`
+- **Logging:** Use `Log()` wrapper (fmt.Sprintf style), not raw `fmt.Println`
+- **Telemetry:** Use `SendException`, `SendEvent` from `telemetry.go`; never create new TelemetryClient instances
+
+### Ruby (`source/plugins/ruby/`)
+- **Naming:** Classes `PascalCase`, methods `snake_case`, constants `UPPER_CASE` or `@@camelCase`
+- **Plugins:** Inherit from `Fluent::Plugin::Input/Filter/Output`; implement `initialize`, `configure`, `start`, `shutdown`
+- **Error handling:** `begin/rescue/ensure` with `$log.warn`/`$log.error`
+- **Telemetry:** Use `ApplicationInsightsUtility.sendCustomEvent` or `sendMetricTelemetry`
+- **Config:** Use `config_param` DSL; read env vars via `ENV["VAR_NAME"]`
+
+### Bash (`kubernetes/linux/`, `scripts/`, `build/`)
+- **Naming:** Functions `camelCase`, env vars `UPPER_CASE`
+- **Quoting:** Always quote variables in conditionals and arguments
+- **Error handling:** Check exit codes; use `[ -e path ]` guards
+
+### PowerShell (`kubernetes/windows/`, `build/windows/`)
+- **Naming:** Functions `PascalCase-WithHyphens`, variables `$PascalCase`
+- **Error handling:** `-ErrorAction SilentlyContinue` for optional checks; `try/catch` for critical
+- **Testing:** Pester 5.3.3 framework
+
+### Python (`test/e2e/`)
+- **Naming:** Functions `snake_case`, classes `PascalCase`, constants `UPPER_CASE`
+- **Testing:** pytest with session-scoped fixtures in `conftest.py`
+- **Error handling:** `try/except` with `pytest.fail()` for test assertions
+
+## Testing Instructions
+
+Unit tests run in CI on every PR to `ci_dev` and `ci_prod`:
+
+```bash
+# Bash unit tests
+./test/unit-tests/test_main.sh
+
+# Go unit tests (requires Go 1.23.8)
+./test/unit-tests/run_go_tests.sh
+
+# Ruby unit tests (requires Fluentd 1.14.2 gem)
+./test/unit-tests/run_ruby_tests.sh
+
+# PowerShell unit tests (requires Pester 5.3.3 on Windows)
+./test/unit-tests/test_main.ps1
+```
+
+Test files live in `test/unit-tests/test_cases/` (Bash), `source/plugins/go/src/*_test.go` (Go), and `test/e2e/` (Python E2E). Go tests use `*_test.go` convention; Ginkgo E2E suites are in `test/ginkgo-e2e/`.
+
+## Dev Environment Tips
+
+- Go 1.23.8 is required for building Go plugins
+- `build/version` contains the version metadata — do not edit manually during releases
+- Linux Dockerfile base is Mariner (CBL-Mariner/Azure Linux) — distroless variant
+- Windows Dockerfile uses `ltsc2019`/`ltsc2022` Server Core
+- Environment variables for telemetry: `APPLICATIONINSIGHTS_AUTH`, `TELEMETRY_APPLICATIONINSIGHTS_KEY`
+- Agent config is in `container-azm-ms-agentconfig.yaml` ConfigMap
+
+## Recommended AI Workflow
+
+### Explore → Plan → Code → Commit
+
+1. **Explore** — Ask the AI to read and explain relevant code before changes.
+   Example: "Read `source/plugins/go/src/oms.go` and explain the data flow."
+2. **Plan** — Ask for a structured implementation plan.
+   Example: "Plan how to add a new Fluent input plugin for network flow logs."
+3. **Code** — Implement step by step, verifying each.
+4. **Test** — Run `./test/unit-tests/run_go_tests.sh` (or appropriate test suite).
+5. **Commit** — Use descriptive messages with PR number references.
+
+### Validating AI-Generated Code
+1. Review for correctness and understand the code.
+2. Run `cd build/linux && make` to build.
+3. Run the appropriate unit test suite.
+4. Check for hardcoded secrets and proper error handling.
+5. Verify telemetry patterns match existing code.
+
+## PR Instructions
+
+- **Commit messages:** Freeform descriptive style with PR number, e.g., `Fix CVEs in go.mod (#1234)`. Some commits use Conventional Commits (`fix:`, `feat:`).
+- **Branch naming:** Feature branches typically use `<author>/<description>` pattern.
+- **Target branches:** PRs target `ci_dev` or `ci_prod`.
+- **CI checks:** CodeQL (Go/Python/Ruby), DevSkim, unit tests (Bash/Go/Ruby/PowerShell), PR build and scan.
+- **Review:** All PRs require review before merge.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Cluster"
+        DS[DaemonSet ama-logs]
+        RS[ReplicaSet ama-logs-rs]
+    end
+
+    subgraph "Agent Container"
+        FB[Fluent Bit<br/>Go Output Plugin]
+        FD[Fluentd<br/>Ruby Input/Filter Plugins]
+        MDSD[MDSD<br/>Geneva Telemetry]
+        Main[main.sh / main.ps1<br/>Entry Point]
+    end
+
+    subgraph "Data Sources"
+        CL[Container Logs]
+        KA[Kubernetes API]
+        cAdvisor[cAdvisor Metrics]
+    end
+
+    subgraph "Azure"
+        LA[Log Analytics<br/>Workspace]
+        AI[Application Insights<br/>Telemetry]
+        ACR[Azure Container<br/>Registry]
+    end
+
+    Main --> FB
+    Main --> FD
+    Main --> MDSD
+    CL --> FB
+    KA --> FD
+    cAdvisor --> FD
+    FB --> LA
+    FD --> FB
+    MDSD --> AI
+    DS --> Main
+    RS --> Main
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,82 @@
+# Docker-Provider (Azure Monitor Container Insights Agent)
+
+Azure Monitor Container Insights agent that collects container logs, Kubernetes inventory, performance metrics, and telemetry from Kubernetes clusters (AKS, Arc-enabled, hybrid environments) and forwards data to Azure Monitor / Log Analytics workspaces.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log output plugin | Go 1.23.8 (Fluent Bit CGo plugin) |
+| Input/filter plugins | Ruby (Fluentd 1.14.2+) |
+| Build system | Make (Linux), PowerShell (Windows) |
+| Container base | Azure Linux (Mariner) distroless, Windows Server Core |
+| Orchestration | Kubernetes DaemonSet + ReplicaSet |
+| Telemetry | Application Insights (Go + Ruby SDKs) |
+| Package management | Helm 3 charts |
+| CI/CD | GitHub Actions + Azure DevOps Pipelines |
+| E2E testing | Python pytest + Go Ginkgo |
+| Unit testing | Bash scripts, Go testing, Pester 5.3.3 |
+| Security scanning | CodeQL, DevSkim, Trivy |
+| IaC | Bicep, Terraform, Helm |
+
+## Architecture Overview
+
+The agent runs as a DaemonSet (per-node) and ReplicaSet (cluster-wide) in Kubernetes. The Go plugin (`source/plugins/go/src/`) handles Fluent Bit output to Log Analytics. Ruby plugins (`source/plugins/ruby/`) collect Kubernetes inventory, pod metrics, and container logs via Fluentd. MDSD handles Geneva telemetry forwarding. Entry points are `kubernetes/linux/main.sh` (Linux) and `kubernetes/windows/main.ps1` (Windows).
+
+## Functional Requirements
+
+### 1) Container Log Collection
+Collect stdout/stderr logs from all containers, parse multi-line formats, and forward to Log Analytics in ContainerLogV2 schema.
+
+### 2) Kubernetes Inventory
+Collect pod, node, deployment, service inventory from Kubernetes API and emit as structured records.
+
+### 3) Performance Metrics
+Collect CPU, memory, disk, and network metrics from cAdvisor and Kubernetes metrics API.
+
+### 4) Multi-Cloud Support
+Support Azure Public, China, Government, US Nat, US Sec, and Azure Bleu cloud environments.
+
+## Non-Functional Requirements
+
+- Must handle clusters with 10,000+ pods (high-scale mode)
+- Telemetry instrumented via Application Insights for operational monitoring
+- Container images scanned for CVEs before release (Trivy)
+- Supports both AMD64 and ARM64 architectures
+- Windows agent support (Server Core LTSC2019/2022)
+
+## Expected Project Files
+
+| File/Directory | Purpose |
+|---------------|---------|
+| `source/plugins/go/src/` | Go Fluent Bit output plugin |
+| `source/plugins/ruby/` | Ruby Fluentd input/filter plugins |
+| `kubernetes/linux/` | Linux container setup and entrypoint |
+| `kubernetes/windows/` | Windows container setup and entrypoint |
+| `build/linux/` | Linux Makefile and installer |
+| `build/windows/` | Windows build scripts |
+| `charts/` | Helm charts for deployment |
+| `test/unit-tests/` | Multi-language unit tests |
+| `test/e2e/` | Python E2E test framework |
+| `test/ginkgo-e2e/` | Go Ginkgo E2E tests |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `APPLICATIONINSIGHTS_AUTH` | Application Insights auth key (telemetry) |
+| `TELEMETRY_APPLICATIONINSIGHTS_KEY` | Telemetry instrumentation key |
+| `DOMAIN` | Log Analytics domain (opinsights.azure.com) |
+| `WSID` | Log Analytics workspace ID |
+| `CLUSTER_CLOUD_ENVIRONMENT` | Target cloud environment |
+| `CONTROLLER_TYPE` | DaemonSet or ReplicaSet |
+| `OS_TYPE` | linux or windows |
+
+## Acceptance Criteria
+
+- All unit tests pass (Bash, Go, Ruby, PowerShell)
+- CodeQL analysis finds no new security issues
+- DevSkim scan passes
+- Docker image builds successfully for target architecture
+- No new critical/high CVEs introduced (Trivy scan)
+- Helm chart version bumped for releases

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,171 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Docker-Provider repository. These artifacts make AI assistants (GitHub Copilot, Google Jules, Gemini CLI, Cursor, etc.) understand your codebase deeply and contribute effectively.
+
+## Quick Start
+
+1. Open this repository in VS Code (or your preferred editor with Copilot/AI assistant support).
+2. The AI assistant automatically loads `.github/copilot-instructions.md` on every session.
+3. When you open a `.go`, `.rb`, `.sh`, `.ps1`, or `.py` file, the corresponding `.instructions.md` auto-activates.
+4. Invoke skills by typing trigger phrases in chat (e.g., "add test", "fix bug", "security review").
+5. Invoke agents by @-mentioning them (e.g., `@CodeReviewer`, `@DocumentWriter`).
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Auto every session | Root router — build commands, skill catalogue, known gotchas |
+| `AGENTS.md` | Root | Auto (supported tools) | Setup commands, code style, testing, dev tips |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match | Language-specific coding rules (Go, Ruby, Shell, PS, Python) |
+| `Prompt.md` | Root | On demand | Reusable task-spec template |
+| Skill files | `.github/skills/*/SKILL.md` | On keyword trigger | Step-by-step guides for recurring tasks |
+| `CodeReviewer.agent.md` | `.github/agents/` | On @-mention | Structured code review with STRIDE security |
+| `SecurityReviewer.agent.md` | `.github/agents/` | On @-mention | Deep STRIDE security analysis |
+| `ThreatModelAnalyst.agent.md` | `.github/agents/` | On @-mention | Persistent threat model artifacts with Mermaid diagrams |
+| `DocumentWriter.agent.md` | `.github/agents/` | On @-mention | Documentation following repo conventions |
+| `prd.agent.md` | `.github/agents/` | On @-mention | PRD generation for this project |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Auto by VS Code | MCP server connections (GitHub, Microsoft Docs) |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: .github/copilot-instructions.md (always loaded)
+  ├── General rules, build commands, skill catalogue
+  ├── Routes to →
+Layer 2: .github/instructions/*.instructions.md (auto-loaded on file match)
+  ├── Go, Ruby, Shell, PowerShell, Python coding rules
+  ├── Tells agent to follow repo-specific patterns
+Layer 3: Skills (loaded on keyword trigger)
+  └── Step-by-step procedures for specific tasks
+```
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** Type `@CodeReviewer` in Copilot Chat.
+- **What it does:** Reviews PRs for correctness, style, STRIDE security, telemetry gaps.
+- **Example prompts:** `@CodeReviewer review this PR`, `@CodeReviewer check for security issues`
+
+### @SecurityReviewer
+- **Invoke:** Type `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Deep security assessment — threat modeling, attack surface analysis, STRIDE deep-dive.
+- **Example prompts:** `@SecurityReviewer analyze the auth changes`, `@SecurityReviewer audit container security`
+
+### @ThreatModelAnalyst
+- **Invoke:** Type `@ThreatModelAnalyst` in Copilot Chat.
+- **What it does:** Generates persistent threat model artifacts under `threat-model/YYYY-MM-DD/`.
+- **Example prompts:** `@ThreatModelAnalyst perform a full threat model`, `@ThreatModelAnalyst analyze the log pipeline`
+
+### @DocumentWriter
+- **Invoke:** Type `@DocumentWriter` in Copilot Chat.
+- **Example prompts:** `@DocumentWriter write a README for this module`, `@DocumentWriter update release notes`
+
+### @prd
+- **Invoke:** Type `@prd` in Copilot Chat.
+- **Example prompts:** `@prd create a PRD for adding new log format support`
+
+## Using Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "STRIDE analysis", "credential scan" | STRIDE security review with credential detection |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Add Application Insights telemetry following repo patterns |
+| `fix-critical-vulnerabilities` | "fix CVE", "trivy fix", "patch vulnerability" | Fix critical/high CVEs using repo scanning tools |
+| `dependency-update` | "update dependency", "bump package" | Safe dependency updates with testing |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix with regression test |
+| `feature-development` | "add feature", "implement", "new plugin" | New feature scaffolding with tests |
+| `test-authoring` | "add test", "write test" | Create tests across multi-framework infrastructure |
+| `ci-cd-pipeline` | "update pipeline", "CI change" | Modify GitHub Actions or Azure DevOps pipelines |
+| `infrastructure` | "update Helm", "update Dockerfile" | Helm, Docker, Bicep, Terraform changes |
+
+## Prompt Engineering Best Practices
+
+### Structuring Effective Prompts
+1. **Break complex tasks into smaller prompts** — "Explain the Fluent Bit output flow" then "Add error handling to the flush function."
+2. **Be specific** — Reference actual paths: "Fix the liveness probe in `source/plugins/go/src/oms.go`".
+3. **Provide examples** — "Parse container logs like `2024-01-15T10:30:00Z stdout F message`".
+4. **State constraints** — "Using Go 1.23.8, follow existing `if err != nil` patterns."
+5. **Ask for explanations** — "Explain what `FLBPluginFlushCtx` does before I modify it."
+
+### Anti-Patterns to Avoid
+- Vague requests without specifying the affected component
+- Asking for changes across all languages in one prompt
+- Skipping test validation after accepting generated code
+
+## Choosing the Right Copilot Tool
+
+| Task | Best Tool | Why |
+|------|-----------|-----|
+| Completing code as you type | Inline suggestions | Fast for patterns, variable names |
+| Questions about code, @agents | Copilot Chat (IDE) | Context-aware, supports @-agents |
+| Autonomous multi-file tasks | Copilot CLI | Terminal-native, supports `/plan` |
+| Reviewing code changes | @CodeReviewer | Structured review against repo conventions |
+| Async branch work | Coding agent (`/delegate`) | Runs in cloud, creates PRs |
+
+## Recommended Workflow: Explore → Plan → Code → Commit
+
+1. **Explore** — "Read `source/plugins/go/src/oms.go` and explain the data flow"
+2. **Plan** — "/plan Add support for a new log format in the output plugin"
+3. **Code** — "Implement step 1: add the log format parser"
+4. **Test** — "Run `./test/unit-tests/run_go_tests.sh` and fix failures"
+5. **Commit** — "Commit with a descriptive message"
+
+| Use for | Skip for |
+|---------|----------|
+| New features, multi-file refactoring | Quick bug fixes, single-file edits |
+| Architecture changes, new plugins | Documentation-only updates |
+
+## Validating AI-Generated Code
+
+1. **Understand** — Read the code; ask for explanation if unclear.
+2. **Build** — `cd build/linux && make`
+3. **Test** — Run appropriate test suite (`run_go_tests.sh`, `run_ruby_tests.sh`, etc.)
+4. **Security** — Check for hardcoded secrets, proper error handling.
+5. **Patterns** — Compare against existing code for consistency.
+
+## Test-Driven Development with AI
+
+1. Write failing tests first: "Write a Go test for the new flush timeout handling"
+2. Review and approve the tests.
+3. Implement to pass: "Write code to make all tests pass"
+4. Refactor while keeping tests green.
+
+## Codebase Onboarding with AI
+
+- "How does container log collection work in this project?"
+- "What's the pattern for adding a new Fluentd input plugin?"
+- "Explain the Kubernetes inventory collection flow in Ruby"
+- "Where are the Helm chart templates for the DaemonSet?"
+- "What environment variables does the agent need to start?"
+
+## Context Management
+
+1. **Open relevant files** before prompting — Copilot uses open tabs as context.
+2. **Close unrelated files** — too many tabs dilute focus.
+3. **Start fresh** for new tasks — residual context from previous tasks can confuse responses.
+4. **Use @-references** — `#file:source/plugins/go/src/oms.go` to focus on specific code.
+
+## Security When Using AI Assistants
+
+- Never commit secrets — verify AI code doesn't hardcode API keys or connection strings.
+- Review all proposed changes — AI can produce subtly incorrect security code.
+- Don't share credentials via prompts — use environment variables and `.env` files.
+- Run security tools after changes — CodeQL, DevSkim, Trivy.
+
+## Measuring AI-Assisted Productivity
+
+- **Time from issue to PR** — How quickly tasks move from backlog to PR.
+- **Review iteration cycles** — Number of rounds needed on AI-assisted vs. manual PRs.
+- **Test coverage** — Whether AI-assisted development maintains or improves coverage.
+- **Bug rate** — Post-merge defects to calibrate trust in AI suggestions.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow conventions | Verify `.instructions.md` `applyTo` glob matches your file |
+| Skill not activating | Use exact trigger phrases from the skills table |
+| Agent not available | Ensure `.agent.md` is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` and provide credentials when prompted |
+| Build/test commands fail | Verify Setup Commands in `AGENTS.md` match your environment |
+| AI gives generic advice | Open the relevant `.instructions.md` file in your editor |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,42 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Pure Go logic with no external dependencies?** → Go unit test (`testing` + `testify/assert`) in `source/plugins/go/src/*_test.go`
+2. **Bash script logic or environment detection?** → Shell test in `test/unit-tests/test_cases/*.sh` using `test_framework.sh`
+3. **Ruby Fluentd plugin behavior?** → Ruby test via `test/unit-tests/run_ruby_tests.sh` (requires Fluentd 1.14.2)
+4. **PowerShell Windows script logic?** → Pester test in `test/unit-tests/test_main.ps1` (Pester 5.3.3)
+5. **End-to-end Kubernetes log/metric verification?** → Go Ginkgo in `test/ginkgo-e2e/` or Python pytest in `test/e2e/`
+6. **Container log scale/performance?** → Scale test configs in `test/containerlog-scale-tests/`
+7. **Scenario-based multiline log parsing?** → Config files in `test/scenario/multiline/`
+
+## Test Patterns in This Repo
+
+### Unit Tests
+
+- **Bash:** `test/unit-tests/test_main.sh` → `test/unit-tests/test_framework.sh` → `test/unit-tests/test_cases/*.sh`
+- **Go:** `source/plugins/go/src/*_test.go` using `testing` + `testify/assert`
+- **Ruby:** Invoked via `test/unit-tests/run_ruby_tests.sh` (needs `fluentd` gem 1.14.2)
+- **PowerShell:** `test/unit-tests/test_main.ps1` using Pester 5.3.3 + PSScriptAnalyzer
+
+### E2E Tests
+
+- **Go Ginkgo:** `test/ginkgo-e2e/querylogs/`, `test/ginkgo-e2e/livenessprobe/`, `test/ginkgo-e2e/containerstatus/`
+  - Each suite has its own `go.mod`
+  - Uses `test/ginkgo-e2e/utils/` for shared Kubernetes utilities
+- **Python pytest:** `test/e2e/src/core/e2e_tests.py` with session-scoped fixtures in `conftest.py`
+  - Utilities in `test/e2e/src/common/` (Kubernetes, Helm, ARM helpers)
+
+### Scenario Tests
+
+- `test/scenario/multiline/` — Multiline log parsing test configs
+- `test/scenario/yamls/` — Kubernetes deployment templates for test scenarios
+
+## Common Test Utilities
+
+- `test/unit-tests/test_framework.sh` — Bash test framework (assertions, test runner)
+- `test/ginkgo-e2e/utils/` — Kubernetes client helpers, setup utilities for Go E2E
+- `test/e2e/src/common/kubernetes_pod_utility.py` — Pod CRUD operations
+- `test/e2e/src/common/constants.py` — Cloud endpoint constants


### PR DESCRIPTION
Auto-generated AI agent artifacts for coding assistants (GitHub Copilot, Jules, Gemini CLI, Cursor, etc.).

## Generated Files (25 files)

### Core Files
- `.github/copilot-instructions.md` — Root router with build commands, skill catalogue, known gotchas
- `AGENTS.md` — Setup commands, code style (Go/Ruby/Bash/PS/Python), testing, AI workflow
- `Prompt.md` — Reusable task-spec template
- `coding-agent-instructions.md` — Comprehensive usage guide for developers

### Instruction Files (`.github/instructions/`)
- `go.instructions.md` — Go Fluent Bit plugin conventions
- `ruby.instructions.md` — Ruby Fluentd plugin conventions
- `shell.instructions.md` — Bash script conventions
- `powershell.instructions.md` — PowerShell conventions
- `python-test.instructions.md` — Python E2E test conventions

### Agent Definitions (`.github/agents/`)
- `CodeReviewer.agent.md` — Structured code review with STRIDE security and telemetry gap detection
- `SecurityReviewer.agent.md` — Deep STRIDE security analysis
- `ThreatModelAnalyst.agent.md` — Persistent threat model artifacts with Mermaid diagrams
- `DocumentWriter.agent.md` — Documentation following repo conventions
- `prd.agent.md` — PRD generation tailored to this project

### Skills (`.github/skills/`)
- Always generated: `security-review`, `telemetry-authoring`, `fix-critical-vulnerabilities`
- From commit history (≥3 occurrences): `dependency-update`, `bug-fix`, `feature-development`, `test-authoring`, `ci-cd-pipeline`, `infrastructure`

### Other
- `.vscode/mcp.json` — GitHub + Microsoft Docs MCP server configuration
- `test/AGENTS.md` — Test framework guide with decision tree

Review before merging.