### PR TITLE
feat: add AI coding agent artifacts

### DIFF
--- a/.github/agents/CodeReviewer.agent.md
+++ b/.github/agents/CodeReviewer.agent.md
@@ -1,0 +1,73 @@
+# CodeReviewer Agent
+
+## Description
+You are a code reviewer for the Docker-Provider (Container Insights) repository. Your job is to review pull requests and code changes for correctness, style, security, and adherence to project conventions.
+
+## Review Philosophy
+1. Security & secrets — no hardcoded credentials, proper env var usage (35% priority)
+2. Error handling — proper `if err != nil` (Go) and `rescue` (Ruby) with telemetry (25%)
+3. Telemetry gaps — missing Application Insights instrumentation on new code paths (20%)
+4. Code conventions — frozen_string_literal (Ruby), gofmt (Go), set -e (Shell) (10%)
+5. Test coverage — new code must have corresponding tests (10%)
+
+## Scope
+- **Review:** `source/plugins/go/`, `source/plugins/ruby/`, `scripts/`, `kubernetes/`, `build/`, `test/`, `charts/`, `deployment/`
+- **Skip:** Auto-generated files, `go.sum`, `.trivyignore` entries (just verify justification), lock files
+
+## PR Diff Method
+Use `gh pr diff <number>` to get the diff. To get the base SHA, run `gh pr view <number> --json baseRefOid -q .baseRefOid` first as a separate command, then use the result in `git diff <base-sha>...HEAD`.
+
+## Review Checklist
+- [ ] Code follows naming conventions (Go: camelCase/PascalCase, Ruby: snake_case, Shell: snake_case)
+- [ ] Ruby files include `# frozen_string_literal: true`
+- [ ] All new/modified functions have appropriate tests
+- [ ] No secrets, credentials, or hardcoded configuration values
+- [ ] Error handling follows repo patterns (Go: `if err != nil` + telemetry, Ruby: `rescue` + `sendExceptionTelemetry`)
+- [ ] Logging uses project conventions (Go: custom `Log()`, Ruby: `@log`, not `puts`)
+- [ ] Environment variables used for all configuration
+- [ ] CI checks would pass (lint, build, test, Trivy)
+
+### Security Review Checklist (STRIDE)
+- [ ] **Spoofing** — Auth present at entry points; tokens validated
+- [ ] **Tampering** — Input validated at trust boundaries; container images pinned
+- [ ] **Repudiation** — Security actions logged via Application Insights
+- [ ] **Information Disclosure** — No hardcoded secrets; secrets not in logs/errors
+- [ ] **Denial of Service** — Resource limits set; timeouts on HTTP calls; bounded concurrency
+- [ ] **Elevation of Privilege** — Non-root containers; RBAC least-privilege; security contexts set
+- [ ] **Credential Leak Scan** — No API keys, tokens, passwords in changed files
+- [ ] **Weak Pattern Scan** — No disabled TLS, weak crypto, shell injection vectors
+
+### Telemetry Review Checklist
+- [ ] New error paths have telemetry (Go: `SendException`, Ruby: `sendExceptionTelemetry`)
+- [ ] New entry points are instrumented with timing metrics
+- [ ] Telemetry follows existing patterns (same SDK, naming, dimensions)
+- [ ] No sensitive data in telemetry dimensions/properties
+- [ ] No telemetry regressions (existing calls not removed without explanation)
+
+## Language-Specific Best Practices
+
+### Go (`source/plugins/go/`)
+- **Enforced by CI:** `go vet`, `go test -race`
+- **Reviewer focus:** Error handling completeness, goroutine safety (Mutex usage), Fluent Bit plugin API compliance
+- **Idiomatic patterns:** `CommonProperties` map for telemetry dimensions, `sync.Mutex` for shared state
+- **Common mistakes:** Missing error telemetry, hardcoded config values, unbounded goroutines
+
+### Ruby (`source/plugins/ruby/`)
+- **Enforced by CI:** Fluentd plugin load test
+- **Reviewer focus:** Thread safety (Mutex), proper `begin/rescue`, `frozen_string_literal` pragma
+- **Idiomatic patterns:** `@@ClassVariable` for shared state, `ApplicationInsightsUtility` for telemetry
+- **Common mistakes:** Missing `frozen_string_literal`, bare `rescue` without telemetry, `puts` instead of `@log`
+
+### Shell (`scripts/`, `build/`)
+- **Reviewer focus:** Variable quoting, `set -e` usage, no secrets in arguments
+- **Common mistakes:** Unquoted variables, missing error handling, hardcoded paths
+
+### PowerShell (`kubernetes/windows/`)
+- **Reviewer focus:** Error handling, environment variable usage
+- **Common mistakes:** Hardcoded paths, missing error trapping
+
+## Testing Expectations
+- Go changes → `go test ./...` in affected module
+- Ruby changes → `./test/unit-tests/run_ruby_tests.sh`
+- Shell changes → `./test/unit-tests/test_main.sh`
+- All changes → `cd build/linux && make` succeeds

--- a/.github/agents/DocumentWriter.agent.md
+++ b/.github/agents/DocumentWriter.agent.md
@@ -1,0 +1,53 @@
+# DocumentWriter Agent
+
+## Description
+You are a technical writer for the Docker-Provider (Container Insights) repository. Your job is to create and maintain documentation that is accurate, consistent, and follows the project's documentation conventions.
+
+## Audience & Tone
+- Primary audience: DevOps engineers, SREs, and developers who deploy and operate Container Insights
+- Writing tone: Technical, concise, action-oriented
+- Use second person ("you") for guides, imperative for instructions
+- Assumed knowledge: Kubernetes basics, Azure Monitor concepts
+
+## Documentation Structure
+- `README.md` — Project overview, setup instructions, and contributor guide
+- `ReleaseNotes.md` — Versioned release notes with change descriptions
+- `Documentation/` — Grafana dashboards, Data Collection Rule (DCR) docs
+- `charts/*/README.md` — Helm chart documentation
+- `Dev Guide.md` — Developer setup and build guide
+- `MARINER.md` — Mariner OS-specific documentation
+- `test/README.md` — Test infrastructure documentation
+
+## Writing Conventions
+- Heading style: ATX (`#`, `##`, `###`)
+- Code blocks: Triple backtick with language annotation (```bash, ```go, ```ruby)
+- Lists: Dash (`-`) for unordered, numbers for ordered/sequential steps
+- Links: Inline `[text](url)` style
+- File references: Use backtick-quoted paths (`` `source/plugins/go/src/` ``)
+- Tables: Pipe-delimited Markdown tables for structured data
+
+## Documentation Types
+- **Release Notes:** Version header, date, bullet list of changes with PR references
+- **READMEs:** Purpose, prerequisites, setup, usage, troubleshooting
+- **Helm Chart Docs:** Chart version, values description, deployment examples
+- **Code Comments:** Minimal — code should be self-explanatory. Comment only for non-obvious logic.
+
+## Templates
+
+### Release Note Entry
+```markdown
+## v3.1.XX (YYYY-MM-DD)
+- Feature/Fix description (#PR_NUMBER)
+- Feature/Fix description (#PR_NUMBER)
+```
+
+### Code Comment Conventions
+- Go: `//` single-line comments above functions
+- Ruby: `#` comments for non-obvious logic
+- Shell: `#` comments for section headers and complex logic
+
+## Validation
+- All file paths referenced in documentation must exist
+- All code examples must be syntactically valid
+- Version numbers must match actual release versions
+- Commands must actually work in the repo's build environment

--- a/.github/agents/SecurityReviewer.agent.md
+++ b/.github/agents/SecurityReviewer.agent.md
@@ -1,0 +1,80 @@
+---
+description: "Dedicated Security Reviewer — deep threat modeling, attack surface analysis, and security architecture review for Docker-Provider"
+---
+
+# SecurityReviewer Agent
+
+## Description
+You are a security specialist for the Docker-Provider (Container Insights) repository. You perform deep security assessments for this Kubernetes monitoring agent that runs as a privileged workload inside customer clusters.
+
+## When to Use This Agent vs. CodeReviewer Security Checks
+- **CodeReviewer** → Lightweight STRIDE checklist on every PR (fast, surface-level)
+- **SecurityReviewer** → Deep-dive security analysis invoked explicitly (thorough, architectural)
+
+Use `@SecurityReviewer` when:
+- A PR introduces or modifies authentication/authorization logic (FIC auth, MSI, certificates)
+- New external-facing APIs or network endpoints are added
+- Dockerfile or Kubernetes manifest changes modify security boundaries
+- Preparing for a security audit or compliance review
+- After a security incident to assess exposure
+
+## Threat Modeling Methodology
+
+### 1. Attack Surface Enumeration
+- **Entry points:** Fluent Bit input (container logs, CAdvisor API, Kubernetes API), MDSD socket, Telegraf metrics endpoint
+- **Trust boundaries:** External network ↔ Cluster network, Node ↔ Container, Container ↔ Sidecar, Agent ↔ Azure Monitor endpoints
+- **Data flows:** Container stdout/stderr → Fluent Bit → Go plugins → MDSD → Azure Monitor
+- **Secrets:** `APPLICATIONINSIGHTS_AUTH`, `WSID`, TLS certificates, MSI tokens
+
+### 2. STRIDE Deep Analysis
+**Spoofing:** Can an attacker impersonate the monitoring agent?
+- Verify MSI/FIC authentication for Azure endpoints
+- Check certificate validation for mTLS connections
+- Verify Kubernetes ServiceAccount token handling
+
+**Tampering:** Can log data be modified in transit?
+- Check TLS configuration for MDSD/Geneva connections
+- Verify container image integrity (digests vs tags)
+- Check Helm chart value injection points
+
+**Repudiation:** Can actions occur without audit trail?
+- Verify Application Insights captures security events
+- Check Kubernetes RBAC audit logging
+
+**Information Disclosure:** Can secrets leak?
+- Scan for hardcoded keys in Go/Ruby/Shell code
+- Check log output for credential exposure
+- Verify environment variable handling
+
+**Denial of Service:** Can the agent be crashed or starved?
+- Check resource limits in DaemonSet/ReplicaSet specs
+- Verify liveness/readiness probe configuration
+- Check for unbounded goroutines or Ruby threads
+
+**Elevation of Privilege:** Can the agent be exploited for cluster access?
+- Review ClusterRole/ClusterRoleBinding permissions
+- Check container security contexts
+- Verify no privileged mode without justification
+
+### 3. Dependency Security Assessment
+- Go modules: `source/plugins/go/src/go.mod` (ApplicationInsights-Go, k8s client-go, fluent-bit-go)
+- Container base: Azure Linux / Mariner (check for OS-level CVEs)
+- Ruby gems: Fluentd and dependencies
+- Scanning tools: Trivy (CI), CodeQL (weekly), DevSkim (PRs)
+
+### 4. Infrastructure Security Review
+- Multi-stage Docker builds with distroless final image
+- Kubernetes RBAC definitions in Helm chart templates
+- Network exposure: MDSD socket, metrics endpoints
+- Secret management via Kubernetes secrets and environment variables
+
+## Output Format
+### Findings Summary
+| # | Severity | STRIDE | Finding | Location | Recommendation |
+|---|----------|--------|---------|----------|----------------|
+
+### Positive Security Patterns
+- Multi-stage Docker builds with distroless base
+- Microsoft SECURITY.md with CVD policy
+- Trivy scanning in CI pipeline
+- CodeQL and DevSkim for SAST

--- a/.github/agents/ThreatModelAnalyst.agent.md
+++ b/.github/agents/ThreatModelAnalyst.agent.md
@@ -1,0 +1,56 @@
+---
+description: "Threat Model Analyst — generates STRIDE-based threat models with Mermaid security boundary diagrams, severity ratings, and timestamped artifacts under threat-model/"
+---
+
+# ThreatModelAnalyst Agent
+
+## Description
+You are a senior security architect specializing in threat modeling. You perform comprehensive threat model analysis following the **Microsoft Threat Modeling methodology** and produce structured, persistent artifacts:
+
+1. A **Mermaid architecture diagram** with clearly labeled security/trust boundaries
+2. A **full STRIDE analysis** for every component crossing a trust boundary, with severity ratings
+3. A **threat catalogue** with mitigations and residual risk assessment
+
+All artifacts are generated under `threat-model/YYYY-MM-DD/` at the repository root.
+
+## Methodology — Microsoft SDL Threat Modeling
+
+Follow the four-question framework:
+1. **What are we building?** — Identify components, data flows, external dependencies
+2. **What can go wrong?** — Apply STRIDE to each component and data flow
+3. **What are we going to do about it?** — Document mitigations (existing and recommended)
+4. **Did we do a good job?** — Validate completeness and residual risk
+
+**Reference:** https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool
+
+## Execution Procedure
+
+### Step 1: Repository Analysis
+1. **Components:** DaemonSet (Fluent Bit + Go plugins + Ruby plugins + Telegraf), ReplicaSet, optional AMA Core Agent, MDSD/Geneva agent
+2. **Data flows:** Container logs → Fluent Bit → Go output plugins → MDSD → Azure Monitor; CAdvisor → Ruby plugins → MDM metrics
+3. **External integrations:** Azure Monitor (Log Analytics, Metrics), Application Insights, Kubernetes API, Azure AD (MSI/FIC auth)
+4. **Trust boundaries:** External network ↔ Cluster, Node ↔ Pod, Pod ↔ Sidecar, Agent ↔ Azure endpoints
+5. **Data sensitivity:** Container logs (may contain PII), Kubernetes metadata (internal), telemetry keys (confidential), MSI tokens (restricted)
+
+### Step 2: Generate Mermaid Diagram
+Create diagram with trust boundaries as subgraphs, color-coded by risk level. Save as `threat-model-diagram.mmd`.
+
+### Step 3: STRIDE Analysis
+For every component crossing a trust boundary, evaluate all six STRIDE categories with severity ratings (Critical 9-10, High 7-8, Medium 4-6, Low 1-3).
+
+### Step 4: Generate Artifacts
+Create date-stamped directory with:
+- `threat-model-report.md` — Full report with executive summary
+- `threat-model-diagram.mmd` — Mermaid source
+- `stride-analysis.md` — Detailed STRIDE table per component
+- `threat-catalogue.md` — Prioritized threat catalogue
+
+### Step 5: Update README Index
+Append new row to `threat-model/README.md` index table.
+
+## Anti-Patterns
+- Do NOT generate generic threat models — reference specific Docker-Provider components
+- Do NOT skip components — assess everything crossing a trust boundary
+- Do NOT assume mitigations work — verify in Dockerfiles, k8s manifests, code
+- Do NOT place artifacts outside `threat-model/`
+- Do NOT overwrite previous runs

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -1,0 +1,55 @@
+---
+description: "Generate a PRD (Product Requirements Document) for new features or larger projects in Docker-Provider."
+---
+
+# PRD Agent
+
+## Description
+You generate structured Product Requirements Documents for proposed features or changes to the Docker-Provider (Container Insights) repository. You follow a consistent template tailored to this project's architecture and conventions.
+
+## PRD Template
+
+### 1. Overview
+- Feature name and one-line summary
+- Problem statement: what monitoring/observability gap does this address?
+- Success criteria: how do we know this is working?
+
+### 2. Requirements
+- Functional requirements (what the feature must do)
+- Non-functional requirements (performance, resource limits, multi-cloud support)
+- Out of scope (explicitly state what this does NOT include)
+
+### 3. Architecture
+- **Affected components:** Which plugins/services are affected?
+  - Go plugins (`source/plugins/go/src/`, `source/plugins/go/input/`)
+  - Ruby plugins (`source/plugins/ruby/`)
+  - Fluent Bit configuration
+  - Telegraf configuration
+  - Kubernetes manifests / Helm charts
+- **Data flow:** How does data move through DaemonSet → Fluent Bit → Plugins → MDSD → Azure Monitor?
+- **Configuration:** What new environment variables or Helm values are needed?
+- **Dependencies:** External services, Azure APIs, new Go modules or Ruby gems
+
+### 4. Implementation Plan
+- Phase breakdown with deliverables per phase
+- Files/modules expected to change
+- Backward compatibility strategy (existing clusters must not break)
+
+### 5. Testing Strategy
+- Unit tests: Go (`testify`), Ruby (`minitest`), Shell (`test_framework.sh`)
+- E2E tests: Ginkgo suites under `test/ginkgo-e2e/`
+- Integration tests: TestKube workflows
+- Performance/load testing if applicable
+
+### 6. Monitoring & Observability
+- New Application Insights telemetry (metrics, events, exceptions)
+- Follow existing patterns: `TelemetryClient` (Go), `ApplicationInsightsUtility` (Ruby)
+- Alert rules if needed (`alerts/` directory)
+- Rollback indicators: what signals mean we should revert?
+
+### 7. Deployment
+- Helm chart version bump in `charts/azuremonitor-containers/Chart.yaml`
+- ARM/Bicep/Terraform template updates if needed
+- Multi-cloud support: AKS, ARC, on-premises
+- Multi-architecture: amd64, arm64
+- Rollout strategy: canary → production

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,62 @@
+# Repository Instructions
+
+## Summary
+Docker-Provider (aka Container Insights) is a Microsoft open-source project that collects container logs, metrics, and inventory data from Kubernetes clusters (AKS, ARC, on-prem) and sends them to Azure Monitor (Log Analytics, Metrics, MDSD/Geneva). Primary languages: Ruby (~25%), Go (~11%), Shell (~14%), Python (~7%), PowerShell (~8%), with YAML/JSON configs (~35%). Runs as DaemonSet + ReplicaSet inside the `kube-system` namespace. Uses Fluent Bit (C), Fluentd (Ruby plugins), Telegraf (Go), and custom Go Fluent Bit output plugins for data collection.
+
+## General Guidelines
+
+1. Follow existing code style per language — Ruby uses `snake_case` with `frozen_string_literal`, Go uses standard `gofmt`, Shell scripts use `set -e`.
+2. All telemetry must use the existing `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go) patterns — never introduce new telemetry SDKs.
+3. Environment variables are the source of truth for configuration at runtime — never hardcode secrets, endpoints, or keys.
+4. If newer commits make prior changes unnecessary, revert them.
+5. Check `AGENTS.md` for setup commands, code style, and testing instructions.
+
+## Prompting Best Practices
+
+1. Break complex tasks into smaller prompts — one plugin, one test file, one config change at a time.
+2. Be specific: reference actual file paths like `source/plugins/ruby/in_kube_nodes.rb` or `source/plugins/go/src/oms.go`.
+3. Open relevant source files before prompting — Copilot uses open files as context.
+4. Start new chat sessions for unrelated tasks to avoid context pollution.
+5. Use the explore → plan → code → commit workflow for multi-file changes (see `AGENTS.md`).
+6. Always validate AI-generated code: run tests, check linters, and verify against CI checks.
+
+## Build Instructions
+
+**Prerequisites:** Go 1.25+, Ruby, `make`, Docker, Helm.
+
+**Build (Linux):**
+```bash
+cd build/linux && make
+```
+
+**Docker image:**
+```bash
+cd kubernetes/linux && docker build . --file Dockerfile.multiarch -t <tag>
+```
+
+**Run unit tests:**
+```bash
+# Bash tests
+./test/unit-tests/test_main.sh
+# Go tests
+./test/unit-tests/run_go_tests.sh
+# Ruby tests (requires fluentd gem)
+./test/unit-tests/run_ruby_tests.sh
+```
+
+**Trivy scan:**
+```bash
+trivy image --severity CRITICAL,HIGH <image-tag>
+```
+
+## Known Patterns & Gotchas
+
+- The build system has separate Linux and Windows paths (`build/linux/`, `kubernetes/windows/`).
+- Local computer builds may be broken — see README note. CI builds are the reliable path.
+- Go plugins live under `source/plugins/go/src/` (output plugins) and `source/plugins/go/input/` (input plugins).
+- Ruby plugins under `source/plugins/ruby/` are Fluentd input/output/filter plugins.
+- Multiple `go.mod` files exist: `source/plugins/go/src/`, `source/plugins/go/input/`, and test dirs under `test/ginkgo-e2e/`.
+- Helm charts in `charts/` — `azuremonitor-containers` is the primary chart.
+- ARM/Bicep/Terraform templates are in `deployment/` — do NOT edit manually if helper scripts exist.
+- The `.trivyignore` file tracks temporarily suppressed CVEs — always include justification.
+- Default branch is `ci_prod`, not `main`.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.go"
+description: "Go coding conventions for Docker-Provider Fluent Bit plugins and Kubernetes clients."
+---
+
+# Go Code Standards
+
+- Use `gofmt` formatting — no custom format overrides.
+- Error handling: always check `if err != nil` — never silently ignore errors.
+- Use `ApplicationInsights-Go` (`appinsights.TelemetryClient`) for telemetry — never introduce new telemetry SDKs.
+- Use `fluent/fluent-bit-go` API for Fluent Bit plugin interfaces (`FLBPluginRegister`, `FLBPluginInit`, `FLBPluginFlush`).
+- Kubernetes client-go is used for API calls — follow existing patterns in `source/plugins/go/input/`.
+- Configuration comes from environment variables — access via `os.Getenv()`, never hardcode values.
+- Use `sync.Mutex` for shared state protection — the plugins run concurrently.
+- Log messages use structured format with context fields (computer, container name, etc.).
+- Test with `go test ./...` in the relevant module directory.
+- Multiple `go.mod` files exist — update the correct one for your change scope.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "**/*.py"
+description: "Python coding conventions for Docker-Provider utility scripts."
+---
+
+# Python Code Standards
+
+- Use `snake_case` for functions and variables, `PascalCase` for classes.
+- Include type hints where practical.
+- Use `os.environ` for configuration — never hardcode secrets.
+- Error handling: use specific exception types, not bare `except:`.
+- Python scripts in this repo are primarily utility/tooling scripts (not core plugins).
+- Follow PEP 8 style guidelines.
+- Test any Python changes by running the relevant scripts manually.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.rb"
+description: "Ruby coding conventions for Docker-Provider Fluentd plugins."
+---
+
+# Ruby Code Standards
+
+- Always include `# frozen_string_literal: true` at the top of every file.
+- Use `snake_case` for methods and variables, `PascalCase` for classes.
+- Use `@@ClassVariable` for class-level shared state following existing plugin patterns.
+- Error handling: wrap risky operations in `begin/rescue => e` blocks.
+- Report exceptions via `ApplicationInsightsUtility.sendExceptionTelemetry(e)`.
+- Log via the custom `@log` logger (OMS logger), not `puts` or `$stdout`.
+- Use `require_relative` for local files, `require` for gems.
+- Fluentd plugin API: inherit from `Fluent::Input`, `Fluent::Output`, or `Fluent::Filter`.
+- Configuration via `ENV["VARIABLE_NAME"]` — never hardcode secrets or endpoints.
+- Test files follow `*_test.rb` naming in `source/plugins/ruby/`.
+- Run Ruby tests: `./test/unit-tests/run_ruby_tests.sh` (requires `fluentd` gem).

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**/*.sh"
+description: "Shell script conventions for Docker-Provider build and utility scripts."
+---
+
+# Shell Script Standards
+
+- Use `#!/bin/bash` shebang.
+- Use `set -e` to exit on errors in non-interactive scripts.
+- Use `snake_case` for variables and function names.
+- Quote all variable expansions: `"$variable"` not `$variable`.
+- Configuration via environment variables — never hardcode paths or secrets.
+- Use `echo` for user-facing output, redirect debug output to stderr.
+- For build scripts, follow the pattern in `build/linux/Makefile` targets.
+- Test scripts live under `test/unit-tests/` — follow the existing test framework in `test_framework.sh`.
+- Windows-equivalent scripts use PowerShell (`.ps1`) under `kubernetes/windows/`.

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,38 @@
+# Bug Fix
+
+## Description
+Guide for fixing bugs in the Docker-Provider container insights agent.
+
+USE FOR: fix bug, resolve issue, patch, hotfix, debug, error fix, bug fix
+DO NOT USE FOR: feature development, refactoring, performance optimization, CVE fixes (use fix-critical-vulnerabilities)
+
+## Instructions
+
+### When to Apply
+When fixing a reported bug or unexpected behavior in container log collection, metric emission, inventory gathering, or agent startup/liveness.
+
+### Step-by-Step Procedure
+1. Reproduce or understand the issue — check error logs, telemetry, and symptoms.
+2. Identify the affected component: Go plugins (`source/plugins/go/`), Ruby plugins (`source/plugins/ruby/`), Shell scripts (`scripts/`), or configuration.
+3. Locate the relevant source file(s) using the symptom (log message, error string, metric name).
+4. Implement the fix following existing code patterns and error handling conventions.
+5. Add a regression test in the appropriate test directory.
+6. Run unit tests: `./test/unit-tests/test_main.sh`, `./test/unit-tests/run_go_tests.sh`, `./test/unit-tests/run_ruby_tests.sh`.
+7. Build: `cd build/linux && make`.
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` — Go output plugins
+- `source/plugins/go/input/**/*.go` — Go input plugins
+- `source/plugins/ruby/*.rb` — Ruby Fluentd plugins
+- `scripts/*.sh` — Shell scripts
+- `test/unit-tests/` — Unit test files
+
+### Validation
+- All unit tests pass
+- Build succeeds: `cd build/linux && make`
+- No new Trivy findings
+
+## Examples from This Repo
+- `5c0bca0bb` — bug fix (#1593)
+- `fbcc3de37` — fix bug (#1577)
+- `41e880633` — fix amaca liveness probe issue in high scale mode (#1530)

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,36 @@
+# CI/CD Pipeline
+
+## Description
+Guide for modifying CI/CD pipelines and build configurations.
+
+USE FOR: pipeline change, CI fix, build pipeline, release pipeline, governed release, pipeline migration, Azure Pipelines update
+DO NOT USE FOR: source code changes, dependency updates, feature development
+
+## Instructions
+
+### When to Apply
+When modifying GitHub Actions workflows, Azure Pipelines configurations, build scripts, or release processes.
+
+### Step-by-Step Procedure
+1. Identify which pipeline to modify: GitHub Actions (`.github/workflows/`) or Azure Pipelines.
+2. For GitHub Actions: edit the relevant `.yml` file — `pr-checker.yml` (build + scan), `run_unit_tests.yml` (tests), `codeql-analysis.yml`, `devskim.yml`.
+3. For Azure Pipelines: configurations are referenced in commit history but managed externally.
+4. Test workflow changes by creating a PR — CI runs automatically on PRs to `ci_dev`/`ci_prod`.
+5. Verify all checks pass in the PR.
+
+### Files Typically Involved
+- `.github/workflows/pr-checker.yml` — PR build and Trivy scan
+- `.github/workflows/run_unit_tests.yml` — Unit tests (Bash, Go, Ruby, PowerShell)
+- `.github/workflows/codeql-analysis.yml` — CodeQL SAST
+- `.github/workflows/devskim.yml` — DevSkim security patterns
+- `build/linux/Makefile` — Build targets
+
+### Validation
+- Workflow YAML is valid
+- CI checks pass on test PR
+
+## Examples from This Repo
+- `0d5ca4aeb` — Governed release yamls migration (#1448)
+- `58a1c9436` — Migrate all release pipelines to governed release yaml (#1443)
+- `05c46f5f7` — Migrate merged build pipeline to governed pipeline template (#1442)
+- `1e4f08b56` — migrate esrp signing (#1438)

--- a/.github/skills/dependency-update/SKILL.md
+++ b/.github/skills/dependency-update/SKILL.md
@@ -1,0 +1,41 @@
+# Dependency Update
+
+## Description
+Guide for updating dependencies in Docker-Provider (Go modules, Ruby gems, Fluent Bit, Telegraf, MDSD, Mariner base image).
+
+USE FOR: update dependency, bump package, upgrade library, update go modules, upgrade fluent-bit, upgrade telegraf, upgrade mdsd, mariner upgrade
+DO NOT USE FOR: adding a brand new dependency, CVE-driven updates (use fix-critical-vulnerabilities), major architecture changes
+
+## Instructions
+
+### When to Apply
+When upgrading component versions (Fluent Bit, Telegraf, MDSD, Mariner base) or Go/Ruby dependencies.
+
+### Step-by-Step Procedure
+1. Identify which dependency to update and the target version.
+2. For Go modules: run `go get <package>@<version>` in the correct `go.mod` directory, then `go mod tidy`.
+3. For Ruby gems: update the gem version in the relevant install scripts or Dockerfile.
+4. For Fluent Bit/Telegraf/MDSD: update version references in build scripts and Dockerfiles.
+5. For Mariner base image: update the `FROM` line in `kubernetes/linux/Dockerfile.multiarch`.
+6. Build: `cd build/linux && make`.
+7. Run unit tests to verify nothing broke.
+8. Run `trivy fs --severity CRITICAL,HIGH --scanners vuln .` to check for new vulnerabilities.
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod` — E2E test modules
+- `kubernetes/linux/Dockerfile.multiarch`
+- `build/linux/Makefile`
+
+### Validation
+- Build succeeds
+- All unit tests pass
+- Trivy scan clean
+- Docker image builds
+
+## Examples from This Repo
+- `a71f549e0` — Fluent bit 4.0.14 (#1601)
+- `df85af818` — Upgrade Telegraf 1.34.3 (#1434)
+- `8ac2038cc` — Mariner 3 upgrade (#1439)
+- `388f83c97` — mdsd version upgrade 1.35.7 (#1492)

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,38 @@
+# Documentation
+
+## Description
+Guide for updating documentation, release notes, and README files.
+
+USE FOR: doc update, readme, release notes, changelog, chart update, documentation
+DO NOT USE FOR: code changes, build changes, infrastructure changes
+
+## Instructions
+
+### When to Apply
+When writing release notes, updating READMEs, adding deprecation notices, or updating chart documentation.
+
+### Step-by-Step Procedure
+1. Identify the documentation type: release notes, README, chart docs, or inline code docs.
+2. For release notes: follow the format in `ReleaseNotes.md` — version header, date, bullet list of changes.
+3. For README updates: keep the format consistent with existing `README.md` structure.
+4. For Helm chart docs: update `charts/azuremonitor-containers/README.md` and `Chart.yaml`.
+5. Reference actual PR numbers and commit descriptions.
+6. Verify all file paths and links are valid.
+
+### Files Typically Involved
+- `ReleaseNotes.md` — Release notes
+- `README.md` — Project README
+- `charts/azuremonitor-containers/Chart.yaml` — Helm chart metadata
+- `Documentation/` — Grafana dashboards, DCR docs
+- `MARINER.md`, `Dev Guide.md` — Development docs
+
+### Validation
+- All referenced file paths exist
+- Links are valid
+- Version numbers match release
+
+## Examples from This Repo
+- `7410ab3a9` — release notes for 3.1.35 (#1608)
+- `d30c2c4ad` — 3.1.34 release notes and chart update (#1603)
+- `731a625b6` — add deprecation note for helm chart (#1546)
+- `440ecefe2` — Added Readme for test folder (#1399)

--- a/.github/skills/feature-development/SKILL.md
+++ b/.github/skills/feature-development/SKILL.md
@@ -1,0 +1,44 @@
+# Feature Development
+
+## Description
+Guide for adding new features to the Docker-Provider container insights agent.
+
+USE FOR: add feature, implement, new endpoint, new component, new module, create, add support, enable
+DO NOT USE FOR: bug fixes, refactoring, documentation-only changes, CVE fixes
+
+## Instructions
+
+### When to Apply
+When adding new data collection capabilities, new log streams, new metric sources, new authentication methods, or new deployment modes.
+
+### Step-by-Step Procedure
+1. Understand the feature scope — which components are affected (Go plugins, Ruby plugins, config, deployment).
+2. Plan the implementation: identify all files to create/modify.
+3. For new Go plugins: create under `source/plugins/go/src/` or `source/plugins/go/input/`.
+4. For new Ruby plugins: create under `source/plugins/ruby/`.
+5. Update configuration files if needed (Fluent Bit conf, environment variables).
+6. Add telemetry for the new feature using `ApplicationInsightsUtility` (Ruby) or `TelemetryClient` (Go).
+7. Add unit tests for the new code.
+8. Update deployment templates if the feature requires new configuration (Helm values, ARM parameters).
+9. Build and test: `cd build/linux && make`, then run all unit tests.
+
+### Files Typically Involved
+- `source/plugins/go/src/*.go` — New Go plugins
+- `source/plugins/ruby/*.rb` — New Ruby plugins
+- `source/plugins/ruby/lib/` — Ruby utility libraries
+- `kubernetes/linux/Dockerfile.multiarch` — If new build dependencies needed
+- `charts/azuremonitor-containers/` — Helm chart values
+- `deployment/` — ARM/Bicep/Terraform templates
+
+### Validation
+- Build succeeds
+- New unit tests pass
+- Existing tests still pass
+- Docker image builds
+- Telemetry added for new code paths
+
+## Examples from This Repo
+- `fb8011ca5` — Enabled OTel logs and traces support (#1527)
+- `089b05960` — Added FIC auth support (#1539)
+- `c02975eec` — Adding change for networkflow logs new stream (#1551)
+- `c9f5dfa83` — Add private link support for high log scale (#1512)

--- a/.github/skills/fix-critical-vulnerabilities/SKILL.md
+++ b/.github/skills/fix-critical-vulnerabilities/SKILL.md
@@ -1,0 +1,103 @@
+# Fix Critical Vulnerabilities
+
+## Description
+Identify and fix critical/high vulnerabilities using the repo's own scanning tools.
+
+USE FOR: fix critical vulnerability, fix high vulnerability, CVE fix, trivy fix, security vulnerability remediation, patch CVE, fix security scan failure
+DO NOT USE FOR: general dependency updates, adding new security tools, security architecture review, threat modeling
+
+## Instructions
+
+### 1. Vulnerability Discovery
+
+**Scanning tools in this repo:**
+- **Trivy** — Container image and filesystem scanning (configured in `.github/workflows/pr-checker.yml`)
+- **CodeQL** — SAST for Go, Python, Ruby (`.github/workflows/codeql-analysis.yml`)
+- **DevSkim** — Security pattern matching (`.github/workflows/devskim.yml`)
+
+**Run scans locally:**
+```bash
+# Filesystem scan for Go/Ruby dependencies
+trivy fs --severity CRITICAL,HIGH --scanners vuln .
+
+# Specific Go module scan
+trivy fs --severity CRITICAL,HIGH --scanners vuln source/plugins/go/src/go.mod
+
+# Container image scan (after building)
+trivy image --severity CRITICAL,HIGH <image-tag>
+```
+
+### 2. Vulnerability Triage
+
+**a. Direct Go module vulnerabilities**
+- Check `source/plugins/go/src/go.mod` and `source/plugins/go/input/go.mod`
+- Also check test modules: `test/ginkgo-e2e/*/go.mod`
+- Priority: HIGH — directly fixable
+
+**b. Ruby gem vulnerabilities**
+- Check gem installations in Dockerfiles
+- Priority: HIGH for runtime gems
+
+**c. Container base image vulnerabilities**
+- Check `kubernetes/linux/Dockerfile.multiarch` — Azure Linux / Mariner base
+- Check `kubernetes/windows/Dockerfile` — Windows base
+- Priority: HIGH if base image update available
+
+**d. Already-ignored CVEs**
+- Check `.trivyignore` — currently suppresses `CVE-2026-24051`
+- If a CVE is already ignored with justification, skip it
+
+### 3. Fix Implementation
+
+**Go module vulnerabilities:**
+```bash
+cd source/plugins/go/src
+go get <package>@<fixed-version>
+go mod tidy
+# Repeat for source/plugins/go/input/ and test modules if affected
+```
+
+**Ruby gem vulnerabilities:**
+- Update gem version in Dockerfile install commands
+- Or uninstall the gem if not needed (e.g., `gem uninstall net-imap`)
+
+**Container base image:**
+- Update the `FROM` line in `kubernetes/linux/Dockerfile.multiarch`
+- Update Mariner package versions
+
+**Unfixable CVEs:**
+- Add to `.trivyignore` with justification comment and date
+
+### 4. Build and Test
+
+```bash
+# Build
+cd build/linux && make
+
+# Run tests
+./test/unit-tests/test_main.sh
+./test/unit-tests/run_go_tests.sh
+./test/unit-tests/run_ruby_tests.sh
+
+# Re-scan
+trivy fs --severity CRITICAL,HIGH --scanners vuln .
+```
+
+### 5. Commit
+- Format: `Fix CVEs in <component> (#PR)`
+- Include table of CVEs fixed in PR description
+
+### Files Typically Involved
+- `source/plugins/go/src/go.mod`, `source/plugins/go/src/go.sum`
+- `source/plugins/go/input/go.mod`, `source/plugins/go/input/go.sum`
+- `test/ginkgo-e2e/*/go.mod`, `test/ginkgo-e2e/*/go.sum`
+- `kubernetes/linux/Dockerfile.multiarch`
+- `kubernetes/windows/Dockerfile`
+- `.trivyignore`
+
+## Examples from This Repo
+- `31c5bc4fc` — Longw/3.1.35 address vulnerabilities (#1605)
+- `6f4c31f91` — 3.1.32 CVE fixes (#1596)
+- `733532d7f` — 3.1.31 CVEs fixes (#1572)
+- `15e97f599` — Fix CVEs and handle intermittent errors (#1556)
+- `a1a39074e` — CVE 202543857: uninstall net-imap gem (#1480)

--- a/.github/skills/infrastructure/SKILL.md
+++ b/.github/skills/infrastructure/SKILL.md
@@ -1,0 +1,44 @@
+# Infrastructure
+
+## Description
+Guide for modifying infrastructure-as-code, deployment templates, and Kubernetes configurations.
+
+USE FOR: infrastructure change, Terraform update, Bicep template, Helm chart, ARM template, deployment config, Kubernetes manifest
+DO NOT USE FOR: source code changes, CI/CD pipeline modifications, dependency updates
+
+## Instructions
+
+### When to Apply
+When modifying deployment templates (Terraform, Bicep, ARM), Helm charts, Kubernetes manifests, or onboarding scripts.
+
+### Step-by-Step Procedure
+1. Identify the deployment target: AKS, ARC, multi-tenant, high-scale, network flow.
+2. Locate the relevant template directory:
+   - Helm charts: `charts/azuremonitor-containers/`
+   - Terraform: `deployment/` (look for `.tf` files)
+   - Bicep: `deployment/` (look for `.bicep` files)
+   - ARM JSON: `deployment/`, `alerts/`
+   - Kubernetes YAML: `kubernetes/`
+3. Make changes following existing template patterns.
+4. If helper scripts exist for config management, use them instead of editing templates directly.
+5. Validate template syntax before committing.
+6. Update Helm chart version in `Chart.yaml` if modifying chart templates.
+
+### Files Typically Involved
+- `charts/azuremonitor-containers/` — Helm chart templates and values
+- `deployment/` — ARM, Bicep, Terraform templates
+- `kubernetes/linux/` — Linux DaemonSet/ReplicaSet configs
+- `kubernetes/windows/` — Windows configs
+- `alerts/` — Alert rule definitions
+- `scripts/` — Onboarding and migration scripts
+
+### Validation
+- Template syntax validates (Helm lint, Terraform validate, Bicep build)
+- No hardcoded secrets in templates
+- Parameters have appropriate defaults
+
+## Examples from This Repo
+- `1669d2526` — Longw/high scale and networkflow logs Bicep templates (#1470)
+- `4cb3207d3` — Longw/multi tenant templates with Terraform (#1505)
+- `ed515567a` — Update ARM template parameter check (#1421)
+- `14fa37367` — Longw/retina networkflow logs (#1372)

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -1,0 +1,93 @@
+# Security Review
+
+## Description
+STRIDE-based security review skill for Docker-Provider code changes.
+
+USE FOR: security review, threat model, STRIDE analysis, credential leak check, secret scan, vulnerability review, security audit
+DO NOT USE FOR: performance optimization, functional bug fixes, code style issues, feature implementation
+
+## Instructions
+
+### When to Apply
+Apply to PRs modifying: authentication logic, network-facing code, data handling, Dockerfiles, Kubernetes manifests, Helm charts, or dependency changes.
+
+### Step-by-Step Procedure
+
+#### 1. STRIDE Threat Model Checklist
+
+**Spoofing (Identity)**
+- Are Azure AD MSI auth checks present at container entry points?
+- Are tokens validated (not just checked for presence)?
+- Is service-to-service auth using managed identity or certificates?
+
+**Tampering (Data Integrity)**
+- Is input validated at trust boundaries (log parsing, API responses)?
+- Are container image digests pinned (not `:latest` tags)?
+- Are file permissions restrictive in Dockerfiles?
+
+**Repudiation (Auditability)**
+- Are security-relevant actions logged via Application Insights?
+- Do logs include context (who, what, when) without leaking secrets?
+
+**Information Disclosure (Confidentiality)**
+- No hardcoded secrets, API keys, tokens, or connection strings.
+- No secrets in log output or error messages.
+- Env vars used for: `APPLICATIONINSIGHTS_AUTH`, `WSID`, endpoints.
+- TLS certificates excluded from repo (check `.gitignore`).
+
+**Denial of Service (Availability)**
+- Resource limits set in Kubernetes manifests (CPU/memory).
+- Timeouts on HTTP calls and API requests.
+- Bounded concurrent operations (goroutines, threads).
+- Container liveness/readiness probes configured.
+
+**Elevation of Privilege (Authorization)**
+- Containers running as non-root (check `USER` in Dockerfiles).
+- RBAC roles follow least-privilege (check ClusterRole definitions).
+- Security contexts set in Kubernetes manifests.
+- No privileged containers without justification.
+
+#### 2. Credential & Secret Detection
+Scan changed files for:
+- API keys: `AKIA[0-9A-Z]{16}`, hex strings > 32 chars
+- Connection strings: `Server=...;Password=...`
+- Tokens: `Bearer`, `ghp_`, `github_pat_`
+- Private keys: `-----BEGIN PRIVATE KEY-----`
+- Hardcoded endpoints that should be configurable
+
+#### 3. Weak Security Patterns
+
+**Go:**
+- `#nosec` annotations without justification
+- Unchecked `err` returns from crypto/auth functions
+- `fmt.Sprintf` for SQL queries
+- `exec.Command` with unsanitized input
+
+**Ruby:**
+- `eval`, `send` with user-controlled input
+- `system()` with unsanitized input
+- `YAML.load` instead of `YAML.safe_load`
+
+**Shell/Bash:**
+- Unquoted variables in commands
+- `chmod 777` or overly permissive permissions
+- Secrets passed as command-line arguments
+- Missing `set -e`
+
+**Infrastructure (Dockerfiles, k8s):**
+- Running as root without justification
+- Using `:latest` tags
+- Secrets in ENV instead of mounted secrets
+- Missing security contexts
+- Exposed ports that should be internal-only
+
+#### 4. CI Security Integration
+- CodeQL runs weekly on Go, Python, Ruby
+- DevSkim runs on PRs
+- Trivy scans Docker images for CRITICAL/HIGH CVEs
+- `.trivyignore` tracks suppressed CVEs (verify justifications)
+
+### Validation
+- Run `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+- Verify `.gitignore` excludes `*.pem`, `*.key`, `.env`
+- Confirm `SECURITY.md` exists (Microsoft CVD policy)

--- a/.github/skills/telemetry-authoring/SKILL.md
+++ b/.github/skills/telemetry-authoring/SKILL.md
@@ -1,0 +1,59 @@
+# Telemetry Authoring
+
+## Description
+Guide for adding telemetry instrumentation following existing Application Insights patterns.
+
+USE FOR: add telemetry, add metrics, add tracing, add observability, instrument code, track event, emit metric, add logging, add Application Insights
+DO NOT USE FOR: fixing broken telemetry pipelines, configuring telemetry infrastructure, dashboard creation, alert rule authoring
+
+## Instructions
+
+### When to Apply
+When adding telemetry to new or existing code paths in Go plugins, Ruby plugins, or scripts.
+
+### Step-by-Step Procedure
+
+#### 1. Telemetry Pattern Discovery
+Before adding ANY telemetry:
+- **Go plugins:** Use `TelemetryClient` from `source/plugins/go/src/telemetry.go`. Initialize via `appinsights.NewTelemetryClient()` with `APPLICATIONINSIGHTS_AUTH` env var.
+- **Ruby plugins:** Use `ApplicationInsightsUtility` from `source/plugins/ruby/ApplicationInsightsUtility.rb`. Call `sendExceptionTelemetry(e)` for errors, `sendMetricTelemetry()` for metrics.
+- NEVER introduce a new telemetry SDK — always follow the existing pattern.
+
+#### 2. What to Instrument
+
+**a. Error paths (highest priority)**
+- Go: `if err != nil` blocks → `SendException(err)` with context
+- Ruby: `rescue => e` blocks → `ApplicationInsightsUtility.sendExceptionTelemetry(e)`
+- Include: error type, message, operation context
+
+**b. Entry points and API boundaries**
+- Track operation name, duration, success/failure
+- Go: create metric tracking at function start/end
+- Ruby: use `sendMetricTelemetry()` with timing
+
+**c. External calls**
+- HTTP calls, Kubernetes API calls, MDSD writes
+- Track: target, duration, response status
+
+**d. Critical business logic**
+- Data collection milestones, flush events, configuration changes
+- Use custom events with properties
+
+#### 3. Telemetry Conventions
+- **Go metric naming:** descriptive variable names (e.g., `FlushedRecordsCount`, `TelegrafMetricsSentCount`)
+- **Ruby event naming:** `@@HeartBeat = "HeartBeatEvent"`, `@@Exception = "ExceptionEvent"`
+- **Standard dimensions (Go):** `CommonProperties` map with computer, controller type, AKS resource ID, region
+- **Standard dimensions (Ruby):** `@@CustomProperties` with ID, Region, WSID, AgentVersion, ControllerType
+
+#### 4. Anti-Patterns to Avoid
+- Do NOT log sensitive data (credentials, tokens, PII)
+- Do NOT add telemetry inside tight loops
+- Do NOT use `puts`/`fmt.Println` for production telemetry
+- Do NOT create new TelemetryClient instances — reuse `TelemetryClient` (Go) or `@@Tc` (Ruby)
+- Do NOT hardcode instrumentation keys — use `APPLICATIONINSIGHTS_AUTH` env var
+
+#### 5. Validation
+- Verify the telemetry import matches existing files
+- Verify metric/event names follow repo conventions
+- Run unit tests to ensure telemetry doesn't break test isolation
+- Check that telemetry is gated for test environments

--- a/.github/skills/test-authoring/SKILL.md
+++ b/.github/skills/test-authoring/SKILL.md
@@ -1,0 +1,43 @@
+# Test Authoring
+
+## Description
+Guide for adding tests to the Docker-Provider codebase.
+
+USE FOR: add test, write test, test coverage, test for feature, add unit test, add integration test, TDD
+DO NOT USE FOR: fixing flaky tests, refactoring tests, test infrastructure changes
+
+## Instructions
+
+### When to Apply
+When adding test coverage for new or existing code across any language in the repo.
+
+### Step-by-Step Procedure
+1. Identify which language/component needs tests.
+2. Choose the correct test framework and location:
+   - **Go unit tests:** `source/plugins/go/src/*_test.go` or `source/plugins/go/input/**/*_test.go` — use `testify` assertions.
+   - **Ruby unit tests:** `source/plugins/ruby/*_test.rb` — run with `./test/unit-tests/run_ruby_tests.sh`.
+   - **Shell unit tests:** `test/unit-tests/test_cases/*.sh` — follow `test_framework.sh` patterns.
+   - **Go E2E tests:** `test/ginkgo-e2e/<suite>/` — use Ginkgo/Gomega framework.
+   - **PowerShell tests:** use Pester v5.3.3 framework.
+3. Write failing tests first (TDD approach), then implement code to pass them.
+4. Follow existing naming conventions in the test directory.
+5. Run all tests to verify nothing is broken.
+
+### Files Typically Involved
+- `source/plugins/go/src/*_test.go` — Go unit tests
+- `source/plugins/ruby/*_test.rb` — Ruby unit tests
+- `test/unit-tests/test_cases/*.sh` — Shell test cases
+- `test/ginkgo-e2e/` — E2E test suites
+- `test/unit-tests/test_main.sh` — Test runner
+
+### Validation
+- `./test/unit-tests/test_main.sh` passes
+- `./test/unit-tests/run_go_tests.sh` passes
+- `./test/unit-tests/run_ruby_tests.sh` passes
+- Go: `go test -cover -race ./...`
+
+## Examples from This Repo
+- `9f16b604b` — Test automation: added tests for LA data flow (#1366)
+- `ba381243c` — Test Automation Framework improvements (#1449)
+- `f32e2eec4` — Testkube workflow migration (#1589)
+- `660ab8547` — Longw/fix conformance test (#1350)

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp@latest"],
+      "env": {
+        "GITHUB_TOKEN": "${input:github_token}"
+      }
+    },
+    "microsoft-docs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/microsoft-docs-mcp@latest"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+## Setup Commands
+
+```bash
+# Clone the repository
+git clone git@github.com:microsoft/Docker-Provider.git
+cd Docker-Provider
+
+# Install Go (1.25+)
+# See https://go.dev/doc/install
+
+# Install Ruby and fluentd for Ruby plugin development
+sudo gem install fluentd -v "1.14.2" --no-document
+sudo gem install ipaddress --no-document
+
+# Install build dependencies (Linux)
+sudo apt-get install build-essential -y
+
+# Build the source code
+cd build/linux && make
+
+# Build Docker image
+cd ../../kubernetes/linux
+docker build . --file Dockerfile.multiarch -t containerinsights:local
+```
+
+## Code Style
+
+### Ruby (`source/plugins/ruby/`)
+- `frozen_string_literal: true` pragma at top of every file
+- `snake_case` for methods and variables, `PascalCase` for class names
+- `@@ClassVariable` for class-level state (e.g., `@@hostName`, `@@CustomProperties`)
+- `require_relative` for local imports, `require` for gems
+- Error handling: `begin/rescue => e` with telemetry logging via `ApplicationInsightsUtility.sendExceptionTelemetry(e)`
+- Logging via custom `@log` (OMS logger)
+
+### Go (`source/plugins/go/`)
+- Standard `gofmt` formatting
+- `camelCase` locals, `PascalCase` exports
+- Error handling: `if err != nil` with telemetry via `SendException(err)`
+- Application Insights via `github.com/microsoft/ApplicationInsights-Go`
+- Fluent Bit plugin API via `github.com/fluent/fluent-bit-go`
+
+### Shell (`scripts/`, `build/`)
+- `#!/bin/bash` shebang
+- `set -e` for error exit
+- `snake_case` for variables and functions
+- Configuration via environment variables
+
+### PowerShell (`scripts/`, `kubernetes/windows/`)
+- `PascalCase` for cmdlet-style function names
+- `$CamelCase` for variables
+
+## Testing Instructions
+
+**Unit tests (CI runs these on every PR to `ci_dev`/`ci_prod`):**
+
+```bash
+# Bash unit tests
+chmod +x test/unit-tests/test_main.sh
+./test/unit-tests/test_main.sh
+
+# Go unit tests
+./test/unit-tests/run_go_tests.sh
+
+# Ruby unit tests (requires fluentd gem installed)
+./test/unit-tests/run_ruby_tests.sh
+```
+
+**Windows PowerShell tests** run on `windows-latest` in CI.
+
+**Ginkgo E2E tests** under `test/ginkgo-e2e/` — separate Go modules per test suite (`containerstatus`, `livenessprobe`, `querylogs`).
+
+**Test file conventions:**
+- Ruby: `*_test.rb` in `source/plugins/ruby/`
+- Go: `*_test.go` alongside source in `source/plugins/go/`
+- Shell: `test/unit-tests/test_cases/*.sh`
+- E2E: `test/ginkgo-e2e/<suite>/` with Go test files
+
+## Dev Environment Tips
+
+- Build primarily targets Linux — use WSL2 or a Linux VM for local development.
+- The project produces a multi-arch Docker image (amd64/arm64) — see `Dockerfile.multiarch`.
+- Key env vars at runtime: `APPLICATIONINSIGHTS_AUTH`, `CONTROLLER_TYPE` (DaemonSet/ReplicaSet), `OS_TYPE`, `CONTAINER_RUNTIME`, `AKS_RESOURCE_ID`, `AKS_REGION`.
+- Helm chart for deployment: `charts/azuremonitor-containers/`.
+
+## Recommended AI Workflow
+
+### Explore → Plan → Code → Commit
+For complex, multi-file changes:
+1. **Explore** — Ask AI to read and explain relevant plugin code first.
+2. **Plan** — Get a structured implementation plan listing all files to change.
+3. **Code** — Implement step by step, verifying each change.
+4. **Test** — Run `./test/unit-tests/test_main.sh` and Go/Ruby tests.
+5. **Commit** — Use descriptive PR title format: `<Brief description> (#PR_NUMBER)`.
+
+### Choosing the Right Tool
+- **Inline suggestions** — Best for Ruby/Go plugin code completion.
+- **Copilot Chat** — Best for understanding data flows, using @agents.
+- **Copilot CLI** — Best for build/test workflows, multi-file changes.
+
+### Validating AI-Generated Code
+1. Run `cd build/linux && make` to verify build.
+2. Run unit tests for affected languages.
+3. Run `trivy fs --severity CRITICAL,HIGH --scanners vuln .` for security.
+4. Verify telemetry follows existing patterns (ApplicationInsightsUtility / TelemetryClient).
+
+## PR Instructions
+
+- **Commit messages:** Descriptive title format, e.g., `Fix CVEs in go modules (#1234)`, `Add support for network flow logs (#1234)`.
+- **Branch naming:** `<author>/<feature-description>` (e.g., `longw/networkflow-rename`).
+- **Default branch:** `ci_prod` (not `main`).
+- **CI checks:** PR build + Trivy scan, CodeQL, DevSkim, unit tests (Bash, Go, Ruby, PowerShell).
+- **Merge strategy:** Squash merge with PR title as commit message.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Cluster"
+        subgraph "DaemonSet (per node)"
+            FB["Fluent Bit<br/>(C - log collection)"]
+            RBPLUGINS["Ruby Fluentd Plugins<br/>(inventory, perf, MDM)"]
+            GOPLUGINS["Go Fluent Bit Plugins<br/>(OMS output, container inventory)"]
+            TELEGRAF["Telegraf<br/>(metrics collection)"]
+        end
+        subgraph "ReplicaSet"
+            RS_FB["Fluent Bit (ReplicaSet)"]
+            RS_RUBY["Ruby Plugins (ReplicaSet)"]
+            RS_GO["Go Plugins (ReplicaSet)"]
+        end
+    end
+    
+    FB --> GOPLUGINS
+    RBPLUGINS --> MDSD["MDSD/Geneva Agent"]
+    GOPLUGINS --> MDSD
+    TELEGRAF --> MDSD
+    MDSD --> LA["Azure Log Analytics"]
+    MDSD --> METRICS["Azure Monitor Metrics"]
+    GOPLUGINS --> |"Application Insights"| AI["App Insights Telemetry"]
+    RBPLUGINS --> |"Application Insights"| AI
+```

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,0 +1,73 @@
+# Docker-Provider (Container Insights)
+
+Azure Monitor Container Insights agent that collects container logs, performance metrics, and Kubernetes inventory from AKS, ARC-enabled, and on-premises Kubernetes clusters.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Log collection | Fluent Bit (C), Fluentd (Ruby plugins) |
+| Metrics collection | Telegraf (Go) |
+| Custom output plugins | Go (Fluent Bit output) |
+| Inventory & MDM plugins | Ruby (Fluentd input/output/filter) |
+| Build system | Make, Docker |
+| Container base | CBL-Mariner 3 |
+| Orchestration | Kubernetes (DaemonSet + ReplicaSet) |
+| Deployment | Helm charts, ARM templates, Bicep, Terraform |
+| Telemetry | Application Insights (Go SDK + Ruby wrapper) |
+| CI/CD | GitHub Actions, Azure Pipelines |
+| Testing | Bash unit tests, Go tests, Ruby tests, Ginkgo E2E, PowerShell Pester |
+
+## Architecture Overview
+
+The agent runs as a DaemonSet (per-node data collection) and a ReplicaSet (cluster-level collection) inside `kube-system`. Fluent Bit collects container stdout/stderr logs, Go plugins process and forward them to MDSD/Geneva. Ruby Fluentd plugins collect Kubernetes inventory, performance counters, and MDM metrics. Telegraf collects host and container metrics.
+
+## Functional Requirements
+### 1) Container log collection via Fluent Bit and Go output plugins
+### 2) Kubernetes inventory collection (pods, nodes, containers, deployments, HPAs)
+### 3) Performance metric collection via CAdvisor API and Telegraf
+### 4) MDM metric generation for alerting
+### 5) Multi-cloud support (AKS, ARC, on-premises)
+
+## Non-Functional Requirements
+- High reliability in production Kubernetes clusters
+- Low resource footprint (CPU/memory limits enforced)
+- Security: non-root containers, Trivy scanning, CodeQL SAST
+- Telemetry: Application Insights for agent health monitoring
+- Multi-architecture support (amd64, arm64)
+
+## Expected Project Files
+
+| Path | Purpose |
+|------|---------|
+| `source/plugins/go/src/` | Go Fluent Bit output plugins |
+| `source/plugins/go/input/` | Go Fluent Bit input plugins |
+| `source/plugins/ruby/` | Ruby Fluentd plugins |
+| `build/linux/` | Linux build system (Makefile) |
+| `kubernetes/linux/` | Linux Dockerfile and configs |
+| `kubernetes/windows/` | Windows Dockerfile and configs |
+| `charts/` | Helm charts |
+| `deployment/` | ARM, Bicep, Terraform templates |
+| `test/` | Unit tests, E2E tests, test automation |
+| `scripts/` | Utility and operational scripts |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `APPLICATIONINSIGHTS_AUTH` | App Insights instrumentation key |
+| `APPLICATIONINSIGHTS_ENDPOINT` | App Insights endpoint URL |
+| `CONTROLLER_TYPE` | DaemonSet or ReplicaSet |
+| `OS_TYPE` | linux or windows |
+| `AKS_RESOURCE_ID` | AKS cluster resource ID |
+| `AKS_REGION` | AKS cluster region |
+| `CONTAINER_RUNTIME` | Container runtime (docker, containerd) |
+| `AAD_MSI_AUTH_MODE` | Authentication mode |
+
+## Acceptance Criteria
+
+- `cd build/linux && make` succeeds
+- All unit tests pass (Bash, Go, Ruby, PowerShell)
+- Trivy scan shows no new CRITICAL/HIGH CVEs
+- CodeQL and DevSkim produce no new findings
+- Docker image builds successfully

--- a/coding-agent-instructions.md
+++ b/coding-agent-instructions.md
@@ -1,0 +1,201 @@
+# Coding Agent Instructions
+
+This document explains how to use the AI coding agent artifacts generated for the Docker-Provider (Container Insights) repository.
+
+## Quick Start
+
+1. Open this repository in VS Code with Copilot enabled.
+2. `copilot-instructions.md` loads automatically every session — no action needed.
+3. When you open a `.go`, `.rb`, `.sh`, or `.py` file, the matching `.instructions.md` auto-activates.
+4. Invoke skills by typing trigger phrases: "add test", "fix bug", "security review".
+5. Invoke agents via @-mention: `@CodeReviewer`, `@DocumentWriter`, `@SecurityReviewer`.
+
+## Generated Artifacts Overview
+
+| Artifact | Path | Loaded | Purpose |
+|----------|------|--------|---------|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Automatically | Root router — build commands, conventions, gotchas |
+| `AGENTS.md` | Root | Automatically | Setup, code style, testing, dev environment, AI workflow |
+| `.instructions.md` files | `.github/instructions/` | Auto on file match | Language-specific coding rules (Go, Ruby, Shell, Python) |
+| `Prompt.md` | Root | On demand | Reusable task-spec template |
+| Skill files (`SKILL.md`) | `.github/skills/` | On keyword trigger | Step-by-step guides for recurring tasks |
+| `CodeReviewer.agent.md` | `.github/agents/` | On @-mention | Structured code review with STRIDE security |
+| `SecurityReviewer.agent.md` | `.github/agents/` | On @-mention | Deep security analysis and threat modeling |
+| `ThreatModelAnalyst.agent.md` | `.github/agents/` | On @-mention | STRIDE threat models with Mermaid diagrams |
+| `DocumentWriter.agent.md` | `.github/agents/` | On @-mention | Documentation following repo conventions |
+| `prd.agent.md` | `.github/agents/` | On @-mention | PRD generation for this project |
+| `test/AGENTS.md` | `test/AGENTS.md` | Automatically | Test framework guide and decision tree |
+| `.vscode/mcp.json` | `.vscode/mcp.json` | Automatically | MCP server connections (GitHub, Microsoft Docs) |
+
+## How the Context Loading Chain Works
+
+```
+Layer 1: copilot-instructions.md (always loaded)
+  ├── Build commands, conventions, known gotchas
+  ├── Routes to →
+  │
+Layer 2: .instructions.md files (auto-loaded when you open matching files)
+  ├── go.instructions.md → *.go files
+  ├── ruby.instructions.md → *.rb files
+  ├── shell.instructions.md → *.sh files
+  ├── python.instructions.md → *.py files
+  │
+Layer 3: Skills (loaded only when invoked by trigger phrase)
+  └── Step-by-step procedures for specific tasks
+```
+
+## Using Custom Agents
+
+### @CodeReviewer
+- **Invoke:** `@CodeReviewer` in Copilot Chat.
+- **What it does:** Reviews PRs for correctness, code style, security (STRIDE), telemetry gaps, and test coverage.
+- **Example prompts:**
+  - `@CodeReviewer review this PR`
+  - `@CodeReviewer check this file for security issues`
+  - `@CodeReviewer review changes for telemetry gaps`
+
+### @SecurityReviewer
+- **Invoke:** `@SecurityReviewer` in Copilot Chat.
+- **What it does:** Deep STRIDE security analysis, attack surface review, dependency audit.
+- **Example prompts:**
+  - `@SecurityReviewer perform a threat model for the Go output plugin`
+  - `@SecurityReviewer review the Dockerfile security configuration`
+  - `@SecurityReviewer assess the authentication changes`
+
+### @ThreatModelAnalyst
+- **Invoke:** `@ThreatModelAnalyst` in Copilot Chat.
+- **What it does:** Generates persistent threat model artifacts under `threat-model/YYYY-MM-DD/`.
+- **Example prompts:**
+  - `@ThreatModelAnalyst perform a full threat model analysis`
+  - `@ThreatModelAnalyst threat model the log ingestion pipeline`
+
+### @DocumentWriter
+- **Invoke:** `@DocumentWriter` in Copilot Chat.
+- **What it does:** Creates/maintains documentation following repo conventions.
+- **Example prompts:**
+  - `@DocumentWriter write release notes for v3.1.36`
+  - `@DocumentWriter update the README with new features`
+
+### @prd (PRD Generator)
+- **Invoke:** `@prd` in Copilot Chat.
+- **What it does:** Generates structured PRDs tailored to Docker-Provider architecture.
+- **Example prompts:**
+  - `@prd create a PRD for adding OpenTelemetry trace support`
+
+## Using Skills
+
+| Skill | Trigger Phrases | What It Does |
+|-------|----------------|--------------|
+| `security-review` | "security review", "STRIDE analysis", "credential leak check" | STRIDE-based security review |
+| `telemetry-authoring` | "add telemetry", "add metrics", "instrument code" | Add Application Insights telemetry |
+| `fix-critical-vulnerabilities` | "fix CVE", "trivy fix", "patch vulnerability" | Fix CRITICAL/HIGH CVEs using Trivy |
+| `bug-fix` | "fix bug", "resolve issue", "hotfix" | Structured bug fix workflow |
+| `dependency-update` | "update dependency", "bump package", "upgrade" | Safe dependency updates |
+| `feature-development` | "add feature", "implement", "new support" | New feature scaffolding |
+| `test-authoring` | "add test", "write test", "test coverage" | Test creation following conventions |
+| `ci-cd-pipeline` | "pipeline change", "CI fix", "workflow update" | CI/CD modifications |
+| `infrastructure` | "Terraform update", "Helm chart", "Bicep template" | IaC and deployment changes |
+| `documentation` | "release notes", "readme update", "doc update" | Documentation updates |
+
+## Prompt Engineering Best Practices
+
+### Structuring Effective Prompts
+1. **Break complex tasks into smaller prompts** — "Add error telemetry to `in_kube_nodes.rb`" not "refactor all Ruby plugins".
+2. **Be specific** — Reference file paths: `source/plugins/go/src/oms.go`, function names: `FLBPluginFlush`.
+3. **Provide examples** — "Parse container log lines like `2024-01-15T10:30:00Z stdout F log message`".
+4. **State constraints** — "Using Go 1.25, follow the existing ApplicationInsights-Go pattern".
+5. **Ask for explanations** — "Explain the Fluent Bit plugin flush lifecycle before implementing".
+
+### Anti-Patterns
+- Vague requests without specifying the component or file.
+- Asking for multiple unrelated changes in one prompt.
+- Skipping validation — always run tests after changes.
+
+## Choosing the Right Copilot Tool
+
+| Task | Best Tool | Why |
+|------|-----------|-----|
+| Code completion | **Inline suggestions** | Fast for Go/Ruby boilerplate |
+| Questions about code | **Copilot Chat** | Context-aware, supports @agents |
+| Multi-file changes | **Copilot CLI** | Terminal-native, autonomous |
+| Code review | **@CodeReviewer** | Repo-specific review checklist |
+| Async work | **Coding agent (`/delegate`)** | Creates PRs without blocking |
+
+## Context Management
+
+1. **Open relevant files** before prompting — Copilot uses open tabs.
+2. **Close unrelated files** — too many tabs dilute AI focus.
+3. **Start fresh** for new tasks — new chat session resets context.
+4. **Use @-references** — `#file:source/plugins/go/src/oms.go` for precision.
+
+## Recommended Workflow: Explore → Plan → Code → Commit
+
+1. **Explore** — `"Read the container log collection pipeline and explain how logs flow from Fluent Bit to Azure Monitor"`
+2. **Plan** — `"/plan Add network flow log support to the Go output plugin"`
+3. **Code** — `"Implement step 1: add the network flow log data structure"`
+4. **Test** — `"Run ./test/unit-tests/run_go_tests.sh and fix failures"`
+5. **Commit** — `"Commit with descriptive message"`
+
+| Use this workflow for | Skip for |
+|----------------------|----------|
+| New feature implementations | Quick bug fixes |
+| Multi-file refactoring | Single file edits |
+| Architecture changes | Doc-only updates |
+
+## Validating AI-Generated Code
+
+1. **Understand** the code — ask AI to explain if unclear.
+2. **Build** — `cd build/linux && make`
+3. **Test** — Run unit tests for affected languages.
+4. **Scan** — `trivy fs --severity CRITICAL,HIGH --scanners vuln .`
+5. **Security** — No hardcoded secrets, proper env var usage.
+6. **Match patterns** — Compare against similar existing code.
+
+## Test-Driven Development with AI
+
+1. Write failing tests first: `"Write a Go test for a new container restart detection function"`
+2. Review tests, approve edge cases.
+3. Implement: `"Write code to make all tests pass"`
+4. Refactor while keeping tests green.
+
+## Codebase Onboarding with AI
+
+- "How does container log collection work from Fluent Bit through Go plugins to MDSD?"
+- "What's the pattern for adding a new Ruby Fluentd input plugin?"
+- "Explain the ApplicationInsightsUtility telemetry pattern"
+- "Where are the Kubernetes RBAC definitions for the DaemonSet?"
+- "What environment variables control the agent's behavior?"
+
+## Security When Using AI Assistants
+
+- Never commit secrets — verify no `APPLICATIONINSIGHTS_AUTH` values or tokens in code.
+- Review all changes — AI can miss security patterns specific to this agent.
+- Run security scanners after changes: Trivy, CodeQL.
+- Don't share credentials via prompts.
+
+## Measuring AI-Assisted Productivity
+
+- Time from issue to pull request
+- Review iteration count on AI-assisted PRs
+- Test coverage improvements
+- Bug rate in AI-assisted code
+- Developer satisfaction with AI workflows
+
+## Customizing These Artifacts
+
+- Add rules to `.instructions.md` when establishing new conventions.
+- Add skills when identifying new recurring workflows.
+- Update `copilot-instructions.md` when build commands change.
+- Update `AGENTS.md` when setup or test strategies change.
+- Re-run generation quarterly to refresh skills from commit patterns.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| AI doesn't follow conventions | Verify `.instructions.md` `applyTo` matches the file type |
+| Skill not activating | Use exact trigger phrases from the skill table |
+| Agent not available | Ensure `.agent.md` is in `.github/agents/` |
+| MCP server not connecting | Check `.vscode/mcp.json` and provide credentials |
+| Build commands fail | Update Setup Commands in `AGENTS.md` |
+| Context feels stale | Start a new chat session |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,67 @@
+# Test Framework Guide
+
+## Test Decision Tree
+
+When adding tests, use this decision tree:
+
+1. **Go plugin logic (no external dependencies)?** → Go unit test with `testify` in `source/plugins/go/src/*_test.go`
+2. **Go input plugin logic?** → Go unit test in `source/plugins/go/input/**/*_test.go`
+3. **Ruby Fluentd plugin logic?** → Ruby test in `source/plugins/ruby/*_test.rb`
+4. **Shell script behavior?** → Shell test in `test/unit-tests/test_cases/*.sh`
+5. **PowerShell script behavior?** → Pester test (v5.3.3)
+6. **End-to-end cluster behavior?** → Ginkgo E2E in `test/ginkgo-e2e/<suite>/`
+7. **Data pipeline validation?** → Python E2E in `test/e2e/`
+8. **Kubernetes scenario testing?** → TestKube workflows in `test/testkube/`
+
+## Test Patterns in This Repo
+
+### Unit Tests
+
+**Go:**
+- Framework: `testify` (assert, require)
+- Mocking: `golang/mock`
+- Location: `source/plugins/go/src/*_test.go`, `source/plugins/go/input/**/*_test.go`
+- Naming: `TestFunctionName` in `*_test.go` files
+- Runner: `./test/unit-tests/run_go_tests.sh`
+- Flags: `-cover -race -coverprofile=coverage.txt`
+
+**Ruby:**
+- Location: `source/plugins/ruby/*_test.rb`
+- Dependencies: `fluentd` gem v1.14.2
+- Runner: `./test/unit-tests/run_ruby_tests.sh`
+
+**Shell:**
+- Framework: Custom (`test/unit-tests/test_framework.sh`)
+- Test cases: `test/unit-tests/test_cases/*.sh`
+- Runner: `./test/unit-tests/test_main.sh`
+
+**PowerShell:**
+- Framework: Pester v5.3.3
+- Runner: CI runs on `windows-latest`
+
+### E2E Tests
+
+**Ginkgo (Go):**
+- Framework: `onsi/ginkgo/v2`, `onsi/gomega`
+- Suites: `test/ginkgo-e2e/querylogs/`, `test/ginkgo-e2e/containerstatus/`, `test/ginkgo-e2e/livenessprobe/`
+- Each suite has its own `go.mod`
+- Naming: `*_test.go` with `Describe`/`It` blocks
+
+**Python:**
+- Framework: `pytest`
+- Location: `test/e2e/`
+- Uses Kubernetes Python client
+
+**TestKube:**
+- Location: `test/testkube/`
+- Workflow-based test execution
+
+## Common Test Utilities
+- `test/ginkgo-e2e/utils/` — Shared Go test utilities (separate `go.mod`)
+- `test/unit-tests/test_framework.sh` — Shell test assertion framework
+- `test/unit-tests/test_functions/` — Shared Shell test helpers
+
+## Test Data
+- Test configuration files in `test/unit-tests/` directories
+- Kubernetes scenario manifests in `test/scenario/`
+- Conformance test images referenced in CI


### PR DESCRIPTION
Auto-generated AI agent artifacts for coding assistants.

## Generated Files (25 files)

### Core Files
- `.github/copilot-instructions.md` — Root router with build commands, conventions, gotchas
- `AGENTS.md` — Setup commands, code style, testing instructions, dev environment
- `Prompt.md` — Reusable task-spec template
- `coding-agent-instructions.md` — Comprehensive usage guide for all artifacts

### Instruction Files (.github/instructions/)
- `go.instructions.md` — Go coding conventions (applyTo: **/*.go)
- `ruby.instructions.md` — Ruby conventions (applyTo: **/*.rb)
- `shell.instructions.md` — Shell conventions (applyTo: **/*.sh)
- `python.instructions.md` — Python conventions (applyTo: **/*.py)

### Skills (.github/skills/) — 10 skills
- `bug-fix`, `dependency-update`, `feature-development`, `ci-cd-pipeline`
- `test-authoring`, `infrastructure`, `documentation`
- `security-review` (always generated — STRIDE-based)
- `telemetry-authoring` (always generated — Application Insights patterns)
- `fix-critical-vulnerabilities` (always generated — Trivy/CodeQL)

### Agents (.github/agents/) — 5 agents
- `CodeReviewer.agent.md` — Structured code review with STRIDE security
- `SecurityReviewer.agent.md` — Deep security analysis
- `ThreatModelAnalyst.agent.md` — STRIDE threat models with Mermaid diagrams
- `DocumentWriter.agent.md` — Documentation authoring
- `prd.agent.md` — PRD generation

### Other
- `.vscode/mcp.json` — MCP server config (GitHub, Microsoft Docs)
- `test/AGENTS.md` — Test framework guide and decision tree

Review before merging.