### PR TITLE
ama-logs deployment and test in dev clusters

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -12,6 +12,9 @@ variables:
   subscription: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
   containerRegistry: 'containerinsightsprod'
   repoImageName: '${{ variables.containerRegistry }}.azurecr.io/public/azuremonitor/containerinsights/cidev'
+  # Default image repository path for CI builds. Override when queuing pipeline with pre-built ciprod images.
+  # Set to '/azuremonitor/containerinsights/ciprod' when using LinuxImageOverride/WindowsImageOverride with prod images.
+  ImageRepositoryOverride: '/azuremonitor/containerinsights/ciprod'
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
   IS_MAIN_BRANCH: $[eq(variables['Build.SourceBranchName'], 'ci_prod')]
   IS_RELEASE: $[ne(variables['TELEMETRY_TAG'], '')]
@@ -42,842 +45,981 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    - stage: stage
+    # This stage will be skipped when LinuxImageOverride and WindowsImageOverride are both set
+    # This feature allows bypassing the build stage when using pre-built images for testing, which saves time and resources.
+    # - stage: stage
+    #   displayName: 'Build and Publish Container Images'
+    #   condition: |
+    #     or(
+    #       eq(variables['LinuxImageOverride'], ''),
+    #       eq(variables['WindowsImageOverride'], '')
+    #     )
+    #   jobs:
+    #   - job: common
+    #     pool:
+    #       name: Azure-Pipelines-CI-Test-EO
+    #       image: ci-1es-managed-ubuntu-2204
+    #       os: linux
+    #     variables:
+    #       skipComponentGovernanceDetection: true
+    #       Codeql.SkipTaskAutoInjection: true
+    #     templateContext:
+    #       outputs:
+    #       - output: pipelineArtifact
+    #         targetPath: '$(Build.ArtifactStagingDirectory)'
+    #         artifactName: drop
+    #     steps:
+    #     - task: ComponentGovernanceComponentDetection@0
+    #     - bash: |
+    #         commit=$(git describe)
+    #         datetime=$(date +%Y%m%d%H%M%S)
+    #         linuxImagetag="$commit"-"$datetime"
+    #         windowsImageTag=win-"$commit"-"$datetime"
+    #         telemetryTag=$linuxImagetag
+    #         if [ -z "$TELEMETRY_TAG" ]
+    #           then
+    #             echo "\$TELEMETRY_TAG variable is not set"
+    #           else
+    #             telemetryTag=$TELEMETRY_TAG
+    #             echo "\$TELEMETRY_TAG is $TELEMETRY_TAG"
+    #         fi
+    #         linuxTelemetryTag="$telemetryTag"
+    #         windowsTelemetryTag=win-"$telemetryTag"
+    #         echo "linuxImagetag is $linuxImagetag"
+    #         echo "windowsImageTag is $windowsImageTag"
+    #         echo "linuxTelemetryTag is $linuxTelemetryTag"
+    #         echo "windowsTelemetryTag is $windowsTelemetryTag"
+    #         echo "##vso[task.setvariable variable=linuxImagetag;isOutput=true]$linuxImagetag"
+    #         echo "##vso[task.setvariable variable=windowsImageTag;isOutput=true]$windowsImageTag"
+    #         echo "##vso[task.setvariable variable=linuxTelemetryTag;isOutput=true]$linuxTelemetryTag"
+    #         echo "##vso[task.setvariable variable=windowsTelemetryTag;isOutput=true]$windowsTelemetryTag"
+    #         echo "appRegistrationClientId is $APP_REGISTRATION_CLIENT_ID"
+    #         echo "appRegistrationTenantId is $APP_REGISTRATION_TENANT_ID"
+    #         echo "authAKVName is $AUTH_AKV_NAME"
+    #         echo "authCertName is $AUTH_CERT_NAME"
+    #         echo "authSignCertName is $AUTH_SIGN_CERT_NAME"
+    #         cd $(Build.SourcesDirectory)/deployment/mergebranch-multiarch-agent-deployment/ServiceGroupRoot/Scripts
+    #         tar -czvf ../artifacts.tar.gz pushAgentToAcr.sh
+    #         cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension/ServiceGroupRoot/Scripts
+    #         tar -czvf ../artifacts.tar.gz ../../../../charts/azuremonitor-containers/ pushChartToAcr.sh
+    #         cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
+    #         tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
+    #         windowsAMAUrl=""
+    #         if [ -z "$WINDOWS_AMA_URL" ]
+    #           then
+    #             echo "\$WINDOWS_AMA_URL variable is not set"
+    #           else
+    #             windowsAMAUrl=$WINDOWS_AMA_URL
+    #             echo "\$WINDOWS_AMA_URL is $WINDOWS_AMA_URL"
+    #         fi
+    #         echo "##vso[task.setvariable variable=windowsAMAUrl;isOutput=true]$windowsAMAUrl"
+    #       name: setup
+    #     - task: CredScan@3
+    #       displayName: "SDL : Run credscan"
+    #     - task: CopyFiles@2
+    #       displayName: "Copy ev2 deployment artifacts"
+    #       inputs:
+    #         SourceFolder: "$(Build.SourcesDirectory)/deployment"
+    #         Contents: |
+    #           **/*
+    #           !**/ScanTelemetry_*.json
+    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+    #     - task: CopyFiles@2
+    #       displayName: "Copy ev2 deployment scripts"
+    #       inputs:
+    #         SourceFolder: "$(Build.SourcesDirectory)/.pipelines"
+    #         Contents: |
+    #           **/*.sh
+    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+    #     - task: CopyFiles@2
+    #       displayName: "Copy ev2 deployment scripts"
+    #       inputs:
+    #         SourceFolder: "$(Build.SourcesDirectory)/kubernetes"
+    #         Contents: |
+    #           *.yaml
+    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+    #     - task: CopyFiles@2
+    #       displayName: "Copy ev2 deployment scripts"
+    #       inputs:
+    #         SourceFolder: "$(Build.SourcesDirectory)/charts"
+    #         Contents: |
+    #           **/*
+    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+    #     - task: CopyFiles@2
+    #       displayName: "Copy ev2 deployment scripts"
+    #       inputs:
+    #         SourceFolder: "$(Build.SourcesDirectory)/test/e2e"
+    #         Contents: |
+    #           *.yaml
+    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+    #     - task: Armory@2
+    #       displayName: 'Run ARMory'
+    #       inputs:
+    #         toolVersion: Latest
+    #         targetDirectory: '$(Build.SourcesDirectory)'
+    #   - job: build_linux
+    #     timeoutInMinutes: 120
+    #     dependsOn: common
+    #     variables:
+    #       linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
+    #       linuxTelemetryTag: $[ dependencies.common.outputs['setup.linuxTelemetryTag'] ]
+    #       Codeql.Enabled: true
+    #       Codeql.BuildIdentifier: 'linuxbuild'
+    #       DOCKER_BUILDKIT: 1
+    #     templateContext:
+    #       outputs:
+    #       - output: pipelineArtifact
+    #         targetPath: '$(Build.ArtifactStagingDirectory)'
+    #         artifactName: linux-drop
+    #     steps:
+    #     - task: CodeQL3000Init@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #     - task: AzureCLI@2
+    #       displayName: "Multi-arch Linux build"
+    #       inputs:
+    #         azureSubscription: ${{ variables.armServiceConnectionName }}
+    #         scriptType: bash
+    #         scriptLocation: inlineScript
+    #         inlineScript: |
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/linux
+    #           sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
+    #           docker system prune --all -f
+    #           docker images -q --filter "dangling=true" | xargs docker rmi
+    #           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    #           docker buildx create --name testbuilder
+    #           docker buildx use testbuilder
+    #           az --version
+    #           az account show
+    #           az account set -s ${{ variables.subscription }}
+    #           az acr login -n ${{ variables.containerRegistry }}
+    #           # NOTE: Using the prometheus-collector team's cached buildx image since moby/buildkit:buildx-stable-1 getting throttled
+    #           docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
+    #           docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
+    #           docker buildx inspect --bootstrap
+    #           # Determine if we should push to ACR
+    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+    #           SHOULD_PUSH="false"
+    #           if [ "$(Build.Reason)" != "PullRequest" ]; then
+    #             SHOULD_PUSH="true"
+    #           elif [[ "$(System.PullRequest.SourceBranch)" == "zane/ci-agent-auto-deploy" ]] || [[ "$(System.PullRequest.SourceBranch)" == *"run-e2e"* ]]; then
+    #             SHOULD_PUSH="true"
+    #             echo "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+    #           fi
+              
+    #           if [ "$SHOULD_PUSH" == "true" ]; then
+    #             docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .
+    #             echo "##vso[task.logissue type=warning]Linux image built with tag: ${{ variables.repoImageName }}:$(linuxImagetag)"
+    #             docker pull ${{ variables.repoImageName }}:$(linuxImagetag)
+    #           else
+    #             docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --provenance=false .
+    #             # load the multi-arch image to run tests
+    #             docker buildx build --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --load --provenance=false .
+    #           fi
+    #     - bash: |
+    #         curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
+    #         mkdir -p oras-install/
+    #         tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
+    #         sudo mv oras-install/oras /usr/local/bin/
+    #         rm -rf oras_1.0.0_*.tar.gz oras-install/
+    #         TARGET_ARTIFACT=$(oras manifest fetch ${{ variables.repoImageName }}:$(linuxImagetag) --descriptor)
+    #         cat <<EOF >>$(Build.ArtifactStagingDirectory)/linux/payload.json
+    #         {"targetArtifact":$TARGET_ARTIFACT}
+    #         EOF
+    #         cat $(Build.ArtifactStagingDirectory)/linux/payload.json
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+    #       displayName: "Install oras and build the payload json file"
+    #       condition: eq(variables.IS_PR, false)
+    #     - task: EsrpCodeSigning@5
+    #       condition: eq(variables.IS_PR, false)
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/linux'
+    #         Pattern: 'payload.json'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                       {
+    #                           "keyCode": "CP-469451",
+    #                           "operationSetCode": "NotaryCoseSign",
+    #                           "parameters": [
+    #                             {
+    #                               "parameterName": "CoseFlags",
+    #                               "parameterValue": "chainunprotected"
+    #                             }
+    #                           ],
+    #                           "toolName": "sign",
+    #                           "toolVersion": "1.0"
+    #                       }
+    #                     ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #         PendingAnalysisWaitTimeoutMinutes: '5'
+    #       displayName: 'Esrp Image Signing for linux image'
+    #     - bash: |
+    #         set -euxo pipefail
+    #         oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
+    #           --artifact-type 'application/vnd.cncf.notary.signature' \
+    #           ./payload.json:application/cose \
+    #           -a "io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]"
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+    #       displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
+    #       condition: eq(variables.IS_PR, false)
+    #     - bash: |
+    #         set -euxo pipefail
+    #         oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
+    #             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+    #             --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+    #       displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
+    #       condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
+    #     - task: AzureCLI@2
+    #       displayName: "Vulnerability Scan with Trivy"
+    #       inputs:
+    #         azureSubscription: ${{ variables.armServiceConnectionName }}
+    #         scriptType: bash
+    #         scriptLocation: inlineScript
+    #         inlineScript: |
+    #           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+    #           PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
+    #           SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
+    #           PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
+    #           SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
+    #           # Set initial repositories to primary
+    #           export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY
+    #           export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
+    #           # Function to run Trivy scan and handle output
+    #           run_trivy_scan() {
+    #               trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+    #               return $?
+    #           }
+    #           # Attempt scan up to 5 times with repository fallback
+    #           for i in {1..5}; do
+    #               echo "Running Trivy scan attempt $i"
+    #               # Run the Trivy scan and capture exit code
+    #               run_trivy_scan
+    #               TRIVY_EXIT_CODE=$?
+    #               # Check if scan was successful
+    #               if [ $TRIVY_EXIT_CODE -eq 0 ]; then
+    #                   echo "Trivy scan succeeded."
+    #                   cat trivy_output.log
+    #                   break
+    #               fi
+    #               # If the first attempt fails, switch to secondary repositories
+    #               if [ $i -eq 1 ]; then
+    #                   echo "Primary repositories failed with an error. Switching to secondary repositories."
+    #                   export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY
+    #                   export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY
+    #               fi
+    #               # Log and wait before retrying if an error occurred
+    #               echo "Error: Trivy scan attempt $i failed. Retrying ($i/5)"
+    #               cat trivy_output.log
+    #               sleep 5 # Wait 5 seconds before retrying
+    #           done
+    #           # Final check: if still failing after 5 attempts, exit with error
+    #           if [ $TRIVY_EXIT_CODE -ne 0 ]; then
+    #               echo "Error: Trivy scan failed after 5 retries."
+    #               exit 1
+    #           fi
+    #     - task: GoTool@0
+    #       inputs:
+    #         version: '1.23.8'
+    #     - bash: |
+    #         cd $(System.DefaultWorkingDirectory)/build/linux/
+    #         ls
+    #         make
+    #       displayName: 'Execute Makefile for Linux Build'
+    #     - task: CodeQL3000Finalize@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    #       displayName: 'Generation Task'
+    #       condition: eq(variables.IS_PR, false)
+    #       inputs:
+    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
+    #         DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+    #     - bash: |
+    #         dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+    #         echo "Docker images to scan: $dockerImagesToScan"
+    #         echo "##vso[task.setvariable variable=dockerImagesToScan]$dockerImagesToScan"
+    #       displayName: 'Set Docker images to scan'
+    #   - job: build_windows_2019
+    #     pool:
+    #       name: Azure-Pipelines-CI-Test-EO
+    #       image: ci-1es-managed-windows-2022
+    #       os: windows
+    #     timeoutInMinutes: 120
+    #     dependsOn:
+    #     - common
+    #     variables:
+    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+    #       windows2019BaseImageVersion: ltsc2019
+    #       Codeql.Enabled: true
+    #       Codeql.BuildIdentifier: 'windowsbuild'
+    #       windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
+    #     steps:
+    #     - task: PowerShell@2
+    #       inputs:
+    #         targetType: 'filePath'
+    #         filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    #       displayName: 'install prereqs'
+    #     - task: CodeQL3000Init@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #     - script: |
+    #         setlocal enabledelayedexpansion
+    #         powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+    #         endlocal
+    #         exit /B %ERRORLEVEL%
+    #       displayName: 'build base'
+    #     - task: AzureCLI@2
+    #       displayName: "Set up acr for windows ltsc2019 build"
+    #       inputs:
+    #         azureSubscription: ${{ variables.armServiceConnectionName }}
+    #         scriptType: ps
+    #         scriptLocation: inlineScript
+    #         retryCountOnTaskFailure: 2
+    #         inlineScript: |
+    #           az --version
+    #           az account show
+    #           az account set -s ${{ variables.subscription }}
+    #           az acr login -n ${{ variables.containerRegistry }}
+    #     - task: PowerShell@2          
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           # Check if directory exists and remove it before creating it to handle retry scenarios
+    #           if (Test-Path -Path "$(Build.ArtifactStagingDirectory)/windows") {
+    #             Remove-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -Recurse -Force
+    #           }
+    #           New-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -ItemType Directory -Force
+    #           cd kubernetes/windows
+    #           # Build the Docker image
+    #           docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
+    #       displayName: "Docker windows build for ltsc2019"
+    #       retryCountOnTaskFailure: 2
+    #     - task: PowerShell@2
+    #       displayName: Extract files to sign
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           echo "Creating docker container"
+    #           docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
+    #           echo "Creating fist party directory"
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
+    #           cd $(Build.ArtifactStagingDirectory)/fpSigning
+    #           echo "Extract CertificateGenerator"
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
+    #           echo "Extract LivenessProbe"
+    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
+    #           echo "Extract ps scripts"
+    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
+    #           echo "Creating OSS directory"
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
+    #           cd $(Build.ArtifactStagingDirectory)/ossSigning
+    #           echo "Extract CertificateGenerator"
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
+    #           echo "Extract fluent-bit"
+    #           docker cp signingContainer:C:\opt\fluent-bit .
+    #           echo "Extract Ruby"
+    #           docker cp signingContainer:C:\ruby31 .
+    #           echo "Extract telegraf"
+    #           docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
+    #           echo "Extract out oms"
+    #           docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
+    #           echo "Extract containerinventory.so"
+    #           docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
+    #           echo "Extract perf.so"
+    #           docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
+    #           echo "Removing container"
+    #           docker rm signingContainer
+    #           echo "List ArtifactStagingDirectory"
+    #           ls $(Build.ArtifactStagingDirectory)
+    #           ls .
+    #     - script: dir $(System.DefaultWorkingDirectory)
+    #       displayName: 'List files in DefaultWorking Directory'
+    #     - script: dir $(Build.ArtifactStagingDirectory)
+    #       displayName: 'List files in Staging Directory'
+    #     - task: EsrpCodeSigning@5
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
+    #         Pattern: '*.dll,*.exe,*.so,*.ps1'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                   {
+    #                       "KeyCode" : "CP-230012",
+    #                       "OperationCode" : "SigntoolSign",
+    #                       "Parameters" : {
+    #                           "OpusName" : "Microsoft",
+    #                           "OpusInfo" : "http://www.microsoft.com",
+    #                           "FileDigest" : "/fd \"SHA256\"",
+    #                           "PageHash" : "/NPH",
+    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #                       },
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   },
+    #                   {
+    #                       "KeyCode" : "CP-230012",
+    #                       "OperationCode" : "SigntoolVerify",
+    #                       "Parameters" : {},
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   }
+    #               ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #       displayName: 'EsrpCodeSigning for first party'
+    #     - task: EsrpCodeSigning@5
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
+    #         Pattern: '*.dll,*.exe,*.so'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                   {
+    #                       "KeyCode" : "CP-231522",
+    #                       "OperationCode" : "SigntoolSign",
+    #                       "Parameters" : {
+    #                           "OpusName" : "Microsoft",
+    #                           "OpusInfo" : "http://www.microsoft.com",
+    #                           "Append" : "/as",
+    #                           "FileDigest" : "/fd \"SHA256\"",
+    #                           "PageHash" : "/NPH",
+    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #                       },
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   },
+    #                   {
+    #                       "KeyCode" : "CP-231522",
+    #                       "OperationCode" : "SigntoolVerify",
+    #                       "Parameters" : {},
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   }
+    #               ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #       displayName: 'EsrpCodeSigning for OSS'
+    #     - task: BinSkim@4
+    #       displayName: 'SDL: run binskim'
+    #       inputs:
+    #         InputType: 'CommandLine'
+    #         arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
+    #       retryCountOnTaskFailure: 1
+    #     - task: PoliCheck@2
+    #       displayName: "SDL : Run PoliCheck"
+    #       inputs:
+    #         targetType: 'F'
+    #         targetArgument: '$(Build.SourcesDirectory)'
+    #     - task: PowerShell@2
+    #       displayName: Replace files in origin Image
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
+    #           echo "Copy Signed binaries/folders back to docker image"
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
+    #           docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+    #           docker rm pushContainer
+    #     - task: PowerShell@2
+    #       displayName: Push Docker Image
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+    #           $shouldPush = $false
+    #           if ("$(Build.Reason)" -ne "PullRequest") {
+    #             $shouldPush = $true
+    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+    #             $shouldPush = $true
+    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+    #           }
+              
+    #           if ($shouldPush) {
+    #             docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+    #           }
+    #     - task: CodeQL3000Finalize@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #   - job: build_windows_2022
+    #     pool:
+    #       name: Azure-Pipelines-CI-Test-EO
+    #       image: ci-1es-managed-windows-2022
+    #       os: windows
+    #     timeoutInMinutes: 120
+    #     dependsOn:
+    #     - common
+    #     variables:
+    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+    #       windows2022BaseImageVersion: ltsc2022
+    #       Codeql.SkipTaskAutoInjection: true
+    #       windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
+    #     steps:
+    #     - task: PowerShell@2
+    #       inputs:
+    #         targetType: 'filePath'
+    #         filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+    #       displayName: 'install prereqs'
+    #     - task: CodeQL3000Init@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #     - script: |
+    #         setlocal enabledelayedexpansion
+    #         powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+    #         endlocal
+    #         exit /B %ERRORLEVEL%
+    #       displayName: 'build base'
+    #     - task: AzureCLI@2
+    #       displayName: "Docker windows build for ltsc2022"
+    #       inputs:
+    #         azureSubscription: ${{ variables.armServiceConnectionName }}
+    #         scriptType: ps
+    #         scriptLocation: inlineScript
+    #         retryCountOnTaskFailure: 2
+    #         inlineScript: |
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/windows
+    #           cd kubernetes/windows
+    #           az --version
+    #           az account show
+    #           az account set -s ${{ variables.subscription }}
+    #           az acr login -n ${{ variables.containerRegistry }}
+    #           docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
+    #     - task: PowerShell@2
+    #       displayName: Extract files to sign
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           echo "Creating docker container"
+    #           docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
+    #           echo "Creating fist party directory"
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
+    #           cd $(Build.ArtifactStagingDirectory)/fpSigning
+    #           echo "Extract CertificateGenerator"
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
+    #           echo "Extract LivenessProbe"
+    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
+    #           echo "Extract ps scripts"
+    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
+    #           echo "Creating OSS directory"
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
+    #           cd $(Build.ArtifactStagingDirectory)/ossSigning
+    #           echo "Extract CertificateGenerator"
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
+    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
+    #           echo "Extract fluent-bit"
+    #           docker cp signingContainer:C:\opt\fluent-bit .
+    #           echo "Extract Ruby"
+    #           docker cp signingContainer:C:\ruby31 .
+    #           echo "Extract telegraf"
+    #           docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
+    #           echo "Extract out oms"
+    #           docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
+    #           echo "Extract containerinventory.so"
+    #           docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
+    #           echo "Extract perf.so"
+    #           docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
+    #           echo "Removing container"
+    #           docker rm signingContainer
+    #           echo "List ArtifactStagingDirectory"
+    #           ls $(Build.ArtifactStagingDirectory)
+    #           ls .
+    #     - script: dir $(System.DefaultWorkingDirectory)
+    #       displayName: 'List files in DefaultWorking Directory'
+    #     - script: dir $(Build.ArtifactStagingDirectory)
+    #       displayName: 'List files in Staging Directory'
+    #     - task: EsrpCodeSigning@5
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
+    #         Pattern: '*.dll,*.exe,*.so,*.ps1'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                   {
+    #                       "KeyCode" : "CP-230012",
+    #                       "OperationCode" : "SigntoolSign",
+    #                       "Parameters" : {
+    #                           "OpusName" : "Microsoft",
+    #                           "OpusInfo" : "http://www.microsoft.com",
+    #                           "FileDigest" : "/fd \"SHA256\"",
+    #                           "PageHash" : "/NPH",
+    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #                       },
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   },
+    #                   {
+    #                       "KeyCode" : "CP-230012",
+    #                       "OperationCode" : "SigntoolVerify",
+    #                       "Parameters" : {},
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   }
+    #               ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #       displayName: 'EsrpCodeSigning for first party'
+    #     - task: EsrpCodeSigning@5
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
+    #         Pattern: '*.dll,*.exe,*.so'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                   {
+    #                       "KeyCode" : "CP-231522",
+    #                       "OperationCode" : "SigntoolSign",
+    #                       "Parameters" : {
+    #                           "OpusName" : "Microsoft",
+    #                           "OpusInfo" : "http://www.microsoft.com",
+    #                           "Append" : "/as",
+    #                           "FileDigest" : "/fd \"SHA256\"",
+    #                           "PageHash" : "/NPH",
+    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #                       },
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   },
+    #                   {
+    #                       "KeyCode" : "CP-231522",
+    #                       "OperationCode" : "SigntoolVerify",
+    #                       "Parameters" : {},
+    #                       "ToolName" : "sign",
+    #                       "ToolVersion" : "1.0"
+    #                   }
+    #               ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #       displayName: 'EsrpCodeSigning for OSS'
+    #     - task: BinSkim@4
+    #       displayName: 'SDL: run binskim'
+    #       inputs:
+    #         InputType: 'CommandLine'
+    #         arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
+    #       retryCountOnTaskFailure: 1
+    #     - task: PoliCheck@2
+    #       displayName: "SDL : Run PoliCheck"
+    #       inputs:
+    #         targetType: 'F'
+    #         targetArgument: '$(Build.SourcesDirectory)'
+    #     - task: PowerShell@2
+    #       displayName: Replace files in origin Image
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
+    #           echo "Copy Signed binaries/folders back to docker image"
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
+    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
+    #           docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+    #           docker rm pushContainer
+    #     - task: PowerShell@2
+    #       displayName: Push Docker Image
+    #       inputs:
+    #         targetType: 'inline'
+    #         script: |
+    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+    #           $shouldPush = $false
+    #           if ("$(Build.Reason)" -ne "PullRequest") {
+    #             $shouldPush = $true
+    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+    #             $shouldPush = $true
+    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+    #           }
+              
+    #           if ($shouldPush) {
+    #             docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+    #           }
+    #     - task: CodeQL3000Finalize@0
+    #       condition: eq(variables.IS_MAIN_BRANCH, true)
+    #   - job: build_windows_multi_arc
+    #     pool:
+    #       name: Azure-Pipelines-CI-Test-EO
+    #       image: ci-1es-managed-windows-2022
+    #       os: windows
+    #     timeoutInMinutes: 120
+    #     dependsOn:
+    #     - common
+    #     - build_windows_2019
+    #     - build_windows_2022
+    #     variables:
+    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+    #       windows2019BaseImageVersion: ltsc2019
+    #       windows2022BaseImageVersion: ltsc2022
+    #       Codeql.SkipTaskAutoInjection: true
+    #     templateContext:
+    #       outputs:
+    #       - output: pipelineArtifact
+    #         targetPath: '$(Build.ArtifactStagingDirectory)'
+    #         artifactName: windows-drop
+    #     steps:
+    #     - task: AzureCLI@2
+    #       displayName: "Docker windows build for multi-arc image"
+    #       inputs:
+    #         azureSubscription: ${{ variables.armServiceConnectionName }}
+    #         scriptType: ps
+    #         scriptLocation: inlineScript
+    #         inlineScript: |
+    #           mkdir -p $(Build.ArtifactStagingDirectory)/windows
+    #           cd kubernetes/windows
+    #           az --version
+    #           az account show
+    #           az account set -s ${{ variables.subscription }}
+    #           az acr login -n ${{ variables.containerRegistry }}
+    #           @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+    #           $shouldPush = $false
+    #           if ("$(Build.Reason)" -ne "PullRequest") {
+    #             $shouldPush = $true
+    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+    #             $shouldPush = $true
+    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push multi-arch image to ACR for E2E testing"
+    #           }
+              
+    #           if ($shouldPush) {
+    #              docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+    #              docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+    #              Write-Host "##vso[task.logissue type=warning]Windows image built with tag: ${{ variables.repoImageName }}:$(windowsImageTag)"
+    #           }
+    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    #       displayName: 'Generation Task'
+    #       condition: eq(variables.IS_PR, true)
+    #       inputs:
+    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+    #         DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022'
+    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    #       displayName: 'Generation Task'
+    #       condition: eq(variables.IS_PR, false)
+    #       inputs:
+    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+    #         DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022,${{ variables.repoImageName }}:$(windowsImageTag)'
+    #     - powershell: |
+    #         curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
+    #         $currentDirectory = Get-Location
+    #         Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
+    #         New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
+    #         Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
+    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+    #         $output = oras manifest fetch ${{ variables.repoImageName }}:$(windowsImageTag) --descriptor
+    #         $outputObject = $output | ConvertFrom-Json
+    #         $payload = @{
+    #             targetArtifact = $outputObject
+    #         } | ConvertTo-Json -Depth 2
+    #         $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+    #         [System.IO.File]::WriteAllLines("$(Build.ArtifactStagingDirectory)/windows/payload.json", $payload, $utf8NoBomEncoding)
+    #         Get-Content "$(Build.ArtifactStagingDirectory)/windows/payload.json"
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+    #       displayName: "Install oras and build the payload json file"
+    #       condition: eq(variables.IS_PR, false)
+    #     - task: EsrpCodeSigning@5
+    #       condition: eq(variables.IS_PR, false)
+    #       inputs:
+    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+    #         UseMSIAuthentication: true
+    #         AppRegistrationClientId: $(appRegistrationClientId)
+    #         AppRegistrationTenantId: $(appRegistrationTenantId)
+    #         EsrpClientId: $(esrpClientId)
+    #         AuthAKVName: $(authAKVName)
+    #         AuthCertName: $(authCertName)
+    #         AuthSignCertName: $(authSignCertName)
+    #         FolderPath: '$(Build.ArtifactStagingDirectory)/windows'
+    #         Pattern: 'payload.json'
+    #         signConfigType: 'inlineSignParams'
+    #         inlineOperation: |
+    #           [
+    #                       {
+    #                           "keyCode": "CP-469451",
+    #                           "operationSetCode": "NotaryCoseSign",
+    #                           "parameters": [
+    #                             {
+    #                               "parameterName": "CoseFlags",
+    #                               "parameterValue": "chainunprotected"
+    #                             }
+    #                           ],
+    #                           "toolName": "sign",
+    #                           "toolVersion": "1.0"
+    #                       }
+    #                     ]
+    #         SessionTimeout: '60'
+    #         MaxConcurrency: '50'
+    #         MaxRetryAttempts: '5'
+    #         PendingAnalysisWaitTimeoutMinutes: '5'
+    #       displayName: 'Esrp Image Signing for windows image'
+    #     - powershell: |
+    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+    #         oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+    #       displayName: "Run oras attach"
+    #       condition: eq(variables.IS_PR, false)
+    #     - powershell: |
+    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+    #         oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"
+    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+    #       displayName: "Run oras attach"
+    #       condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
+    #     - task: AntiMalware@4
+    #       displayName: 'Run MpCmdRun.exe'
+    #       inputs:
+    #         InputType: Basic
+    #         ScanType: CustomScan
+    #         FileDirPath: '$(Build.ArtifactStagingDirectory)'
+    #         DisableRemediation: false
+    #         AcceptableOutdatedSignatureInHours: 72
+
+    - stage: Deploy_and_Test_Images_In_Dev_Clusters
+      displayName: Deploy and Test Images in Dev Clusters
+      lockBehavior: sequential
+      dependsOn: 
+        #- stage
+        []
+      # Deploy runs when Build succeeds OR when Build is skipped with valid overrides
+      # This stage runs when:
+      # 1. Direct push to ci_prod or zane/ci-agent-auto-deploy or branches containing 'run-e2e'
+      # 2. PR from zane/ci-agent-auto-deploy branch OR PR from branch containing 'run-e2e'
+      # condition: |
+      #   and(
+      #     or(
+      #       eq(variables['Build.SourceBranch'], 'refs/heads/ci_prod'),
+      #       eq(variables['Build.SourceBranch'], 'refs/heads/zane/ci-agent-auto-deploy'),
+      #       contains(variables['Build.SourceBranch'], 'run-e2e'),
+      #       and(
+      #         eq(variables['Build.Reason'], 'PullRequest'),
+      #         or(
+      #           eq(variables['System.PullRequest.SourceBranch'], 'zane/ci-agent-auto-deploy'),
+      #           contains(variables['System.PullRequest.SourceBranch'], 'run-e2e')
+      #         )
+      #       )
+      #     ),
+      #     or(
+      #       eq(dependencies.stage.result, 'Succeeded'),
+      #       and(
+      #         eq(dependencies.stage.result, 'Skipped'),
+      #         ne(variables['LinuxImageOverride'], ''),
+      #         ne(variables['WindowsImageOverride'], '')
+      #       )
+      #     )
+      #   )
+      variables:
+        # Use images built from previous build stage by default
+        # To override: Set pipeline variables 'LinuxImageOverride' and 'WindowsImageOverride' when queuing
+        linuxImageTagUnderTest: $[coalesce(variables['LinuxImageOverride'], '3.1.34')]
+        windowsImageTagUnderTest: $[coalesce(variables['WindowsImageOverride'], 'win-3.1.34')]
       jobs:
-      - job: common
-        pool:
-          name: Azure-Pipelines-CI-Test-EO
-          image: ci-1es-managed-ubuntu-2204
-          os: linux
-        variables:
-          skipComponentGovernanceDetection: true
-          Codeql.SkipTaskAutoInjection: true
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: drop
-        steps:
-        - task: ComponentGovernanceComponentDetection@0
-        - bash: |
-            commit=$(git describe)
-            datetime=$(date +%Y%m%d%H%M%S)
-            linuxImagetag="$commit"-"$datetime"
-            windowsImageTag=win-"$commit"-"$datetime"
-            telemetryTag=$linuxImagetag
-            if [ -z "$TELEMETRY_TAG" ]
-              then
-                echo "\$TELEMETRY_TAG variable is not set"
-              else
-                telemetryTag=$TELEMETRY_TAG
-                echo "\$TELEMETRY_TAG is $TELEMETRY_TAG"
-            fi
-            linuxTelemetryTag="$telemetryTag"
-            windowsTelemetryTag=win-"$telemetryTag"
-            echo "linuxImagetag is $linuxImagetag"
-            echo "windowsImageTag is $windowsImageTag"
-            echo "linuxTelemetryTag is $linuxTelemetryTag"
-            echo "windowsTelemetryTag is $windowsTelemetryTag"
-            echo "##vso[task.setvariable variable=linuxImagetag;isOutput=true]$linuxImagetag"
-            echo "##vso[task.setvariable variable=windowsImageTag;isOutput=true]$windowsImageTag"
-            echo "##vso[task.setvariable variable=linuxTelemetryTag;isOutput=true]$linuxTelemetryTag"
-            echo "##vso[task.setvariable variable=windowsTelemetryTag;isOutput=true]$windowsTelemetryTag"
-            echo "appRegistrationClientId is $APP_REGISTRATION_CLIENT_ID"
-            echo "appRegistrationTenantId is $APP_REGISTRATION_TENANT_ID"
-            echo "authAKVName is $AUTH_AKV_NAME"
-            echo "authCertName is $AUTH_CERT_NAME"
-            echo "authSignCertName is $AUTH_SIGN_CERT_NAME"
-            cd $(Build.SourcesDirectory)/deployment/mergebranch-multiarch-agent-deployment/ServiceGroupRoot/Scripts
-            tar -czvf ../artifacts.tar.gz pushAgentToAcr.sh
-            cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension/ServiceGroupRoot/Scripts
-            tar -czvf ../artifacts.tar.gz ../../../../charts/azuremonitor-containers/ pushChartToAcr.sh
-            cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
-            tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
-            windowsAMAUrl=""
-            if [ -z "$WINDOWS_AMA_URL" ]
-              then
-                echo "\$WINDOWS_AMA_URL variable is not set"
-              else
-                windowsAMAUrl=$WINDOWS_AMA_URL
-                echo "\$WINDOWS_AMA_URL is $WINDOWS_AMA_URL"
-            fi
-            echo "##vso[task.setvariable variable=windowsAMAUrl;isOutput=true]$windowsAMAUrl"
-          name: setup
-        - task: CredScan@3
-          displayName: "SDL : Run credscan"
-        - task: CopyFiles@2
-          displayName: "Copy ev2 deployment artifacts"
-          inputs:
-            SourceFolder: "$(Build.SourcesDirectory)/deployment"
-            Contents: |
-              **/*
-              !**/ScanTelemetry_*.json
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-        - task: CopyFiles@2
-          displayName: "Copy ev2 deployment scripts"
-          inputs:
-            SourceFolder: "$(Build.SourcesDirectory)/.pipelines"
-            Contents: |
-              **/*.sh
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-        - task: CopyFiles@2
-          displayName: "Copy ev2 deployment scripts"
-          inputs:
-            SourceFolder: "$(Build.SourcesDirectory)/kubernetes"
-            Contents: |
-              *.yaml
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-        - task: CopyFiles@2
-          displayName: "Copy ev2 deployment scripts"
-          inputs:
-            SourceFolder: "$(Build.SourcesDirectory)/charts"
-            Contents: |
-              **/*
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-        - task: CopyFiles@2
-          displayName: "Copy ev2 deployment scripts"
-          inputs:
-            SourceFolder: "$(Build.SourcesDirectory)/test/e2e"
-            Contents: |
-              *.yaml
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-        - task: Armory@2
-          displayName: 'Run ARMory'
-          inputs:
-            toolVersion: Latest
-            targetDirectory: '$(Build.SourcesDirectory)'
-      - job: build_linux
-        timeoutInMinutes: 120
-        dependsOn: common
-        variables:
-          linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
-          linuxTelemetryTag: $[ dependencies.common.outputs['setup.linuxTelemetryTag'] ]
-          Codeql.Enabled: true
-          Codeql.BuildIdentifier: 'linuxbuild'
-          DOCKER_BUILDKIT: 1
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: linux-drop
-        steps:
-        - task: CodeQL3000Init@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-        - task: AzureCLI@2
-          displayName: "Multi-arch Linux build"
-          inputs:
-            azureSubscription: ${{ variables.armServiceConnectionName }}
-            scriptType: bash
-            scriptLocation: inlineScript
-            inlineScript: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/linux
-              sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
-              docker system prune --all -f
-              docker images -q --filter "dangling=true" | xargs docker rmi
-              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-              docker buildx create --name testbuilder
-              docker buildx use testbuilder
-              az --version
-              az account show
-              az account set -s ${{ variables.subscription }}
-              az acr login -n ${{ variables.containerRegistry }}
-              # NOTE: Using the prometheus-collector team's cached buildx image since moby/buildkit:buildx-stable-1 getting throttled
-              docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
-              docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
-              docker buildx inspect --bootstrap
-              if [ "$(Build.Reason)" != "PullRequest" ]; then
-                docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .
-                echo "##vso[task.logissue type=warning]Linux image built with tag: ${{ variables.repoImageName }}:$(linuxImagetag)"
-                docker pull ${{ variables.repoImageName }}:$(linuxImagetag)
-              else
-                docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --provenance=false .
-                # load the multi-arch image to run tests
-                docker buildx build --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --load --provenance=false .
-              fi
-        - bash: |
-            curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
-            mkdir -p oras-install/
-            tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
-            sudo mv oras-install/oras /usr/local/bin/
-            rm -rf oras_1.0.0_*.tar.gz oras-install/
-            TARGET_ARTIFACT=$(oras manifest fetch ${{ variables.repoImageName }}:$(linuxImagetag) --descriptor)
-            cat <<EOF >>$(Build.ArtifactStagingDirectory)/linux/payload.json
-            {"targetArtifact":$TARGET_ARTIFACT}
-            EOF
-            cat $(Build.ArtifactStagingDirectory)/linux/payload.json
-          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-          displayName: "Install oras and build the payload json file"
-          condition: eq(variables.IS_PR, false)
-        - task: EsrpCodeSigning@5
-          condition: eq(variables.IS_PR, false)
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/linux'
-            Pattern: 'payload.json'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                          {
-                              "keyCode": "CP-469451",
-                              "operationSetCode": "NotaryCoseSign",
-                              "parameters": [
-                                {
-                                  "parameterName": "CoseFlags",
-                                  "parameterValue": "chainunprotected"
-                                }
-                              ],
-                              "toolName": "sign",
-                              "toolVersion": "1.0"
-                          }
-                        ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-            PendingAnalysisWaitTimeoutMinutes: '5'
-          displayName: 'Esrp Image Signing for linux image'
-        - bash: |
-            set -euxo pipefail
-            oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
-              --artifact-type 'application/vnd.cncf.notary.signature' \
-              ./payload.json:application/cose \
-              -a "io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]"
-          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-          displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
-          condition: eq(variables.IS_PR, false)
-        - bash: |
-            set -euxo pipefail
-            oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
-                --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-                --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
-          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-          displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
-          condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
-        - task: AzureCLI@2
-          displayName: "Vulnerability Scan with Trivy"
-          inputs:
-            azureSubscription: ${{ variables.armServiceConnectionName }}
-            scriptType: bash
-            scriptLocation: inlineScript
-            inlineScript: |
-              curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-              PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
-              SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
-              PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
-              SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
-              # Set initial repositories to primary
-              export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY
-              export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
-              # Function to run Trivy scan and handle output
-              run_trivy_scan() {
-                  trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
-                  return $?
-              }
-              # Attempt scan up to 5 times with repository fallback
-              for i in {1..5}; do
-                  echo "Running Trivy scan attempt $i"
-                  # Run the Trivy scan and capture exit code
-                  run_trivy_scan
-                  TRIVY_EXIT_CODE=$?
-                  # Check if scan was successful
-                  if [ $TRIVY_EXIT_CODE -eq 0 ]; then
-                      echo "Trivy scan succeeded."
-                      cat trivy_output.log
-                      break
-                  fi
-                  # If the first attempt fails, switch to secondary repositories
-                  if [ $i -eq 1 ]; then
-                      echo "Primary repositories failed with an error. Switching to secondary repositories."
-                      export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY
-                      export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY
-                  fi
-                  # Log and wait before retrying if an error occurred
-                  echo "Error: Trivy scan attempt $i failed. Retrying ($i/5)"
-                  cat trivy_output.log
-                  sleep 5 # Wait 5 seconds before retrying
-              done
-              # Final check: if still failing after 5 attempts, exit with error
-              if [ $TRIVY_EXIT_CODE -ne 0 ]; then
-                  echo "Error: Trivy scan failed after 5 retries."
-                  exit 1
-              fi
-        - task: GoTool@0
-          inputs:
-            version: '1.23.8'
-        - bash: |
-            cd $(System.DefaultWorkingDirectory)/build/linux/
-            ls
-            make
-          displayName: 'Execute Makefile for Linux Build'
-        - task: CodeQL3000Finalize@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Generation Task'
-          condition: eq(variables.IS_PR, false)
-          inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
-            DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
-        - bash: |
-            dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
-            echo "Docker images to scan: $dockerImagesToScan"
-            echo "##vso[task.setvariable variable=dockerImagesToScan]$dockerImagesToScan"
-          displayName: 'Set Docker images to scan'
-      - job: build_windows_2019
-        pool:
-          name: Azure-Pipelines-CI-Test-EO
-          image: ci-1es-managed-windows-2022
-          os: windows
-        timeoutInMinutes: 120
-        dependsOn:
-        - common
-        variables:
-          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-          windows2019BaseImageVersion: ltsc2019
-          Codeql.Enabled: true
-          Codeql.BuildIdentifier: 'windowsbuild'
-          windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
-        steps:
-        - task: PowerShell@2
-          inputs:
-            targetType: 'filePath'
-            filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-          displayName: 'install prereqs'
-        - task: CodeQL3000Init@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-        - script: |
-            setlocal enabledelayedexpansion
-            powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-            endlocal
-            exit /B %ERRORLEVEL%
-          displayName: 'build base'
-        - task: AzureCLI@2
-          displayName: "Set up acr for windows ltsc2019 build"
-          inputs:
-            azureSubscription: ${{ variables.armServiceConnectionName }}
-            scriptType: ps
-            scriptLocation: inlineScript
-            retryCountOnTaskFailure: 2
-            inlineScript: |
-              az --version
-              az account show
-              az account set -s ${{ variables.subscription }}
-              az acr login -n ${{ variables.containerRegistry }}
-        - task: PowerShell@2          
-          inputs:
-            targetType: 'inline'
-            script: |
-              # Check if directory exists and remove it before creating it to handle retry scenarios
-              if (Test-Path -Path "$(Build.ArtifactStagingDirectory)/windows") {
-                Remove-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -Recurse -Force
-              }
-              New-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -ItemType Directory -Force
-              cd kubernetes/windows
-              # Build the Docker image
-              docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
-          displayName: "Docker windows build for ltsc2019"
-          retryCountOnTaskFailure: 2
-        - task: PowerShell@2
-          displayName: Extract files to sign
-          inputs:
-            targetType: 'inline'
-            script: |
-              echo "Creating docker container"
-              docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
-              echo "Creating fist party directory"
-              mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
-              cd $(Build.ArtifactStagingDirectory)/fpSigning
-              echo "Extract CertificateGenerator"
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
-              echo "Extract LivenessProbe"
-              docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
-              echo "Extract ps scripts"
-              docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
-              echo "Creating OSS directory"
-              mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
-              cd $(Build.ArtifactStagingDirectory)/ossSigning
-              echo "Extract CertificateGenerator"
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
-              echo "Extract fluent-bit"
-              docker cp signingContainer:C:\opt\fluent-bit .
-              echo "Extract Ruby"
-              docker cp signingContainer:C:\ruby31 .
-              echo "Extract telegraf"
-              docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
-              echo "Extract out oms"
-              docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
-              echo "Extract containerinventory.so"
-              docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
-              echo "Extract perf.so"
-              docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
-              echo "Removing container"
-              docker rm signingContainer
-              echo "List ArtifactStagingDirectory"
-              ls $(Build.ArtifactStagingDirectory)
-              ls .
-        - script: dir $(System.DefaultWorkingDirectory)
-          displayName: 'List files in DefaultWorking Directory'
-        - script: dir $(Build.ArtifactStagingDirectory)
-          displayName: 'List files in Staging Directory'
-        - task: EsrpCodeSigning@5
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
-            Pattern: '*.dll,*.exe,*.so,*.ps1'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                      {
-                          "KeyCode" : "CP-230012",
-                          "OperationCode" : "SigntoolSign",
-                          "Parameters" : {
-                              "OpusName" : "Microsoft",
-                              "OpusInfo" : "http://www.microsoft.com",
-                              "FileDigest" : "/fd \"SHA256\"",
-                              "PageHash" : "/NPH",
-                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                          },
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      },
-                      {
-                          "KeyCode" : "CP-230012",
-                          "OperationCode" : "SigntoolVerify",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      }
-                  ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-          displayName: 'EsrpCodeSigning for first party'
-        - task: EsrpCodeSigning@5
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
-            Pattern: '*.dll,*.exe,*.so'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                      {
-                          "KeyCode" : "CP-231522",
-                          "OperationCode" : "SigntoolSign",
-                          "Parameters" : {
-                              "OpusName" : "Microsoft",
-                              "OpusInfo" : "http://www.microsoft.com",
-                              "Append" : "/as",
-                              "FileDigest" : "/fd \"SHA256\"",
-                              "PageHash" : "/NPH",
-                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                          },
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      },
-                      {
-                          "KeyCode" : "CP-231522",
-                          "OperationCode" : "SigntoolVerify",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      }
-                  ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-          displayName: 'EsrpCodeSigning for OSS'
-        - task: BinSkim@4
-          displayName: 'SDL: run binskim'
-          inputs:
-            InputType: 'CommandLine'
-            arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
-          retryCountOnTaskFailure: 1
-        - task: PoliCheck@2
-          displayName: "SDL : Run PoliCheck"
-          inputs:
-            targetType: 'F'
-            targetArgument: '$(Build.SourcesDirectory)'
-        - task: PowerShell@2
-          displayName: Replace files in origin Image
-          inputs:
-            targetType: 'inline'
-            script: |
-              docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
-              echo "Copy Signed binaries/folders back to docker image"
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
-              docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
-              docker rm pushContainer
-        - task: PowerShell@2
-          displayName: Push Docker Image
-          inputs:
-            targetType: 'inline'
-            script: |
-              if ("$(Build.Reason)" -ne "PullRequest") {
-                docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
-              }
-        - task: CodeQL3000Finalize@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-      - job: build_windows_2022
-        pool:
-          name: Azure-Pipelines-CI-Test-EO
-          image: ci-1es-managed-windows-2022
-          os: windows
-        timeoutInMinutes: 120
-        dependsOn:
-        - common
-        variables:
-          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-          windows2022BaseImageVersion: ltsc2022
-          Codeql.SkipTaskAutoInjection: true
-          windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
-        steps:
-        - task: PowerShell@2
-          inputs:
-            targetType: 'filePath'
-            filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-          displayName: 'install prereqs'
-        - task: CodeQL3000Init@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-        - script: |
-            setlocal enabledelayedexpansion
-            powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-            endlocal
-            exit /B %ERRORLEVEL%
-          displayName: 'build base'
-        - task: AzureCLI@2
-          displayName: "Docker windows build for ltsc2022"
-          inputs:
-            azureSubscription: ${{ variables.armServiceConnectionName }}
-            scriptType: ps
-            scriptLocation: inlineScript
-            retryCountOnTaskFailure: 2
-            inlineScript: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/windows
-              cd kubernetes/windows
-              az --version
-              az account show
-              az account set -s ${{ variables.subscription }}
-              az acr login -n ${{ variables.containerRegistry }}
-              docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
-        - task: PowerShell@2
-          displayName: Extract files to sign
-          inputs:
-            targetType: 'inline'
-            script: |
-              echo "Creating docker container"
-              docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
-              echo "Creating fist party directory"
-              mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
-              cd $(Build.ArtifactStagingDirectory)/fpSigning
-              echo "Extract CertificateGenerator"
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
-              echo "Extract LivenessProbe"
-              docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
-              echo "Extract ps scripts"
-              docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
-              echo "Creating OSS directory"
-              mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
-              cd $(Build.ArtifactStagingDirectory)/ossSigning
-              echo "Extract CertificateGenerator"
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
-              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
-              echo "Extract fluent-bit"
-              docker cp signingContainer:C:\opt\fluent-bit .
-              echo "Extract Ruby"
-              docker cp signingContainer:C:\ruby31 .
-              echo "Extract telegraf"
-              docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
-              echo "Extract out oms"
-              docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
-              echo "Extract containerinventory.so"
-              docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
-              echo "Extract perf.so"
-              docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
-              echo "Removing container"
-              docker rm signingContainer
-              echo "List ArtifactStagingDirectory"
-              ls $(Build.ArtifactStagingDirectory)
-              ls .
-        - script: dir $(System.DefaultWorkingDirectory)
-          displayName: 'List files in DefaultWorking Directory'
-        - script: dir $(Build.ArtifactStagingDirectory)
-          displayName: 'List files in Staging Directory'
-        - task: EsrpCodeSigning@5
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
-            Pattern: '*.dll,*.exe,*.so,*.ps1'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                      {
-                          "KeyCode" : "CP-230012",
-                          "OperationCode" : "SigntoolSign",
-                          "Parameters" : {
-                              "OpusName" : "Microsoft",
-                              "OpusInfo" : "http://www.microsoft.com",
-                              "FileDigest" : "/fd \"SHA256\"",
-                              "PageHash" : "/NPH",
-                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                          },
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      },
-                      {
-                          "KeyCode" : "CP-230012",
-                          "OperationCode" : "SigntoolVerify",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      }
-                  ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-          displayName: 'EsrpCodeSigning for first party'
-        - task: EsrpCodeSigning@5
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
-            Pattern: '*.dll,*.exe,*.so'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                      {
-                          "KeyCode" : "CP-231522",
-                          "OperationCode" : "SigntoolSign",
-                          "Parameters" : {
-                              "OpusName" : "Microsoft",
-                              "OpusInfo" : "http://www.microsoft.com",
-                              "Append" : "/as",
-                              "FileDigest" : "/fd \"SHA256\"",
-                              "PageHash" : "/NPH",
-                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                          },
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      },
-                      {
-                          "KeyCode" : "CP-231522",
-                          "OperationCode" : "SigntoolVerify",
-                          "Parameters" : {},
-                          "ToolName" : "sign",
-                          "ToolVersion" : "1.0"
-                      }
-                  ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-          displayName: 'EsrpCodeSigning for OSS'
-        - task: BinSkim@4
-          displayName: 'SDL: run binskim'
-          inputs:
-            InputType: 'CommandLine'
-            arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
-          retryCountOnTaskFailure: 1
-        - task: PoliCheck@2
-          displayName: "SDL : Run PoliCheck"
-          inputs:
-            targetType: 'F'
-            targetArgument: '$(Build.SourcesDirectory)'
-        - task: PowerShell@2
-          displayName: Replace files in origin Image
-          inputs:
-            targetType: 'inline'
-            script: |
-              docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
-              echo "Copy Signed binaries/folders back to docker image"
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
-              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
-              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
-              docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-              docker rm pushContainer
-        - task: PowerShell@2
-          displayName: Push Docker Image
-          inputs:
-            targetType: 'inline'
-            script: |
-              if ("$(Build.Reason)" -ne "PullRequest") {
-                docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-              }
-        - task: CodeQL3000Finalize@0
-          condition: eq(variables.IS_MAIN_BRANCH, true)
-      - job: build_windows_multi_arc
-        pool:
-          name: Azure-Pipelines-CI-Test-EO
-          image: ci-1es-managed-windows-2022
-          os: windows
-        timeoutInMinutes: 120
-        dependsOn:
-        - common
-        - build_windows_2019
-        - build_windows_2022
-        variables:
-          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-          windows2019BaseImageVersion: ltsc2019
-          windows2022BaseImageVersion: ltsc2022
-          Codeql.SkipTaskAutoInjection: true
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: windows-drop
-        steps:
-        - task: AzureCLI@2
-          displayName: "Docker windows build for multi-arc image"
-          inputs:
-            azureSubscription: ${{ variables.armServiceConnectionName }}
-            scriptType: ps
-            scriptLocation: inlineScript
-            inlineScript: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/windows
-              cd kubernetes/windows
-              az --version
-              az account show
-              az account set -s ${{ variables.subscription }}
-              az acr login -n ${{ variables.containerRegistry }}
-              @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-              if ("$(Build.Reason)" -ne "PullRequest") {
-                 docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-                 docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-                 Write-Host "##vso[task.logissue type=warning]Windows image built with tag: ${{ variables.repoImageName }}:$(windowsImageTag)"
-              }
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Generation Task'
-          condition: eq(variables.IS_PR, true)
-          inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-            DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022'
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Generation Task'
-          condition: eq(variables.IS_PR, false)
-          inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-            DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022,${{ variables.repoImageName }}:$(windowsImageTag)'
-        - powershell: |
-            curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
-            $currentDirectory = Get-Location
-            Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
-            New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
-            Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
-            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-            $output = oras manifest fetch ${{ variables.repoImageName }}:$(windowsImageTag) --descriptor
-            $outputObject = $output | ConvertFrom-Json
-            $payload = @{
-                targetArtifact = $outputObject
-            } | ConvertTo-Json -Depth 2
-            $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
-            [System.IO.File]::WriteAllLines("$(Build.ArtifactStagingDirectory)/windows/payload.json", $payload, $utf8NoBomEncoding)
-            Get-Content "$(Build.ArtifactStagingDirectory)/windows/payload.json"
-          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-          displayName: "Install oras and build the payload json file"
-          condition: eq(variables.IS_PR, false)
-        - task: EsrpCodeSigning@5
-          condition: eq(variables.IS_PR, false)
-          inputs:
-            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-            UseMSIAuthentication: true
-            AppRegistrationClientId: $(appRegistrationClientId)
-            AppRegistrationTenantId: $(appRegistrationTenantId)
-            EsrpClientId: $(esrpClientId)
-            AuthAKVName: $(authAKVName)
-            AuthCertName: $(authCertName)
-            AuthSignCertName: $(authSignCertName)
-            FolderPath: '$(Build.ArtifactStagingDirectory)/windows'
-            Pattern: 'payload.json'
-            signConfigType: 'inlineSignParams'
-            inlineOperation: |
-              [
-                          {
-                              "keyCode": "CP-469451",
-                              "operationSetCode": "NotaryCoseSign",
-                              "parameters": [
-                                {
-                                  "parameterName": "CoseFlags",
-                                  "parameterValue": "chainunprotected"
-                                }
-                              ],
-                              "toolName": "sign",
-                              "toolVersion": "1.0"
-                          }
-                        ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-            PendingAnalysisWaitTimeoutMinutes: '5'
-          displayName: 'Esrp Image Signing for windows image'
-        - powershell: |
-            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-            oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]
-          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-          displayName: "Run oras attach"
-          condition: eq(variables.IS_PR, false)
-        - powershell: |
-            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-            oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"
-          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-          displayName: "Run oras attach"
-          condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
-        - task: AntiMalware@4
-          displayName: 'Run MpCmdRun.exe'
-          inputs:
-            InputType: Basic
-            ScanType: CustomScan
-            FileDirPath: '$(Build.ArtifactStagingDirectory)'
-            DisableRemediation: false
-            AcceptableOutdatedSignatureInHours: 72
+      # TODO: add more clusters from test automation framework when the tests are stable
+      # ============================================================
+      # Cluster 1: zane-test — Deploy via Helm
+      # ============================================================
+      - template: /.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml@self
+        parameters:
+          clusterName: 'zane-test'
+          resourceGroup: 'zane-test'
+          region: 'westus2'
+          subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
+          workspaceId: 'b59109c7-d2ab-4464-a5d0-36ed751cd076' # zane-test-la2
+          imageTag: $(linuxImageTagUnderTest)
+          imageRepository: ${{ variables.ImageRepositoryOverride }}
+          environment: 'CI-Agent-Dev'
+          azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+
+      # Cluster 1: zane-test — Run E2E Tests
+      - template: /.pipelines/e2e-test-templates/test-ci-image-in-aks-cluster.yml@self
+        parameters:
+          clusterName: 'zane-test'
+          resourceGroup: 'zane-test'
+          azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+          environmentName: 'CI-Agent-Dev'
+          dependsOnDeployJob: 'Deploy_AmaLogs_zane_test'
+          azureClientId: $(ZANE_TEST_CLIENT_ID)
+          azureTenantId: $(CI_BUILD_AZURE_TENANT_ID)
+          teamsWebhookUri: $(TeamsWebhookUri)
+
+      # ============================================================
+      # Cluster 2: zane-test2 — Deploy via Helm
+      # ============================================================
+      - template: /.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml@self
+        parameters:
+          clusterName: 'zane-test2'
+          resourceGroup: 'zane-test'
+          region: 'centralus'
+          subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
+          workspaceId: 'b59109c7-d2ab-4464-a5d0-36ed751cd076' # zane-test-la2
+          imageTag: $(linuxImageTagUnderTest)
+          imageRepository: ${{ variables.ImageRepositoryOverride }}
+          environment: 'CI-Agent-Dev2'
+          azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+
+      # Cluster 2: zane-test2 — Run E2E Tests
+      - template: /.pipelines/e2e-test-templates/test-ci-image-in-aks-cluster.yml@self
+        parameters:
+          clusterName: 'zane-test2'
+          resourceGroup: 'zane-test'
+          azureSubscription: 'ContainerInsights_Build_Subscription_CI'
+          environmentName: 'CI-Agent-Dev2'
+          dependsOnDeployJob: 'Deploy_AmaLogs_zane_test2'
+          azureClientId: $(ZANE_TEST2_CLIENT_ID)
+          azureTenantId: $(CI_BUILD_AZURE_TENANT_ID)
+          teamsWebhookUri: $(TeamsWebhookUri)

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -277,8 +277,7 @@ extends:
               export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
               # Function to run Trivy scan and handle output
               run_trivy_scan() {
-                  #trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
-                  trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
                   return $?
               }
               # Attempt scan up to 5 times with repository fallback

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -888,15 +888,18 @@ extends:
       displayName: Deploy and Test Images in Dev Clusters
       lockBehavior: sequential
       dependsOn: 
-        - stage
+        #- stage
+        []
       condition: |
         eq(dependencies.stage.result, 'Succeeded')
       variables:
         # Override the helm chart's default image repository (/azuremonitor/containerinsights/ciprod) to use cidev
         ImageRepositoryOverride: '/azuremonitor/containerinsights/cidev'
         # Use image tags built from the previous build stage
-        linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
-        windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
+        #linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
+        #windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
+        linuxImageTagUnderTest: '3.1.35'
+        windowsImageTagUnderTest: 'win-3.1.35'
       jobs:
       # TODO: add more clusters from test automation framework when the tests are stable
       # ============================================================

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -277,7 +277,8 @@ extends:
               export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
               # Function to run Trivy scan and handle output
               run_trivy_scan() {
-                  trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  #trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
                   return $?
               }
               # Attempt scan up to 5 times with repository fallback

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -277,7 +277,7 @@ extends:
               export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
               # Function to run Trivy scan and handle output
               run_trivy_scan() {
-                  trivy image --exit-code 1--ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
                   return $?
               }
               # Attempt scan up to 5 times with repository fallback

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -12,9 +12,6 @@ variables:
   subscription: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
   containerRegistry: 'containerinsightsprod'
   repoImageName: '${{ variables.containerRegistry }}.azurecr.io/public/azuremonitor/containerinsights/cidev'
-  # Default image repository path for CI builds. Override when queuing pipeline with pre-built ciprod images.
-  # Set to '/azuremonitor/containerinsights/ciprod' when using LinuxImageOverride/WindowsImageOverride with prod images.
-  ImageRepositoryOverride: '/azuremonitor/containerinsights/ciprod'
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
   IS_MAIN_BRANCH: $[eq(variables['Build.SourceBranchName'], 'ci_prod')]
   IS_RELEASE: $[ne(variables['TELEMETRY_TAG'], '')]
@@ -47,927 +44,903 @@ extends:
     stages:
     # This stage will be skipped when LinuxImageOverride and WindowsImageOverride are both set
     # This feature allows bypassing the build stage when using pre-built images for testing, which saves time and resources.
-    # - stage: stage
-    #   displayName: 'Build and Publish Container Images'
-    #   condition: |
-    #     or(
-    #       eq(variables['LinuxImageOverride'], ''),
-    #       eq(variables['WindowsImageOverride'], '')
-    #     )
-    #   jobs:
-    #   - job: common
-    #     pool:
-    #       name: Azure-Pipelines-CI-Test-EO
-    #       image: ci-1es-managed-ubuntu-2204
-    #       os: linux
-    #     variables:
-    #       skipComponentGovernanceDetection: true
-    #       Codeql.SkipTaskAutoInjection: true
-    #     templateContext:
-    #       outputs:
-    #       - output: pipelineArtifact
-    #         targetPath: '$(Build.ArtifactStagingDirectory)'
-    #         artifactName: drop
-    #     steps:
-    #     - task: ComponentGovernanceComponentDetection@0
-    #     - bash: |
-    #         commit=$(git describe)
-    #         datetime=$(date +%Y%m%d%H%M%S)
-    #         linuxImagetag="$commit"-"$datetime"
-    #         windowsImageTag=win-"$commit"-"$datetime"
-    #         telemetryTag=$linuxImagetag
-    #         if [ -z "$TELEMETRY_TAG" ]
-    #           then
-    #             echo "\$TELEMETRY_TAG variable is not set"
-    #           else
-    #             telemetryTag=$TELEMETRY_TAG
-    #             echo "\$TELEMETRY_TAG is $TELEMETRY_TAG"
-    #         fi
-    #         linuxTelemetryTag="$telemetryTag"
-    #         windowsTelemetryTag=win-"$telemetryTag"
-    #         echo "linuxImagetag is $linuxImagetag"
-    #         echo "windowsImageTag is $windowsImageTag"
-    #         echo "linuxTelemetryTag is $linuxTelemetryTag"
-    #         echo "windowsTelemetryTag is $windowsTelemetryTag"
-    #         echo "##vso[task.setvariable variable=linuxImagetag;isOutput=true]$linuxImagetag"
-    #         echo "##vso[task.setvariable variable=windowsImageTag;isOutput=true]$windowsImageTag"
-    #         echo "##vso[task.setvariable variable=linuxTelemetryTag;isOutput=true]$linuxTelemetryTag"
-    #         echo "##vso[task.setvariable variable=windowsTelemetryTag;isOutput=true]$windowsTelemetryTag"
-    #         echo "appRegistrationClientId is $APP_REGISTRATION_CLIENT_ID"
-    #         echo "appRegistrationTenantId is $APP_REGISTRATION_TENANT_ID"
-    #         echo "authAKVName is $AUTH_AKV_NAME"
-    #         echo "authCertName is $AUTH_CERT_NAME"
-    #         echo "authSignCertName is $AUTH_SIGN_CERT_NAME"
-    #         cd $(Build.SourcesDirectory)/deployment/mergebranch-multiarch-agent-deployment/ServiceGroupRoot/Scripts
-    #         tar -czvf ../artifacts.tar.gz pushAgentToAcr.sh
-    #         cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension/ServiceGroupRoot/Scripts
-    #         tar -czvf ../artifacts.tar.gz ../../../../charts/azuremonitor-containers/ pushChartToAcr.sh
-    #         cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
-    #         tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
-    #         windowsAMAUrl=""
-    #         if [ -z "$WINDOWS_AMA_URL" ]
-    #           then
-    #             echo "\$WINDOWS_AMA_URL variable is not set"
-    #           else
-    #             windowsAMAUrl=$WINDOWS_AMA_URL
-    #             echo "\$WINDOWS_AMA_URL is $WINDOWS_AMA_URL"
-    #         fi
-    #         echo "##vso[task.setvariable variable=windowsAMAUrl;isOutput=true]$windowsAMAUrl"
-    #       name: setup
-    #     - task: CredScan@3
-    #       displayName: "SDL : Run credscan"
-    #     - task: CopyFiles@2
-    #       displayName: "Copy ev2 deployment artifacts"
-    #       inputs:
-    #         SourceFolder: "$(Build.SourcesDirectory)/deployment"
-    #         Contents: |
-    #           **/*
-    #           !**/ScanTelemetry_*.json
-    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-    #     - task: CopyFiles@2
-    #       displayName: "Copy ev2 deployment scripts"
-    #       inputs:
-    #         SourceFolder: "$(Build.SourcesDirectory)/.pipelines"
-    #         Contents: |
-    #           **/*.sh
-    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-    #     - task: CopyFiles@2
-    #       displayName: "Copy ev2 deployment scripts"
-    #       inputs:
-    #         SourceFolder: "$(Build.SourcesDirectory)/kubernetes"
-    #         Contents: |
-    #           *.yaml
-    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-    #     - task: CopyFiles@2
-    #       displayName: "Copy ev2 deployment scripts"
-    #       inputs:
-    #         SourceFolder: "$(Build.SourcesDirectory)/charts"
-    #         Contents: |
-    #           **/*
-    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-    #     - task: CopyFiles@2
-    #       displayName: "Copy ev2 deployment scripts"
-    #       inputs:
-    #         SourceFolder: "$(Build.SourcesDirectory)/test/e2e"
-    #         Contents: |
-    #           *.yaml
-    #         TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
-    #     - task: Armory@2
-    #       displayName: 'Run ARMory'
-    #       inputs:
-    #         toolVersion: Latest
-    #         targetDirectory: '$(Build.SourcesDirectory)'
-    #   - job: build_linux
-    #     timeoutInMinutes: 120
-    #     dependsOn: common
-    #     variables:
-    #       linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
-    #       linuxTelemetryTag: $[ dependencies.common.outputs['setup.linuxTelemetryTag'] ]
-    #       Codeql.Enabled: true
-    #       Codeql.BuildIdentifier: 'linuxbuild'
-    #       DOCKER_BUILDKIT: 1
-    #     templateContext:
-    #       outputs:
-    #       - output: pipelineArtifact
-    #         targetPath: '$(Build.ArtifactStagingDirectory)'
-    #         artifactName: linux-drop
-    #     steps:
-    #     - task: CodeQL3000Init@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #     - task: AzureCLI@2
-    #       displayName: "Multi-arch Linux build"
-    #       inputs:
-    #         azureSubscription: ${{ variables.armServiceConnectionName }}
-    #         scriptType: bash
-    #         scriptLocation: inlineScript
-    #         inlineScript: |
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/linux
-    #           sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
-    #           docker system prune --all -f
-    #           docker images -q --filter "dangling=true" | xargs docker rmi
-    #           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    #           docker buildx create --name testbuilder
-    #           docker buildx use testbuilder
-    #           az --version
-    #           az account show
-    #           az account set -s ${{ variables.subscription }}
-    #           az acr login -n ${{ variables.containerRegistry }}
-    #           # NOTE: Using the prometheus-collector team's cached buildx image since moby/buildkit:buildx-stable-1 getting throttled
-    #           docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
-    #           docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
-    #           docker buildx inspect --bootstrap
-    #           # Determine if we should push to ACR
-    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-    #           SHOULD_PUSH="false"
-    #           if [ "$(Build.Reason)" != "PullRequest" ]; then
-    #             SHOULD_PUSH="true"
-    #           elif [[ "$(System.PullRequest.SourceBranch)" == "zane/ci-agent-auto-deploy" ]] || [[ "$(System.PullRequest.SourceBranch)" == *"run-e2e"* ]]; then
-    #             SHOULD_PUSH="true"
-    #             echo "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-    #           fi
+    - stage: stage
+      displayName: 'Build and Publish Container Images'
+      # TODO: add logic to skip build to test an image specified from pipeline variables.
+      # condition: |
+      #   or(
+      #     eq(variables['LinuxImageOverride'], ''),
+      #     eq(variables['WindowsImageOverride'], '')
+      #   )
+      jobs:
+      - job: common
+        pool:
+          name: Azure-Pipelines-CI-Test-EO
+          image: ci-1es-managed-ubuntu-2204
+          os: linux
+        variables:
+          skipComponentGovernanceDetection: true
+          Codeql.SkipTaskAutoInjection: true
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: drop
+        steps:
+        - task: ComponentGovernanceComponentDetection@0
+        - bash: |
+            commit=$(git describe)
+            datetime=$(date +%Y%m%d%H%M%S)
+            linuxImagetag="$commit"-"$datetime"
+            windowsImageTag=win-"$commit"-"$datetime"
+            telemetryTag=$linuxImagetag
+            if [ -z "$TELEMETRY_TAG" ]
+              then
+                echo "\$TELEMETRY_TAG variable is not set"
+              else
+                telemetryTag=$TELEMETRY_TAG
+                echo "\$TELEMETRY_TAG is $TELEMETRY_TAG"
+            fi
+            linuxTelemetryTag="$telemetryTag"
+            windowsTelemetryTag=win-"$telemetryTag"
+            echo "linuxImagetag is $linuxImagetag"
+            echo "windowsImageTag is $windowsImageTag"
+            echo "linuxTelemetryTag is $linuxTelemetryTag"
+            echo "windowsTelemetryTag is $windowsTelemetryTag"
+            echo "##vso[task.setvariable variable=linuxImagetag;isOutput=true]$linuxImagetag"
+            echo "##vso[task.setvariable variable=windowsImageTag;isOutput=true]$windowsImageTag"
+            echo "##vso[task.setvariable variable=linuxTelemetryTag;isOutput=true]$linuxTelemetryTag"
+            echo "##vso[task.setvariable variable=windowsTelemetryTag;isOutput=true]$windowsTelemetryTag"
+            echo "appRegistrationClientId is $APP_REGISTRATION_CLIENT_ID"
+            echo "appRegistrationTenantId is $APP_REGISTRATION_TENANT_ID"
+            echo "authAKVName is $AUTH_AKV_NAME"
+            echo "authCertName is $AUTH_CERT_NAME"
+            echo "authSignCertName is $AUTH_SIGN_CERT_NAME"
+            cd $(Build.SourcesDirectory)/deployment/mergebranch-multiarch-agent-deployment/ServiceGroupRoot/Scripts
+            tar -czvf ../artifacts.tar.gz pushAgentToAcr.sh
+            cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension/ServiceGroupRoot/Scripts
+            tar -czvf ../artifacts.tar.gz ../../../../charts/azuremonitor-containers/ pushChartToAcr.sh
+            cd $(Build.SourcesDirectory)/deployment/arc-k8s-extension-release-v2/ServiceGroupRoot/Scripts
+            tar -czvf ../artifacts.tar.gz arcExtensionRelease.sh
+            windowsAMAUrl=""
+            if [ -z "$WINDOWS_AMA_URL" ]
+              then
+                echo "\$WINDOWS_AMA_URL variable is not set"
+              else
+                windowsAMAUrl=$WINDOWS_AMA_URL
+                echo "\$WINDOWS_AMA_URL is $WINDOWS_AMA_URL"
+            fi
+            echo "##vso[task.setvariable variable=windowsAMAUrl;isOutput=true]$windowsAMAUrl"
+          name: setup
+        - task: CredScan@3
+          displayName: "SDL : Run credscan"
+        - task: CopyFiles@2
+          displayName: "Copy ev2 deployment artifacts"
+          inputs:
+            SourceFolder: "$(Build.SourcesDirectory)/deployment"
+            Contents: |
+              **/*
+              !**/ScanTelemetry_*.json
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+        - task: CopyFiles@2
+          displayName: "Copy ev2 deployment scripts"
+          inputs:
+            SourceFolder: "$(Build.SourcesDirectory)/.pipelines"
+            Contents: |
+              **/*.sh
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+        - task: CopyFiles@2
+          displayName: "Copy ev2 deployment scripts"
+          inputs:
+            SourceFolder: "$(Build.SourcesDirectory)/kubernetes"
+            Contents: |
+              *.yaml
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+        - task: CopyFiles@2
+          displayName: "Copy ev2 deployment scripts"
+          inputs:
+            SourceFolder: "$(Build.SourcesDirectory)/charts"
+            Contents: |
+              **/*
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+        - task: CopyFiles@2
+          displayName: "Copy ev2 deployment scripts"
+          inputs:
+            SourceFolder: "$(Build.SourcesDirectory)/test/e2e"
+            Contents: |
+              *.yaml
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/build'
+        - task: Armory@2
+          displayName: 'Run ARMory'
+          inputs:
+            toolVersion: Latest
+            targetDirectory: '$(Build.SourcesDirectory)'
+      - job: build_linux
+        timeoutInMinutes: 120
+        dependsOn: common
+        variables:
+          linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
+          linuxTelemetryTag: $[ dependencies.common.outputs['setup.linuxTelemetryTag'] ]
+          Codeql.Enabled: true
+          Codeql.BuildIdentifier: 'linuxbuild'
+          DOCKER_BUILDKIT: 1
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: linux-drop
+        steps:
+        - task: CodeQL3000Init@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+        - task: AzureCLI@2
+          displayName: "Multi-arch Linux build"
+          inputs:
+            azureSubscription: ${{ variables.armServiceConnectionName }}
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/linux
+              sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
+              docker system prune --all -f
+              docker images -q --filter "dangling=true" | xargs docker rmi
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --name testbuilder
+              docker buildx use testbuilder
+              az --version
+              az account show
+              az account set -s ${{ variables.subscription }}
+              az acr login -n ${{ variables.containerRegistry }}
+              # NOTE: Using the prometheus-collector team's cached buildx image since moby/buildkit:buildx-stable-1 getting throttled
+              docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
+              docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
+              docker buildx inspect --bootstrap
+              # Determine if we should push to ACR
+              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+              SHOULD_PUSH="false"
+              if [ "$(Build.Reason)" != "PullRequest" ]; then
+                SHOULD_PUSH="true"
+              elif [[ "$(System.PullRequest.SourceBranch)" == "zane/ci-agent-auto-deploy" ]] || [[ "$(System.PullRequest.SourceBranch)" == *"run-e2e"* ]]; then
+                SHOULD_PUSH="true"
+                echo "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+              fi
               
-    #           if [ "$SHOULD_PUSH" == "true" ]; then
-    #             docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .
-    #             echo "##vso[task.logissue type=warning]Linux image built with tag: ${{ variables.repoImageName }}:$(linuxImagetag)"
-    #             docker pull ${{ variables.repoImageName }}:$(linuxImagetag)
-    #           else
-    #             docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --provenance=false .
-    #             # load the multi-arch image to run tests
-    #             docker buildx build --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --load --provenance=false .
-    #           fi
-    #     - bash: |
-    #         curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
-    #         mkdir -p oras-install/
-    #         tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
-    #         sudo mv oras-install/oras /usr/local/bin/
-    #         rm -rf oras_1.0.0_*.tar.gz oras-install/
-    #         TARGET_ARTIFACT=$(oras manifest fetch ${{ variables.repoImageName }}:$(linuxImagetag) --descriptor)
-    #         cat <<EOF >>$(Build.ArtifactStagingDirectory)/linux/payload.json
-    #         {"targetArtifact":$TARGET_ARTIFACT}
-    #         EOF
-    #         cat $(Build.ArtifactStagingDirectory)/linux/payload.json
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-    #       displayName: "Install oras and build the payload json file"
-    #       condition: eq(variables.IS_PR, false)
-    #     - task: EsrpCodeSigning@5
-    #       condition: eq(variables.IS_PR, false)
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/linux'
-    #         Pattern: 'payload.json'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                       {
-    #                           "keyCode": "CP-469451",
-    #                           "operationSetCode": "NotaryCoseSign",
-    #                           "parameters": [
-    #                             {
-    #                               "parameterName": "CoseFlags",
-    #                               "parameterValue": "chainunprotected"
-    #                             }
-    #                           ],
-    #                           "toolName": "sign",
-    #                           "toolVersion": "1.0"
-    #                       }
-    #                     ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #         PendingAnalysisWaitTimeoutMinutes: '5'
-    #       displayName: 'Esrp Image Signing for linux image'
-    #     - bash: |
-    #         set -euxo pipefail
-    #         oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
-    #           --artifact-type 'application/vnd.cncf.notary.signature' \
-    #           ./payload.json:application/cose \
-    #           -a "io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]"
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-    #       displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
-    #       condition: eq(variables.IS_PR, false)
-    #     - bash: |
-    #         set -euxo pipefail
-    #         oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
-    #             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-    #             --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
-    #       displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
-    #       condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
-    #     - task: AzureCLI@2
-    #       displayName: "Vulnerability Scan with Trivy"
-    #       inputs:
-    #         azureSubscription: ${{ variables.armServiceConnectionName }}
-    #         scriptType: bash
-    #         scriptLocation: inlineScript
-    #         inlineScript: |
-    #           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-    #           PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
-    #           SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
-    #           PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
-    #           SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
-    #           # Set initial repositories to primary
-    #           export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY
-    #           export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
-    #           # Function to run Trivy scan and handle output
-    #           run_trivy_scan() {
-    #               trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
-    #               return $?
-    #           }
-    #           # Attempt scan up to 5 times with repository fallback
-    #           for i in {1..5}; do
-    #               echo "Running Trivy scan attempt $i"
-    #               # Run the Trivy scan and capture exit code
-    #               run_trivy_scan
-    #               TRIVY_EXIT_CODE=$?
-    #               # Check if scan was successful
-    #               if [ $TRIVY_EXIT_CODE -eq 0 ]; then
-    #                   echo "Trivy scan succeeded."
-    #                   cat trivy_output.log
-    #                   break
-    #               fi
-    #               # If the first attempt fails, switch to secondary repositories
-    #               if [ $i -eq 1 ]; then
-    #                   echo "Primary repositories failed with an error. Switching to secondary repositories."
-    #                   export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY
-    #                   export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY
-    #               fi
-    #               # Log and wait before retrying if an error occurred
-    #               echo "Error: Trivy scan attempt $i failed. Retrying ($i/5)"
-    #               cat trivy_output.log
-    #               sleep 5 # Wait 5 seconds before retrying
-    #           done
-    #           # Final check: if still failing after 5 attempts, exit with error
-    #           if [ $TRIVY_EXIT_CODE -ne 0 ]; then
-    #               echo "Error: Trivy scan failed after 5 retries."
-    #               exit 1
-    #           fi
-    #     - task: GoTool@0
-    #       inputs:
-    #         version: '1.23.8'
-    #     - bash: |
-    #         cd $(System.DefaultWorkingDirectory)/build/linux/
-    #         ls
-    #         make
-    #       displayName: 'Execute Makefile for Linux Build'
-    #     - task: CodeQL3000Finalize@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    #       displayName: 'Generation Task'
-    #       condition: eq(variables.IS_PR, false)
-    #       inputs:
-    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
-    #         DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
-    #     - bash: |
-    #         dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
-    #         echo "Docker images to scan: $dockerImagesToScan"
-    #         echo "##vso[task.setvariable variable=dockerImagesToScan]$dockerImagesToScan"
-    #       displayName: 'Set Docker images to scan'
-    #   - job: build_windows_2019
-    #     pool:
-    #       name: Azure-Pipelines-CI-Test-EO
-    #       image: ci-1es-managed-windows-2022
-    #       os: windows
-    #     timeoutInMinutes: 120
-    #     dependsOn:
-    #     - common
-    #     variables:
-    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-    #       windows2019BaseImageVersion: ltsc2019
-    #       Codeql.Enabled: true
-    #       Codeql.BuildIdentifier: 'windowsbuild'
-    #       windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
-    #     steps:
-    #     - task: PowerShell@2
-    #       inputs:
-    #         targetType: 'filePath'
-    #         filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-    #       displayName: 'install prereqs'
-    #     - task: CodeQL3000Init@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #     - script: |
-    #         setlocal enabledelayedexpansion
-    #         powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-    #         endlocal
-    #         exit /B %ERRORLEVEL%
-    #       displayName: 'build base'
-    #     - task: AzureCLI@2
-    #       displayName: "Set up acr for windows ltsc2019 build"
-    #       inputs:
-    #         azureSubscription: ${{ variables.armServiceConnectionName }}
-    #         scriptType: ps
-    #         scriptLocation: inlineScript
-    #         retryCountOnTaskFailure: 2
-    #         inlineScript: |
-    #           az --version
-    #           az account show
-    #           az account set -s ${{ variables.subscription }}
-    #           az acr login -n ${{ variables.containerRegistry }}
-    #     - task: PowerShell@2          
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           # Check if directory exists and remove it before creating it to handle retry scenarios
-    #           if (Test-Path -Path "$(Build.ArtifactStagingDirectory)/windows") {
-    #             Remove-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -Recurse -Force
-    #           }
-    #           New-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -ItemType Directory -Force
-    #           cd kubernetes/windows
-    #           # Build the Docker image
-    #           docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
-    #       displayName: "Docker windows build for ltsc2019"
-    #       retryCountOnTaskFailure: 2
-    #     - task: PowerShell@2
-    #       displayName: Extract files to sign
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           echo "Creating docker container"
-    #           docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
-    #           echo "Creating fist party directory"
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
-    #           cd $(Build.ArtifactStagingDirectory)/fpSigning
-    #           echo "Extract CertificateGenerator"
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
-    #           echo "Extract LivenessProbe"
-    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
-    #           echo "Extract ps scripts"
-    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
-    #           echo "Creating OSS directory"
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
-    #           cd $(Build.ArtifactStagingDirectory)/ossSigning
-    #           echo "Extract CertificateGenerator"
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
-    #           echo "Extract fluent-bit"
-    #           docker cp signingContainer:C:\opt\fluent-bit .
-    #           echo "Extract Ruby"
-    #           docker cp signingContainer:C:\ruby31 .
-    #           echo "Extract telegraf"
-    #           docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
-    #           echo "Extract out oms"
-    #           docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
-    #           echo "Extract containerinventory.so"
-    #           docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
-    #           echo "Extract perf.so"
-    #           docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
-    #           echo "Removing container"
-    #           docker rm signingContainer
-    #           echo "List ArtifactStagingDirectory"
-    #           ls $(Build.ArtifactStagingDirectory)
-    #           ls .
-    #     - script: dir $(System.DefaultWorkingDirectory)
-    #       displayName: 'List files in DefaultWorking Directory'
-    #     - script: dir $(Build.ArtifactStagingDirectory)
-    #       displayName: 'List files in Staging Directory'
-    #     - task: EsrpCodeSigning@5
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
-    #         Pattern: '*.dll,*.exe,*.so,*.ps1'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                   {
-    #                       "KeyCode" : "CP-230012",
-    #                       "OperationCode" : "SigntoolSign",
-    #                       "Parameters" : {
-    #                           "OpusName" : "Microsoft",
-    #                           "OpusInfo" : "http://www.microsoft.com",
-    #                           "FileDigest" : "/fd \"SHA256\"",
-    #                           "PageHash" : "/NPH",
-    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #                       },
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   },
-    #                   {
-    #                       "KeyCode" : "CP-230012",
-    #                       "OperationCode" : "SigntoolVerify",
-    #                       "Parameters" : {},
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   }
-    #               ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #       displayName: 'EsrpCodeSigning for first party'
-    #     - task: EsrpCodeSigning@5
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
-    #         Pattern: '*.dll,*.exe,*.so'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                   {
-    #                       "KeyCode" : "CP-231522",
-    #                       "OperationCode" : "SigntoolSign",
-    #                       "Parameters" : {
-    #                           "OpusName" : "Microsoft",
-    #                           "OpusInfo" : "http://www.microsoft.com",
-    #                           "Append" : "/as",
-    #                           "FileDigest" : "/fd \"SHA256\"",
-    #                           "PageHash" : "/NPH",
-    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #                       },
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   },
-    #                   {
-    #                       "KeyCode" : "CP-231522",
-    #                       "OperationCode" : "SigntoolVerify",
-    #                       "Parameters" : {},
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   }
-    #               ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #       displayName: 'EsrpCodeSigning for OSS'
-    #     - task: BinSkim@4
-    #       displayName: 'SDL: run binskim'
-    #       inputs:
-    #         InputType: 'CommandLine'
-    #         arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
-    #       retryCountOnTaskFailure: 1
-    #     - task: PoliCheck@2
-    #       displayName: "SDL : Run PoliCheck"
-    #       inputs:
-    #         targetType: 'F'
-    #         targetArgument: '$(Build.SourcesDirectory)'
-    #     - task: PowerShell@2
-    #       displayName: Replace files in origin Image
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
-    #           echo "Copy Signed binaries/folders back to docker image"
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
-    #           docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
-    #           docker rm pushContainer
-    #     - task: PowerShell@2
-    #       displayName: Push Docker Image
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-    #           $shouldPush = $false
-    #           if ("$(Build.Reason)" -ne "PullRequest") {
-    #             $shouldPush = $true
-    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-    #             $shouldPush = $true
-    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-    #           }
+              if [ "$SHOULD_PUSH" == "true" ]; then
+                docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .
+                echo "##vso[task.logissue type=warning]Linux image built with tag: ${{ variables.repoImageName }}:$(linuxImagetag)"
+                docker pull ${{ variables.repoImageName }}:$(linuxImagetag)
+              else
+                docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --provenance=false .
+                # load the multi-arch image to run tests
+                docker buildx build --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --load --provenance=false .
+              fi
+        - bash: |
+            curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
+            mkdir -p oras-install/
+            tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
+            sudo mv oras-install/oras /usr/local/bin/
+            rm -rf oras_1.0.0_*.tar.gz oras-install/
+            TARGET_ARTIFACT=$(oras manifest fetch ${{ variables.repoImageName }}:$(linuxImagetag) --descriptor)
+            cat <<EOF >>$(Build.ArtifactStagingDirectory)/linux/payload.json
+            {"targetArtifact":$TARGET_ARTIFACT}
+            EOF
+            cat $(Build.ArtifactStagingDirectory)/linux/payload.json
+          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+          displayName: "Install oras and build the payload json file"
+          condition: eq(variables.IS_PR, false)
+        - task: EsrpCodeSigning@5
+          condition: eq(variables.IS_PR, false)
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/linux'
+            Pattern: 'payload.json'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                          {
+                              "keyCode": "CP-469451",
+                              "operationSetCode": "NotaryCoseSign",
+                              "parameters": [
+                                {
+                                  "parameterName": "CoseFlags",
+                                  "parameterValue": "chainunprotected"
+                                }
+                              ],
+                              "toolName": "sign",
+                              "toolVersion": "1.0"
+                          }
+                        ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+            PendingAnalysisWaitTimeoutMinutes: '5'
+          displayName: 'Esrp Image Signing for linux image'
+        - bash: |
+            set -euxo pipefail
+            oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
+              --artifact-type 'application/vnd.cncf.notary.signature' \
+              ./payload.json:application/cose \
+              -a "io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]"
+          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+          displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
+          condition: eq(variables.IS_PR, false)
+        - bash: |
+            set -euxo pipefail
+            oras attach ${{ variables.repoImageName }}:$(linuxImagetag) \
+                --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+                --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
+          workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
+          displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
+          condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
+        - task: AzureCLI@2
+          displayName: "Vulnerability Scan with Trivy"
+          inputs:
+            azureSubscription: ${{ variables.armServiceConnectionName }}
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+              PRIMARY_TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db"
+              SECONDARY_TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db"
+              PRIMARY_TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db"
+              SECONDARY_TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db"
+              # Set initial repositories to primary
+              export TRIVY_DB_REPOSITORY=$PRIMARY_TRIVY_DB_REPOSITORY
+              export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
+              # Function to run Trivy scan and handle output
+              run_trivy_scan() {
+                  trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  return $?
+              }
+              # Attempt scan up to 5 times with repository fallback
+              for i in {1..5}; do
+                  echo "Running Trivy scan attempt $i"
+                  # Run the Trivy scan and capture exit code
+                  run_trivy_scan
+                  TRIVY_EXIT_CODE=$?
+                  # Check if scan was successful
+                  if [ $TRIVY_EXIT_CODE -eq 0 ]; then
+                      echo "Trivy scan succeeded."
+                      cat trivy_output.log
+                      break
+                  fi
+                  # If the first attempt fails, switch to secondary repositories
+                  if [ $i -eq 1 ]; then
+                      echo "Primary repositories failed with an error. Switching to secondary repositories."
+                      export TRIVY_DB_REPOSITORY=$SECONDARY_TRIVY_DB_REPOSITORY
+                      export TRIVY_JAVA_DB_REPOSITORY=$SECONDARY_TRIVY_JAVA_DB_REPOSITORY
+                  fi
+                  # Log and wait before retrying if an error occurred
+                  echo "Error: Trivy scan attempt $i failed. Retrying ($i/5)"
+                  cat trivy_output.log
+                  sleep 5 # Wait 5 seconds before retrying
+              done
+              # Final check: if still failing after 5 attempts, exit with error
+              if [ $TRIVY_EXIT_CODE -ne 0 ]; then
+                  echo "Error: Trivy scan failed after 5 retries."
+                  exit 1
+              fi
+        - task: GoTool@0
+          inputs:
+            version: '1.23.8'
+        - bash: |
+            cd $(System.DefaultWorkingDirectory)/build/linux/
+            ls
+            make
+          displayName: 'Execute Makefile for Linux Build'
+        - task: CodeQL3000Finalize@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generation Task'
+          condition: eq(variables.IS_PR, false)
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)/linux'
+            DockerImagesToScan: '$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+        - bash: |
+            dockerImagesToScan='$(GOLANG_BASE_IMAGE),$(CI_BASE_IMAGE),${{ variables.repoImageName }}:$(linuxImagetag)'
+            echo "Docker images to scan: $dockerImagesToScan"
+            echo "##vso[task.setvariable variable=dockerImagesToScan]$dockerImagesToScan"
+          displayName: 'Set Docker images to scan'
+      - job: build_windows_2019
+        pool:
+          name: Azure-Pipelines-CI-Test-EO
+          image: ci-1es-managed-windows-2022
+          os: windows
+        timeoutInMinutes: 120
+        dependsOn:
+        - common
+        variables:
+          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+          windows2019BaseImageVersion: ltsc2019
+          Codeql.Enabled: true
+          Codeql.BuildIdentifier: 'windowsbuild'
+          windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
+        steps:
+        - task: PowerShell@2
+          inputs:
+            targetType: 'filePath'
+            filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+          displayName: 'install prereqs'
+        - task: CodeQL3000Init@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+        - script: |
+            setlocal enabledelayedexpansion
+            powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+            endlocal
+            exit /B %ERRORLEVEL%
+          displayName: 'build base'
+        - task: AzureCLI@2
+          displayName: "Set up acr for windows ltsc2019 build"
+          inputs:
+            azureSubscription: ${{ variables.armServiceConnectionName }}
+            scriptType: ps
+            scriptLocation: inlineScript
+            retryCountOnTaskFailure: 2
+            inlineScript: |
+              az --version
+              az account show
+              az account set -s ${{ variables.subscription }}
+              az acr login -n ${{ variables.containerRegistry }}
+        - task: PowerShell@2          
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Check if directory exists and remove it before creating it to handle retry scenarios
+              if (Test-Path -Path "$(Build.ArtifactStagingDirectory)/windows") {
+                Remove-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -Recurse -Force
+              }
+              New-Item -Path "$(Build.ArtifactStagingDirectory)/windows" -ItemType Directory -Force
+              cd kubernetes/windows
+              # Build the Docker image
+              docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2019BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
+          displayName: "Docker windows build for ltsc2019"
+          retryCountOnTaskFailure: 2
+        - task: PowerShell@2
+          displayName: Extract files to sign
+          inputs:
+            targetType: 'inline'
+            script: |
+              echo "Creating docker container"
+              docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
+              echo "Creating fist party directory"
+              mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
+              cd $(Build.ArtifactStagingDirectory)/fpSigning
+              echo "Extract CertificateGenerator"
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
+              echo "Extract LivenessProbe"
+              docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
+              echo "Extract ps scripts"
+              docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
+              echo "Creating OSS directory"
+              mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
+              cd $(Build.ArtifactStagingDirectory)/ossSigning
+              echo "Extract CertificateGenerator"
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
+              echo "Extract fluent-bit"
+              docker cp signingContainer:C:\opt\fluent-bit .
+              echo "Extract Ruby"
+              docker cp signingContainer:C:\ruby31 .
+              echo "Extract telegraf"
+              docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
+              echo "Extract out oms"
+              docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
+              echo "Extract containerinventory.so"
+              docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
+              echo "Extract perf.so"
+              docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
+              echo "Removing container"
+              docker rm signingContainer
+              echo "List ArtifactStagingDirectory"
+              ls $(Build.ArtifactStagingDirectory)
+              ls .
+        - script: dir $(System.DefaultWorkingDirectory)
+          displayName: 'List files in DefaultWorking Directory'
+        - script: dir $(Build.ArtifactStagingDirectory)
+          displayName: 'List files in Staging Directory'
+        - task: EsrpCodeSigning@5
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
+            Pattern: '*.dll,*.exe,*.so,*.ps1'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                      {
+                          "KeyCode" : "CP-230012",
+                          "OperationCode" : "SigntoolSign",
+                          "Parameters" : {
+                              "OpusName" : "Microsoft",
+                              "OpusInfo" : "http://www.microsoft.com",
+                              "FileDigest" : "/fd \"SHA256\"",
+                              "PageHash" : "/NPH",
+                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          },
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      },
+                      {
+                          "KeyCode" : "CP-230012",
+                          "OperationCode" : "SigntoolVerify",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      }
+                  ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+          displayName: 'EsrpCodeSigning for first party'
+        - task: EsrpCodeSigning@5
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
+            Pattern: '*.dll,*.exe,*.so'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                      {
+                          "KeyCode" : "CP-231522",
+                          "OperationCode" : "SigntoolSign",
+                          "Parameters" : {
+                              "OpusName" : "Microsoft",
+                              "OpusInfo" : "http://www.microsoft.com",
+                              "Append" : "/as",
+                              "FileDigest" : "/fd \"SHA256\"",
+                              "PageHash" : "/NPH",
+                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          },
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      },
+                      {
+                          "KeyCode" : "CP-231522",
+                          "OperationCode" : "SigntoolVerify",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      }
+                  ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+          displayName: 'EsrpCodeSigning for OSS'
+        - task: BinSkim@4
+          displayName: 'SDL: run binskim'
+          inputs:
+            InputType: 'CommandLine'
+            arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
+          retryCountOnTaskFailure: 1
+        - task: PoliCheck@2
+          displayName: "SDL : Run PoliCheck"
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)'
+        - task: PowerShell@2
+          displayName: Replace files in origin Image
+          inputs:
+            targetType: 'inline'
+            script: |
+              docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)-unsigned
+              echo "Copy Signed binaries/folders back to docker image"
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
+              docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+              docker rm pushContainer
+        - task: PowerShell@2
+          displayName: Push Docker Image
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+              $shouldPush = $false
+              if ("$(Build.Reason)" -ne "PullRequest") {
+                $shouldPush = $true
+              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+                $shouldPush = $true
+                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+              }
               
-    #           if ($shouldPush) {
-    #             docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
-    #           }
-    #     - task: CodeQL3000Finalize@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #   - job: build_windows_2022
-    #     pool:
-    #       name: Azure-Pipelines-CI-Test-EO
-    #       image: ci-1es-managed-windows-2022
-    #       os: windows
-    #     timeoutInMinutes: 120
-    #     dependsOn:
-    #     - common
-    #     variables:
-    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-    #       windows2022BaseImageVersion: ltsc2022
-    #       Codeql.SkipTaskAutoInjection: true
-    #       windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
-    #     steps:
-    #     - task: PowerShell@2
-    #       inputs:
-    #         targetType: 'filePath'
-    #         filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
-    #       displayName: 'install prereqs'
-    #     - task: CodeQL3000Init@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #     - script: |
-    #         setlocal enabledelayedexpansion
-    #         powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
-    #         endlocal
-    #         exit /B %ERRORLEVEL%
-    #       displayName: 'build base'
-    #     - task: AzureCLI@2
-    #       displayName: "Docker windows build for ltsc2022"
-    #       inputs:
-    #         azureSubscription: ${{ variables.armServiceConnectionName }}
-    #         scriptType: ps
-    #         scriptLocation: inlineScript
-    #         retryCountOnTaskFailure: 2
-    #         inlineScript: |
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/windows
-    #           cd kubernetes/windows
-    #           az --version
-    #           az account show
-    #           az account set -s ${{ variables.subscription }}
-    #           az acr login -n ${{ variables.containerRegistry }}
-    #           docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
-    #     - task: PowerShell@2
-    #       displayName: Extract files to sign
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           echo "Creating docker container"
-    #           docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
-    #           echo "Creating fist party directory"
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
-    #           cd $(Build.ArtifactStagingDirectory)/fpSigning
-    #           echo "Extract CertificateGenerator"
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
-    #           echo "Extract LivenessProbe"
-    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
-    #           echo "Extract ps scripts"
-    #           docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
-    #           echo "Creating OSS directory"
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
-    #           cd $(Build.ArtifactStagingDirectory)/ossSigning
-    #           echo "Extract CertificateGenerator"
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
-    #           docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
-    #           echo "Extract fluent-bit"
-    #           docker cp signingContainer:C:\opt\fluent-bit .
-    #           echo "Extract Ruby"
-    #           docker cp signingContainer:C:\ruby31 .
-    #           echo "Extract telegraf"
-    #           docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
-    #           echo "Extract out oms"
-    #           docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
-    #           echo "Extract containerinventory.so"
-    #           docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
-    #           echo "Extract perf.so"
-    #           docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
-    #           echo "Removing container"
-    #           docker rm signingContainer
-    #           echo "List ArtifactStagingDirectory"
-    #           ls $(Build.ArtifactStagingDirectory)
-    #           ls .
-    #     - script: dir $(System.DefaultWorkingDirectory)
-    #       displayName: 'List files in DefaultWorking Directory'
-    #     - script: dir $(Build.ArtifactStagingDirectory)
-    #       displayName: 'List files in Staging Directory'
-    #     - task: EsrpCodeSigning@5
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
-    #         Pattern: '*.dll,*.exe,*.so,*.ps1'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                   {
-    #                       "KeyCode" : "CP-230012",
-    #                       "OperationCode" : "SigntoolSign",
-    #                       "Parameters" : {
-    #                           "OpusName" : "Microsoft",
-    #                           "OpusInfo" : "http://www.microsoft.com",
-    #                           "FileDigest" : "/fd \"SHA256\"",
-    #                           "PageHash" : "/NPH",
-    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #                       },
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   },
-    #                   {
-    #                       "KeyCode" : "CP-230012",
-    #                       "OperationCode" : "SigntoolVerify",
-    #                       "Parameters" : {},
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   }
-    #               ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #       displayName: 'EsrpCodeSigning for first party'
-    #     - task: EsrpCodeSigning@5
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
-    #         Pattern: '*.dll,*.exe,*.so'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                   {
-    #                       "KeyCode" : "CP-231522",
-    #                       "OperationCode" : "SigntoolSign",
-    #                       "Parameters" : {
-    #                           "OpusName" : "Microsoft",
-    #                           "OpusInfo" : "http://www.microsoft.com",
-    #                           "Append" : "/as",
-    #                           "FileDigest" : "/fd \"SHA256\"",
-    #                           "PageHash" : "/NPH",
-    #                           "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #                       },
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   },
-    #                   {
-    #                       "KeyCode" : "CP-231522",
-    #                       "OperationCode" : "SigntoolVerify",
-    #                       "Parameters" : {},
-    #                       "ToolName" : "sign",
-    #                       "ToolVersion" : "1.0"
-    #                   }
-    #               ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #       displayName: 'EsrpCodeSigning for OSS'
-    #     - task: BinSkim@4
-    #       displayName: 'SDL: run binskim'
-    #       inputs:
-    #         InputType: 'CommandLine'
-    #         arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
-    #       retryCountOnTaskFailure: 1
-    #     - task: PoliCheck@2
-    #       displayName: "SDL : Run PoliCheck"
-    #       inputs:
-    #         targetType: 'F'
-    #         targetArgument: '$(Build.SourcesDirectory)'
-    #     - task: PowerShell@2
-    #       displayName: Replace files in origin Image
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
-    #           echo "Copy Signed binaries/folders back to docker image"
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
-    #           docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
-    #           docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-    #           docker rm pushContainer
-    #     - task: PowerShell@2
-    #       displayName: Push Docker Image
-    #       inputs:
-    #         targetType: 'inline'
-    #         script: |
-    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-    #           $shouldPush = $false
-    #           if ("$(Build.Reason)" -ne "PullRequest") {
-    #             $shouldPush = $true
-    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-    #             $shouldPush = $true
-    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-    #           }
+              if ($shouldPush) {
+                docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
+              }
+        - task: CodeQL3000Finalize@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+      - job: build_windows_2022
+        pool:
+          name: Azure-Pipelines-CI-Test-EO
+          image: ci-1es-managed-windows-2022
+          os: windows
+        timeoutInMinutes: 120
+        dependsOn:
+        - common
+        variables:
+          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+          windows2022BaseImageVersion: ltsc2022
+          Codeql.SkipTaskAutoInjection: true
+          windowsAMAUrl: $[ dependencies.common.outputs['setup.windowsAMAUrl'] ]
+        steps:
+        - task: PowerShell@2
+          inputs:
+            targetType: 'filePath'
+            filePath: $(System.DefaultWorkingDirectory)/scripts/build/windows/install-build-pre-requisites.ps1
+          displayName: 'install prereqs'
+        - task: CodeQL3000Init@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+        - script: |
+            setlocal enabledelayedexpansion
+            powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
+            endlocal
+            exit /B %ERRORLEVEL%
+          displayName: 'build base'
+        - task: AzureCLI@2
+          displayName: "Docker windows build for ltsc2022"
+          inputs:
+            azureSubscription: ${{ variables.armServiceConnectionName }}
+            scriptType: ps
+            scriptLocation: inlineScript
+            retryCountOnTaskFailure: 2
+            inlineScript: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/windows
+              cd kubernetes/windows
+              az --version
+              az account show
+              az account set -s ${{ variables.subscription }}
+              az acr login -n ${{ variables.containerRegistry }}
+              docker build --isolation=hyperv --tag ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned --build-arg WINDOWS_VERSION=$(windows2022BaseImageVersion) --build-arg IMAGE_TAG=$(windowsTelemetryTag) --build-arg WINDOWS_AMA_URL=$(windowsAMAUrl) .
+        - task: PowerShell@2
+          displayName: Extract files to sign
+          inputs:
+            targetType: 'inline'
+            script: |
+              echo "Creating docker container"
+              docker create --name signingContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
+              echo "Creating fist party directory"
+              mkdir -p $(Build.ArtifactStagingDirectory)/fpSigning
+              cd $(Build.ArtifactStagingDirectory)/fpSigning
+              echo "Extract CertificateGenerator"
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe .
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll .
+              echo "Extract LivenessProbe"
+              docker cp signingContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe .
+              echo "Extract ps scripts"
+              docker cp signingContainer:C:\opt\amalogswindows\scripts\powershell .
+              echo "Creating OSS directory"
+              mkdir -p $(Build.ArtifactStagingDirectory)/ossSigning
+              cd $(Build.ArtifactStagingDirectory)/ossSigning
+              echo "Extract CertificateGenerator"
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll .
+              docker cp signingContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll .
+              echo "Extract fluent-bit"
+              docker cp signingContainer:C:\opt\fluent-bit .
+              echo "Extract Ruby"
+              docker cp signingContainer:C:\ruby31 .
+              echo "Extract telegraf"
+              docker cp signingContainer:C:\opt\telegraf\telegraf.exe .
+              echo "Extract out oms"
+              docker cp signingContainer:C:\opt\amalogswindows\out_oms.so .
+              echo "Extract containerinventory.so"
+              docker cp signingContainer:C:\opt\fluent-bit\bin\containerinventory.so .
+              echo "Extract perf.so"
+              docker cp signingContainer:C:\opt\fluent-bit\bin\perf.so .
+              echo "Removing container"
+              docker rm signingContainer
+              echo "List ArtifactStagingDirectory"
+              ls $(Build.ArtifactStagingDirectory)
+              ls .
+        - script: dir $(System.DefaultWorkingDirectory)
+          displayName: 'List files in DefaultWorking Directory'
+        - script: dir $(Build.ArtifactStagingDirectory)
+          displayName: 'List files in Staging Directory'
+        - task: EsrpCodeSigning@5
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/fpSigning'
+            Pattern: '*.dll,*.exe,*.so,*.ps1'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                      {
+                          "KeyCode" : "CP-230012",
+                          "OperationCode" : "SigntoolSign",
+                          "Parameters" : {
+                              "OpusName" : "Microsoft",
+                              "OpusInfo" : "http://www.microsoft.com",
+                              "FileDigest" : "/fd \"SHA256\"",
+                              "PageHash" : "/NPH",
+                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          },
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      },
+                      {
+                          "KeyCode" : "CP-230012",
+                          "OperationCode" : "SigntoolVerify",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      }
+                  ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+          displayName: 'EsrpCodeSigning for first party'
+        - task: EsrpCodeSigning@5
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/ossSigning'
+            Pattern: '*.dll,*.exe,*.so'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                      {
+                          "KeyCode" : "CP-231522",
+                          "OperationCode" : "SigntoolSign",
+                          "Parameters" : {
+                              "OpusName" : "Microsoft",
+                              "OpusInfo" : "http://www.microsoft.com",
+                              "Append" : "/as",
+                              "FileDigest" : "/fd \"SHA256\"",
+                              "PageHash" : "/NPH",
+                              "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          },
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      },
+                      {
+                          "KeyCode" : "CP-231522",
+                          "OperationCode" : "SigntoolVerify",
+                          "Parameters" : {},
+                          "ToolName" : "sign",
+                          "ToolVersion" : "1.0"
+                      }
+                  ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+          displayName: 'EsrpCodeSigning for OSS'
+        - task: BinSkim@4
+          displayName: 'SDL: run binskim'
+          inputs:
+            InputType: 'CommandLine'
+            arguments: 'analyze --rich-return-code $(Build.ArtifactStagingDirectory)\ossSigning\out_oms.so $(Build.ArtifactStagingDirectory)\ossSigning\perf.so $(Build.ArtifactStagingDirectory)\ossSigning\containerinventory.so $(Build.ArtifactStagingDirectory)\fpSigning\livenessprobe.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.exe $(Build.ArtifactStagingDirectory)\fpSigning\CertificateGenerator.dll'
+          retryCountOnTaskFailure: 1
+        - task: PoliCheck@2
+          displayName: "SDL : Run PoliCheck"
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)'
+        - task: PowerShell@2
+          displayName: Replace files in origin Image
+          inputs:
+            targetType: 'inline'
+            script: |
+              docker create --name pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)-unsigned
+              echo "Copy Signed binaries/folders back to docker image"
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.exe pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.exe
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/CertificateGenerator.dll pushContainer:C:\opt\amalogswindows\certgenerator\CertificateGenerator.dll
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/livenessprobe.exe pushContainer:C:\opt\amalogswindows\scripts\cmd\livenessprobe.exe
+              docker cp $(Build.ArtifactStagingDirectory)/fpSigning/powershell/. pushContainer:C:\opt\amalogswindows\scripts\powershell/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/BouncyCastle.Crypto.dll pushContainer:C:\opt\amalogswindows\certgenerator\BouncyCastle.Crypto.dll
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/Newtonsoft.Json.dll pushContainer:C:\opt\amalogswindows\certgenerator\Newtonsoft.Json.dll
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/fluent-bit/. pushContainer:C:\opt\fluent-bit/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/ruby31/. pushContainer:C:\ruby31/
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/telegraf.exe pushContainer:C:\opt\telegraf\telegraf.exe
+              docker cp $(Build.ArtifactStagingDirectory)/ossSigning/out_oms.so pushContainer:C:\opt\amalogswindows\out_oms.so
+              docker commit pushContainer ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+              docker rm pushContainer
+        - task: PowerShell@2
+          displayName: Push Docker Image
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+              $shouldPush = $false
+              if ("$(Build.Reason)" -ne "PullRequest") {
+                $shouldPush = $true
+              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+                $shouldPush = $true
+                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
+              }
               
-    #           if ($shouldPush) {
-    #             docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-    #           }
-    #     - task: CodeQL3000Finalize@0
-    #       condition: eq(variables.IS_MAIN_BRANCH, true)
-    #   - job: build_windows_multi_arc
-    #     pool:
-    #       name: Azure-Pipelines-CI-Test-EO
-    #       image: ci-1es-managed-windows-2022
-    #       os: windows
-    #     timeoutInMinutes: 120
-    #     dependsOn:
-    #     - common
-    #     - build_windows_2019
-    #     - build_windows_2022
-    #     variables:
-    #       windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
-    #       windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
-    #       windows2019BaseImageVersion: ltsc2019
-    #       windows2022BaseImageVersion: ltsc2022
-    #       Codeql.SkipTaskAutoInjection: true
-    #     templateContext:
-    #       outputs:
-    #       - output: pipelineArtifact
-    #         targetPath: '$(Build.ArtifactStagingDirectory)'
-    #         artifactName: windows-drop
-    #     steps:
-    #     - task: AzureCLI@2
-    #       displayName: "Docker windows build for multi-arc image"
-    #       inputs:
-    #         azureSubscription: ${{ variables.armServiceConnectionName }}
-    #         scriptType: ps
-    #         scriptLocation: inlineScript
-    #         inlineScript: |
-    #           mkdir -p $(Build.ArtifactStagingDirectory)/windows
-    #           cd kubernetes/windows
-    #           az --version
-    #           az account show
-    #           az account set -s ${{ variables.subscription }}
-    #           az acr login -n ${{ variables.containerRegistry }}
-    #           @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-    #           # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-    #           $shouldPush = $false
-    #           if ("$(Build.Reason)" -ne "PullRequest") {
-    #             $shouldPush = $true
-    #           } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-    #             $shouldPush = $true
-    #             Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push multi-arch image to ACR for E2E testing"
-    #           }
+              if ($shouldPush) {
+                docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+              }
+        - task: CodeQL3000Finalize@0
+          condition: eq(variables.IS_MAIN_BRANCH, true)
+      - job: build_windows_multi_arc
+        pool:
+          name: Azure-Pipelines-CI-Test-EO
+          image: ci-1es-managed-windows-2022
+          os: windows
+        timeoutInMinutes: 120
+        dependsOn:
+        - common
+        - build_windows_2019
+        - build_windows_2022
+        variables:
+          windowsImageTag: $[ dependencies.common.outputs['setup.windowsImageTag'] ]
+          windowsTelemetryTag: $[ dependencies.common.outputs['setup.windowsTelemetryTag'] ]
+          windows2019BaseImageVersion: ltsc2019
+          windows2022BaseImageVersion: ltsc2022
+          Codeql.SkipTaskAutoInjection: true
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: windows-drop
+        steps:
+        - task: AzureCLI@2
+          displayName: "Docker windows build for multi-arc image"
+          inputs:
+            azureSubscription: ${{ variables.armServiceConnectionName }}
+            scriptType: ps
+            scriptLocation: inlineScript
+            inlineScript: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/windows
+              cd kubernetes/windows
+              az --version
+              az account show
+              az account set -s ${{ variables.subscription }}
+              az acr login -n ${{ variables.containerRegistry }}
+              @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
+              $shouldPush = $false
+              if ("$(Build.Reason)" -ne "PullRequest") {
+                $shouldPush = $true
+              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
+                $shouldPush = $true
+                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push multi-arch image to ACR for E2E testing"
+              }
               
-    #           if ($shouldPush) {
-    #              docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
-    #              docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
-    #              Write-Host "##vso[task.logissue type=warning]Windows image built with tag: ${{ variables.repoImageName }}:$(windowsImageTag)"
-    #           }
-    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    #       displayName: 'Generation Task'
-    #       condition: eq(variables.IS_PR, true)
-    #       inputs:
-    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-    #         DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022'
-    #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    #       displayName: 'Generation Task'
-    #       condition: eq(variables.IS_PR, false)
-    #       inputs:
-    #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-    #         DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022,${{ variables.repoImageName }}:$(windowsImageTag)'
-    #     - powershell: |
-    #         curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
-    #         $currentDirectory = Get-Location
-    #         Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
-    #         New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
-    #         Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
-    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-    #         $output = oras manifest fetch ${{ variables.repoImageName }}:$(windowsImageTag) --descriptor
-    #         $outputObject = $output | ConvertFrom-Json
-    #         $payload = @{
-    #             targetArtifact = $outputObject
-    #         } | ConvertTo-Json -Depth 2
-    #         $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
-    #         [System.IO.File]::WriteAllLines("$(Build.ArtifactStagingDirectory)/windows/payload.json", $payload, $utf8NoBomEncoding)
-    #         Get-Content "$(Build.ArtifactStagingDirectory)/windows/payload.json"
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-    #       displayName: "Install oras and build the payload json file"
-    #       condition: eq(variables.IS_PR, false)
-    #     - task: EsrpCodeSigning@5
-    #       condition: eq(variables.IS_PR, false)
-    #       inputs:
-    #         ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
-    #         UseMSIAuthentication: true
-    #         AppRegistrationClientId: $(appRegistrationClientId)
-    #         AppRegistrationTenantId: $(appRegistrationTenantId)
-    #         EsrpClientId: $(esrpClientId)
-    #         AuthAKVName: $(authAKVName)
-    #         AuthCertName: $(authCertName)
-    #         AuthSignCertName: $(authSignCertName)
-    #         FolderPath: '$(Build.ArtifactStagingDirectory)/windows'
-    #         Pattern: 'payload.json'
-    #         signConfigType: 'inlineSignParams'
-    #         inlineOperation: |
-    #           [
-    #                       {
-    #                           "keyCode": "CP-469451",
-    #                           "operationSetCode": "NotaryCoseSign",
-    #                           "parameters": [
-    #                             {
-    #                               "parameterName": "CoseFlags",
-    #                               "parameterValue": "chainunprotected"
-    #                             }
-    #                           ],
-    #                           "toolName": "sign",
-    #                           "toolVersion": "1.0"
-    #                       }
-    #                     ]
-    #         SessionTimeout: '60'
-    #         MaxConcurrency: '50'
-    #         MaxRetryAttempts: '5'
-    #         PendingAnalysisWaitTimeoutMinutes: '5'
-    #       displayName: 'Esrp Image Signing for windows image'
-    #     - powershell: |
-    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-    #         oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-    #       displayName: "Run oras attach"
-    #       condition: eq(variables.IS_PR, false)
-    #     - powershell: |
-    #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-    #         oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"
-    #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-    #       displayName: "Run oras attach"
-    #       condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
-    #     - task: AntiMalware@4
-    #       displayName: 'Run MpCmdRun.exe'
-    #       inputs:
-    #         InputType: Basic
-    #         ScanType: CustomScan
-    #         FileDirPath: '$(Build.ArtifactStagingDirectory)'
-    #         DisableRemediation: false
-    #         AcceptableOutdatedSignatureInHours: 72
+              if ($shouldPush) {
+                 docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
+                 docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
+                 Write-Host "##vso[task.logissue type=warning]Windows image built with tag: ${{ variables.repoImageName }}:$(windowsImageTag)"
+              }
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generation Task'
+          condition: eq(variables.IS_PR, true)
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+            DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022'
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generation Task'
+          condition: eq(variables.IS_PR, false)
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+            DockerImagesToScan: 'mcr.microsoft.com/windows/servercore:ltsc2019,mcr.microsoft.com/windows/servercore:ltsc2022,${{ variables.repoImageName }}:$(windowsImageTag)'
+        - powershell: |
+            curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
+            $currentDirectory = Get-Location
+            Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
+            New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
+            Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
+            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+            $output = oras manifest fetch ${{ variables.repoImageName }}:$(windowsImageTag) --descriptor
+            $outputObject = $output | ConvertFrom-Json
+            $payload = @{
+                targetArtifact = $outputObject
+            } | ConvertTo-Json -Depth 2
+            $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+            [System.IO.File]::WriteAllLines("$(Build.ArtifactStagingDirectory)/windows/payload.json", $payload, $utf8NoBomEncoding)
+            Get-Content "$(Build.ArtifactStagingDirectory)/windows/payload.json"
+          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+          displayName: "Install oras and build the payload json file"
+          condition: eq(variables.IS_PR, false)
+        - task: EsrpCodeSigning@5
+          condition: eq(variables.IS_PR, false)
+          inputs:
+            ConnectedServiceName: 'AME ESRPContainerInsights MSI FIC'
+            UseMSIAuthentication: true
+            AppRegistrationClientId: $(appRegistrationClientId)
+            AppRegistrationTenantId: $(appRegistrationTenantId)
+            EsrpClientId: $(esrpClientId)
+            AuthAKVName: $(authAKVName)
+            AuthCertName: $(authCertName)
+            AuthSignCertName: $(authSignCertName)
+            FolderPath: '$(Build.ArtifactStagingDirectory)/windows'
+            Pattern: 'payload.json'
+            signConfigType: 'inlineSignParams'
+            inlineOperation: |
+              [
+                          {
+                              "keyCode": "CP-469451",
+                              "operationSetCode": "NotaryCoseSign",
+                              "parameters": [
+                                {
+                                  "parameterName": "CoseFlags",
+                                  "parameterValue": "chainunprotected"
+                                }
+                              ],
+                              "toolName": "sign",
+                              "toolVersion": "1.0"
+                          }
+                        ]
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+            PendingAnalysisWaitTimeoutMinutes: '5'
+          displayName: 'Esrp Image Signing for windows image'
+        - powershell: |
+            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+            oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\"49D6CD5DB42623144D6990AA1669CE5D97F1F3D7\"]
+          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+          displayName: "Run oras attach"
+          condition: eq(variables.IS_PR, false)
+        - powershell: |
+            $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+            oras attach ${{ variables.repoImageName }}:$(windowsImageTag) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"
+          workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+          displayName: "Run oras attach"
+          condition: and(eq(variables.IS_RELEASE, false), eq(variables.IS_PR, false))
+        - task: AntiMalware@4
+          displayName: 'Run MpCmdRun.exe'
+          inputs:
+            InputType: Basic
+            ScanType: CustomScan
+            FileDirPath: '$(Build.ArtifactStagingDirectory)'
+            DisableRemediation: false
+            AcceptableOutdatedSignatureInHours: 72
 
     - stage: Deploy_and_Test_Images_In_Dev_Clusters
       displayName: Deploy and Test Images in Dev Clusters
       lockBehavior: sequential
       dependsOn: 
-        #- stage
-        []
-      # Deploy runs when Build succeeds OR when Build is skipped with valid overrides
-      # This stage runs when:
-      # 1. Direct push to ci_prod or zane/ci-agent-auto-deploy or branches containing 'run-e2e'
-      # 2. PR from zane/ci-agent-auto-deploy branch OR PR from branch containing 'run-e2e'
-      # condition: |
-      #   and(
-      #     or(
-      #       eq(variables['Build.SourceBranch'], 'refs/heads/ci_prod'),
-      #       eq(variables['Build.SourceBranch'], 'refs/heads/zane/ci-agent-auto-deploy'),
-      #       contains(variables['Build.SourceBranch'], 'run-e2e'),
-      #       and(
-      #         eq(variables['Build.Reason'], 'PullRequest'),
-      #         or(
-      #           eq(variables['System.PullRequest.SourceBranch'], 'zane/ci-agent-auto-deploy'),
-      #           contains(variables['System.PullRequest.SourceBranch'], 'run-e2e')
-      #         )
-      #       )
-      #     ),
-      #     or(
-      #       eq(dependencies.stage.result, 'Succeeded'),
-      #       and(
-      #         eq(dependencies.stage.result, 'Skipped'),
-      #         ne(variables['LinuxImageOverride'], ''),
-      #         ne(variables['WindowsImageOverride'], '')
-      #       )
-      #     )
-      #   )
+        - stage
+      condition: |
+        eq(dependencies.stage.result, 'Succeeded')
       variables:
-        # Use images built from previous build stage by default
-        # To override: Set pipeline variables 'LinuxImageOverride' and 'WindowsImageOverride' when queuing
-        linuxImageTagUnderTest: $[coalesce(variables['LinuxImageOverride'], '3.1.34')]
-        windowsImageTagUnderTest: $[coalesce(variables['WindowsImageOverride'], 'win-3.1.34')]
+        # Override the helm chart's default image repository (/azuremonitor/containerinsights/ciprod) to use cidev
+        ImageRepositoryOverride: '/azuremonitor/containerinsights/cidev'
+        # Use image tags built from the previous build stage
+        linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
+        windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
       jobs:
       # TODO: add more clusters from test automation framework when the tests are stable
       # ============================================================
@@ -978,10 +951,10 @@ extends:
           clusterName: 'zane-test'
           resourceGroup: 'zane-test'
           region: 'westus2'
-          subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
-          workspaceId: 'b59109c7-d2ab-4464-a5d0-36ed751cd076' # zane-test-la2
+          subscriptionId: $(CI_BUILD_SUB_ID)
+          workspaceId: $(ZANE_TEST_LA2_LAW_ID) # zane-test-la2
           imageTag: $(linuxImageTagUnderTest)
-          imageRepository: ${{ variables.ImageRepositoryOverride }}
+          imageRepository: ${{ variables.ImageRepositoryOverride }} 
           environment: 'CI-Agent-Dev'
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'
 
@@ -1005,8 +978,8 @@ extends:
           clusterName: 'zane-test2'
           resourceGroup: 'zane-test'
           region: 'centralus'
-          subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
-          workspaceId: 'b59109c7-d2ab-4464-a5d0-36ed751cd076' # zane-test-la2
+          subscriptionId: $(CI_BUILD_SUB_ID)
+          workspaceId: $(ZANE_TEST2_LA2_LAW_ID) # zane-test2-la2
           imageTag: $(linuxImageTagUnderTest)
           imageRepository: ${{ variables.ImageRepositoryOverride }}
           environment: 'CI-Agent-Dev2'

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -898,8 +898,8 @@ extends:
         # Use image tags built from the previous build stage
         #linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
         #windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
-        linuxImageTagUnderTest: '3.1.35'
-        windowsImageTagUnderTest: 'win-3.1.35'
+        linuxImageTagUnderTest: '3.1.34-8-g4beda67ad-20260310202859'
+        windowsImageTagUnderTest: 'win-3.1.34-8-g4beda67ad-20260310202859'
       jobs:
       # TODO: add more clusters from test automation framework when the tests are stable
       # ============================================================

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -890,8 +890,8 @@ extends:
       dependsOn: 
         #- stage
         []
-      condition: |
-        eq(dependencies.stage.result, 'Succeeded')
+      #condition: |
+      #  eq(dependencies.stage.result, 'Succeeded')
       variables:
         # Override the helm chart's default image repository (/azuremonitor/containerinsights/ciprod) to use cidev
         ImageRepositoryOverride: '/azuremonitor/containerinsights/cidev'

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -889,7 +889,7 @@ extends:
       dependsOn: 
         - stage
       condition: |
-        eq(dependencies.stage.result, 'Succeeded')
+        and(eq(dependencies.stage.result, 'Succeeded'), eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true))
       variables:
         # Override the helm chart's default image repository (/azuremonitor/containerinsights/ciprod) to use cidev
         ImageRepositoryOverride: '/azuremonitor/containerinsights/cidev'

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -888,20 +888,17 @@ extends:
       displayName: Deploy and Test Images in Dev Clusters
       lockBehavior: sequential
       dependsOn: 
-        #- stage
-        []
-      #condition: |
-      #  eq(dependencies.stage.result, 'Succeeded')
+        - stage
+      condition: |
+        eq(dependencies.stage.result, 'Succeeded')
       variables:
         # Override the helm chart's default image repository (/azuremonitor/containerinsights/ciprod) to use cidev
         ImageRepositoryOverride: '/azuremonitor/containerinsights/cidev'
         # Use image tags built from the previous build stage
-        #linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
-        #windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
-        linuxImageTagUnderTest: '3.1.34-8-g4beda67ad-20260310202859'
-        windowsImageTagUnderTest: 'win-3.1.34-8-g4beda67ad-20260310202859'
+        linuxImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.linuxImagetag']]
+        windowsImageTagUnderTest: $[stageDependencies.stage.common.outputs['setup.windowsImageTag']]
       jobs:
-      # TODO: add more clusters from test automation framework when the tests are stable
+      # TODO: remomve the two temp cluster and add more clusters from test automation framework when the tests are stable
       # ============================================================
       # Cluster 1: zane-test — Deploy via Helm
       # ============================================================

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -42,16 +42,8 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    # This stage will be skipped when LinuxImageOverride and WindowsImageOverride are both set
-    # This feature allows bypassing the build stage when using pre-built images for testing, which saves time and resources.
     - stage: stage
       displayName: 'Build and Publish Container Images'
-      # TODO: add logic to skip build to test an image specified from pipeline variables.
-      # condition: |
-      #   or(
-      #     eq(variables['LinuxImageOverride'], ''),
-      #     eq(variables['WindowsImageOverride'], '')
-      #   )
       jobs:
       - job: common
         pool:
@@ -194,17 +186,7 @@ extends:
               docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
               docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use
               docker buildx inspect --bootstrap
-              # Determine if we should push to ACR
-              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-              SHOULD_PUSH="false"
               if [ "$(Build.Reason)" != "PullRequest" ]; then
-                SHOULD_PUSH="true"
-              elif [[ "$(System.PullRequest.SourceBranch)" == "zane/ci-agent-auto-deploy" ]] || [[ "$(System.PullRequest.SourceBranch)" == *"run-e2e"* ]]; then
-                SHOULD_PUSH="true"
-                echo "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-              fi
-              
-              if [ "$SHOULD_PUSH" == "true" ]; then
                 docker buildx build --platform $(BUILD_PLATFORMS) --tag ${{ variables.repoImageName }}:$(linuxImagetag) -f kubernetes/linux/Dockerfile.multiarch --metadata-file $(Build.ArtifactStagingDirectory)/linux/metadata.json --build-arg IMAGE_TAG=$(linuxTelemetryTag) --build-arg GOLANG_BASE_IMAGE=$(GOLANG_BASE_IMAGE) --build-arg CI_BASE_IMAGE=$(CI_BASE_IMAGE) --push --provenance=false .
                 echo "##vso[task.logissue type=warning]Linux image built with tag: ${{ variables.repoImageName }}:$(linuxImagetag)"
                 docker pull ${{ variables.repoImageName }}:$(linuxImagetag)
@@ -295,7 +277,7 @@ extends:
               export TRIVY_JAVA_DB_REPOSITORY=$PRIMARY_TRIVY_JAVA_DB_REPOSITORY
               # Function to run Trivy scan and handle output
               run_trivy_scan() {
-                  trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
+                  trivy image --exit-code 1--ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM "${{ variables.repoImageName }}:$(linuxImagetag)" > trivy_output.log 2>&1
                   return $?
               }
               # Attempt scan up to 5 times with repository fallback
@@ -562,16 +544,7 @@ extends:
           inputs:
             targetType: 'inline'
             script: |
-              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-              $shouldPush = $false
               if ("$(Build.Reason)" -ne "PullRequest") {
-                $shouldPush = $true
-              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-                $shouldPush = $true
-                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-              }
-              
-              if ($shouldPush) {
                 docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion)
               }
         - task: CodeQL3000Finalize@0
@@ -779,16 +752,7 @@ extends:
           inputs:
             targetType: 'inline'
             script: |
-              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-              $shouldPush = $false
               if ("$(Build.Reason)" -ne "PullRequest") {
-                $shouldPush = $true
-              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-                $shouldPush = $true
-                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push image to ACR for E2E testing"
-              }
-              
-              if ($shouldPush) {
                 docker push ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
               }
         - task: CodeQL3000Finalize@0
@@ -829,16 +793,7 @@ extends:
               az account set -s ${{ variables.subscription }}
               az acr login -n ${{ variables.containerRegistry }}
               @{"image.name"="${{ variables.repoImageName }}:$(windowsImageTag)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-              # Push when: NOT a PR, OR when PR is from specific branches (zane/ci-agent-auto-deploy or branches containing 'run-e2e')
-              $shouldPush = $false
               if ("$(Build.Reason)" -ne "PullRequest") {
-                $shouldPush = $true
-              } elseif ("$(System.PullRequest.SourceBranch)" -eq "zane/ci-agent-auto-deploy" -or "$(System.PullRequest.SourceBranch)" -like "*run-e2e*") {
-                $shouldPush = $true
-                Write-Host "PR from branch $(System.PullRequest.SourceBranch) - will push multi-arch image to ACR for E2E testing"
-              }
-              
-              if ($shouldPush) {
                  docker manifest create ${{ variables.repoImageName }}:$(windowsImageTag) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2019BaseImageVersion) ${{ variables.repoImageName }}:$(windowsImageTag)-$(windows2022BaseImageVersion)
                  docker manifest push ${{ variables.repoImageName }}:$(windowsImageTag)
                  Write-Host "##vso[task.logissue type=warning]Windows image built with tag: ${{ variables.repoImageName }}:$(windowsImageTag)"

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -911,7 +911,7 @@ extends:
           workspaceId: $(ZANE_TEST_LA2_LAW_ID) # zane-test-la2
           amalogsLinuxImage: $(linuxImageTagUnderTest)
           amalogsWindowsImage: $(windowsImageTagUnderTest)
-          imageRepository: ${{ variables.ImageRepositoryOverride }} 
+          imageRepository: $(ImageRepositoryOverride)
           environment: 'CI-Agent-Dev'
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'
 
@@ -939,7 +939,7 @@ extends:
           workspaceId: $(ZANE_TEST2_LA2_LAW_ID) # zane-test2-la2
           amalogsLinuxImage: $(linuxImageTagUnderTest)
           amalogsWindowsImage: $(windowsImageTagUnderTest)
-          imageRepository: ${{ variables.ImageRepositoryOverride }}
+          imageRepository: $(ImageRepositoryOverride)
           environment: 'CI-Agent-Dev2'
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'
 

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -908,7 +908,8 @@ extends:
           region: 'westus2'
           subscriptionId: $(CI_BUILD_SUB_ID)
           workspaceId: $(ZANE_TEST_LA2_LAW_ID) # zane-test-la2
-          imageTag: $(linuxImageTagUnderTest)
+          amalogsLinuxImage: $(linuxImageTagUnderTest)
+          amalogsWindowsImage: $(windowsImageTagUnderTest)
           imageRepository: ${{ variables.ImageRepositoryOverride }} 
           environment: 'CI-Agent-Dev'
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'
@@ -935,7 +936,8 @@ extends:
           region: 'centralus'
           subscriptionId: $(CI_BUILD_SUB_ID)
           workspaceId: $(ZANE_TEST2_LA2_LAW_ID) # zane-test2-la2
-          imageTag: $(linuxImageTagUnderTest)
+          amalogsLinuxImage: $(linuxImageTagUnderTest)
+          amalogsWindowsImage: $(windowsImageTagUnderTest)
           imageRepository: ${{ variables.ImageRepositoryOverride }}
           environment: 'CI-Agent-Dev2'
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'

--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -939,7 +939,7 @@ extends:
           resourceGroup: 'zane-test'
           region: 'centralus'
           subscriptionId: $(CI_BUILD_SUB_ID)
-          workspaceId: $(ZANE_TEST2_LA2_LAW_ID) # zane-test2-la2
+          workspaceId: $(ZANE_TEST_LA2_LAW_ID) # zane-test2-la2
           amalogsLinuxImage: $(linuxImageTagUnderTest)
           amalogsWindowsImage: $(windowsImageTagUnderTest)
           imageRepository: $(ImageRepositoryOverride)

--- a/.pipelines/ci-aks-prod-release.yaml
+++ b/.pipelines/ci-aks-prod-release.yaml
@@ -481,7 +481,7 @@ extends:
     # Stage 3: Deploy ama-logs to AKS Clusters via Helm
     # =============================================================================
     # To add a new cluster, simply add an entry to the template list below.
-    # Each cluster only needs: clusterName, resourceGroup, region, subscriptionId, workspaceId, and imageTag.
+    # Each cluster only needs: clusterName, resourceGroup, region, subscriptionId, workspaceId, amalogsLinuxImage, and amalogsWindowsImage.
     # =============================================================================
     - stage: Stage_3
       displayName: Deploy ama-logs to CI AKS Prod Clusters via Helm
@@ -499,7 +499,8 @@ extends:
           region: 'westcentralus'
           subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
           workspaceId: '22f38e11-4f59-480c-b4b8-2573156b6e06' # "Monitoring-Model-Cluster-WCUS"
-          imageTag: '$(AgentImageTagSuffix)'
+          amalogsLinuxImage: '$(AgentImageTagSuffix)'
+          amalogsWindowsImage: 'win-$(AgentImageTagSuffix)'
           environment: 'CI-Deploy-To-Prod-Cluster-1'
       # Monitoring-Model-Cluster-WEU
       - template: .pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml@self
@@ -509,5 +510,6 @@ extends:
           region: 'westeurope'
           subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
           workspaceId: '5c269467-32a9-4468-a1d6-ec1cac551e74' # "Monitoring-Model-Cluster-WEU"
-          imageTag: '$(AgentImageTagSuffix)'
+          amalogsLinuxImage: '$(AgentImageTagSuffix)'
+          amalogsWindowsImage: 'win-$(AgentImageTagSuffix)'
           environment: 'CI-Deploy-To-Prod-Cluster-2'

--- a/.pipelines/e2e-test-templates/test-ci-image-in-aks-cluster.yml
+++ b/.pipelines/e2e-test-templates/test-ci-image-in-aks-cluster.yml
@@ -1,0 +1,115 @@
+parameters:
+- name: clusterName
+  type: string
+- name: resourceGroup
+  type: string
+- name: azureSubscription
+  type: string
+  default: 'ContainerInsights_Build_Subscription_CI'
+- name: environmentName
+  type: string
+- name: dependsOnDeployJob
+  type: string
+  displayName: 'Name of the deploy job this test depends on (e.g., Deploy_AmaLogs_zane_test)'
+- name: azureClientId
+  type: string
+- name: azureTenantId
+  type: string
+- name: teamsWebhookUri
+  type: string
+  default: '$(TeamsWebhookUri)'
+- name: additionalTestParams
+  type: string
+  default: ''
+
+jobs:
+- deployment: Test_${{ replace(parameters.clusterName, '-', '_') }}
+  displayName: 'Test: ${{ parameters.clusterName }}'
+  environment: ${{ parameters.environmentName }}
+  dependsOn: ${{ parameters.dependsOnDeployJob }}
+  pool:
+    name: Azure-Pipelines-CI-Test-EO
+    image: ci-1es-managed-ubuntu-2204
+    os: linux
+  variables:
+    skipComponentGovernanceDetection: true
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - checkout: self
+          persistCredentials: true
+
+        - script: |
+            set -euo pipefail
+            echo "Ensuring kubectl is installed"
+            if ! command -v kubectl >/dev/null 2>&1; then
+              echo "Installing kubectl"
+              sudo az aks install-cli
+            else
+              echo "kubectl already installed: $(kubectl version --client --short || true)"
+            fi
+          displayName: 'Install kubectl'
+
+        - task: AzureCLI@2
+          displayName: 'Get credentials for ${{ parameters.clusterName }}'
+          inputs:
+            azureSubscription: ${{ parameters.azureSubscription }}
+            scriptLocation: 'inlineScript'
+            scriptType: 'bash'
+            inlineScript: 'az aks get-credentials -g ${{ parameters.resourceGroup }} -n ${{ parameters.clusterName }}'
+
+        - task: Bash@3
+          displayName: 'Wait for logs to be ingested into Log Analytics (20 min)'
+          inputs:
+            targetType: 'inline'
+            script: |
+              echo "========================================"
+              echo "Waiting for Log Analytics Ingestion"
+              echo "========================================"
+              echo "Cluster: ${{ parameters.clusterName }}"
+              echo ""
+              echo "Waiting 10 minutes to allow logs to be ingested..."
+              echo "This ensures queries will find logs from the newly deployed containers."
+              echo ""
+              
+              wait_time=600
+              interval=60
+              elapsed=0
+              
+              while [ $elapsed -lt $wait_time ]; do
+                remaining=$((wait_time - elapsed))
+                minutes_elapsed=$((elapsed / 60))
+                minutes_remaining=$((remaining / 60))
+                echo "⏳ Waiting... ($minutes_elapsed/$((wait_time / 60)) minutes elapsed, $minutes_remaining minutes remaining)"
+                sleep $interval
+                elapsed=$((elapsed + interval))
+              done
+              
+              echo ""
+              echo "✓ Wait complete! Logs should now be available in Log Analytics."
+              echo "========================================"
+
+        - bash: |
+            echo "Running tests for cluster: ${{ parameters.clusterName }}"
+            
+            chmod +x ./install-and-execute-testkube-tests.sh
+            ./install-and-execute-testkube-tests.sh \
+              AzureClientId=${{ parameters.azureClientId }} \
+              AzureTenantId=${{ parameters.azureTenantId }} \
+              TeamsWebhookUri=${{ parameters.teamsWebhookUri }} \
+              ${{ parameters.additionalTestParams }}
+          workingDirectory: $(Build.SourcesDirectory)/test/testkube/
+          displayName: 'Install Testkube and run E2E tests'
+
+        # Log completion
+        - bash: |
+            echo "========================================="
+            echo "TEST COMPLETE"
+            echo "========================================="
+            echo "Cluster: ${{ parameters.clusterName }}"
+            echo "Build ID: $(Build.BuildId)"
+            echo "✓ Testing finished for: ${{ parameters.clusterName }}"
+            echo "========================================="
+          displayName: 'Test Completion'
+          condition: always()

--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -4,10 +4,10 @@
 #     parameters:
 #       clusterName: 'my-cluster'
 #       resourceGroup: 'my-rg'
-#       region: 'eastus'
-#       subscriptionId: '9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb'
+#       region: e.g. 'eastus'
+#       subscriptionId: 'your-subscription-id'
 #       workspaceId: 'your-workspace-id'
-#       imageTag: '$(AgentImageTagSuffix)'  # e.g., 3.1.32
+#       imageTag: '$(AgentImageTagSuffix)'
 #       environment: 'deployment environment'
 
 parameters:
@@ -23,9 +23,12 @@ parameters:
 - name: workspaceId
   type: string
   displayName: 'Log Analytics Workspace ID'
-- name: imageTag
+- name: amalogsLinuxImage
   type: string
   displayName: 'Image tag suffix (e.g., 3.1.32)'
+- name: amalogsWindowsImage
+  type: string
+  displayName: 'Image tag suffix (e.g., win-3.1.32)'
 - name: imageRepository
   type: string
   default: '/azuremonitor/containerinsights/ciprod'
@@ -103,7 +106,7 @@ jobs:
             # TODO: When it is merged to ci_prod, the following chartPath will be updated accordingly.
             chartPath: '$(Build.SourcesDirectory)/charts/azuremonitor-containerinsights-for-prod-clusters'
             releaseName: '${{ parameters.releaseName }}'
-            overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageRepository=${{ parameters.imageRepository }},OmsAgent.imageTagLinux=${{ parameters.imageTag }},OmsAgent.imageTagWindows=win-${{ parameters.imageTag }}'
+            overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageRepository=${{ parameters.imageRepository }},OmsAgent.imageTagLinux=${{ parameters.amalogsLinuxImage }},OmsAgent.imageTagWindows=${{ parameters.amalogsWindowsImage }}'
             waitForExecution: false
             arguments: '--timeout 10m --install'
         - task: AzureCLI@2

--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -26,6 +26,10 @@ parameters:
 - name: imageTag
   type: string
   displayName: 'Image tag suffix (e.g., 3.1.32)'
+- name: imageRepository
+  type: string
+  default: '/azuremonitor/containerinsights/ciprod'
+  displayName: 'Image repository path (e.g., /azuremonitor/containerinsights/ciprod or /azuremonitor/containerinsights/cidev)'
 - name: environment
   type: string
   displayName: 'Azure DevOps Environment name'
@@ -99,7 +103,7 @@ jobs:
             # TODO: When it is merged to ci_prod, the following chartPath will be updated accordingly.
             chartPath: '$(Build.SourcesDirectory)/charts/azuremonitor-containerinsights-for-prod-clusters'
             releaseName: '${{ parameters.releaseName }}'
-            overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageTagLinux=${{ parameters.imageTag }},OmsAgent.imageTagWindows=win-${{ parameters.imageTag }}'
+            overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageRepository=${{ parameters.imageRepository }},OmsAgent.imageTagLinux=${{ parameters.imageTag }},OmsAgent.imageTagWindows=win-${{ parameters.imageTag }}'
             waitForExecution: false
             arguments: '--timeout 10m --install'
         - task: AzureCLI@2

--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -42,21 +42,15 @@ parameters:
 - name: cloudEnvironment
   type: string
   default: 'azurepubliccloud'
-- name: kubernetesVersion
-  type: string
-  default: '1.32.7'
 - name: azureSubscription
   type: string
   default: 'ContainerInsights_Build_Subscription_CI'
-- name: namespace
+- name: namespace 
   type: string
   default: 'default'
 - name: releaseName
   type: string
   default: 'azuremonitor-containers'
-- name: helmVersion
-  type: string
-  default: '3.12.3'
 - name: dependsOn
   type: object
   default: []
@@ -91,7 +85,7 @@ jobs:
         - task: HelmInstaller@1
           displayName: Install Helm
           inputs:
-            helmVersionToInstall: '${{ parameters.helmVersion }}'
+            helmVersionToInstall: 'latest'
         - task: HelmDeploy@0
           displayName: 'Helm Deploy: ama-logs to ${{ parameters.clusterName }}'
           inputs:

--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -7,7 +7,8 @@
 #       region: e.g. 'eastus'
 #       subscriptionId: 'your-subscription-id'
 #       workspaceId: 'your-workspace-id'
-#       imageTag: '$(AgentImageTagSuffix)'
+#       amalogsLinuxImage: "ama-logs linux image tag"
+#       amalogsWindowsImage: "ama-logs windows image tag"
 #       environment: 'deployment environment'
 
 parameters:
@@ -122,8 +123,8 @@ jobs:
               echo "Cluster: ${{ parameters.clusterName }}"
               echo "Resource Group: ${{ parameters.resourceGroup }}"
               echo "Region: ${{ parameters.region }}"
-              echo "Linux Image Tag: ${{ parameters.imageTag }}"
-              echo "Windows Image Tag: win-${{ parameters.imageTag }}"
+              echo "Linux Image Tag: ${{ parameters.amalogsLinuxImage }}"
+              echo "Windows Image Tag: ${{ parameters.amalogsWindowsImage }}"
               echo ""
               
               echo "Getting AKS credentials..."
@@ -158,8 +159,8 @@ jobs:
               echo "=========================================="
               echo "Image Verification"
               echo "=========================================="
-              EXPECTED_LINUX_TAG="${{ parameters.imageTag }}"
-              EXPECTED_WINDOWS_TAG="win-${{ parameters.imageTag }}"
+              EXPECTED_LINUX_TAG="${{ parameters.amalogsLinuxImage }}"
+              EXPECTED_WINDOWS_TAG="${{ parameters.amalogsWindowsImage }}"
               VERIFICATION_PASSED=true
               
               echo "Expected Linux image tag: $EXPECTED_LINUX_TAG"

--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -45,7 +45,7 @@ parameters:
 - name: azureSubscription
   type: string
   default: 'ContainerInsights_Build_Subscription_CI'
-- name: namespace 
+- name: namespace
   type: string
   default: 'default'
 - name: releaseName

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,24 @@
 # to merge trivy scan PR, temporarily ignore CVE-2026-24051 until a fix is available
 CVE-2026-24051
+
+# to unblock PR merge 
+# go dependencies - temporarily ignore until upstream fixes are available
+CVE-2026-32287
+CVE-2026-34040
+CVE-2026-33997
+CVE-2026-27889
+CVE-2026-29785
+CVE-2026-33216
+CVE-2026-33217
+CVE-2026-33218
+CVE-2026-33247
+CVE-2026-33215
+CVE-2026-33219
+CVE-2026-33222
+CVE-2026-33223
+CVE-2026-33246
+CVE-2026-33248
+CVE-2026-33249
+CVE-2026-33186
+CVE-2026-25679
+CVE-2026-27142

--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,7 @@ CVE-2026-33249
 CVE-2026-33186
 CVE-2026-25679
 CVE-2026-27142
+
+# to unblock PR merge 
+# opt/telegraf (gobinary)
+CVE-2026-34986 

--- a/charts/azuremonitor-containerinsights-for-prod-clusters/templates/ama-logs.yaml
+++ b/charts/azuremonitor-containerinsights-for-prod-clusters/templates/ama-logs.yaml
@@ -533,7 +533,7 @@ spec:
                 - NET_RAW
 {{- end }}
         - name: ama-logs
-          image: "{{ template "addon_mcr_repository_base" $ }}/azuremonitor/containerinsights/ciprod:{{- default $amalogsLinuxDefaultImageTag $.Values.OmsAgent.imageTagLinux -}}"
+          image: "{{ template "addon_mcr_repository_base" $ }}{{ $.Values.OmsAgent.imageRepository | default "/azuremonitor/containerinsights/ciprod" }}:{{- default $amalogsLinuxDefaultImageTag $.Values.OmsAgent.imageTagLinux -}}"
         {{- if $.Values.OmsAgent.isImagePullPolicyAlways }}
           imagePullPolicy: Always
         {{- else }}
@@ -715,7 +715,7 @@ spec:
           {{- end }}
       {{- if and (not $.Values.OmsAgent.isPrometheusMetricsScrapingDisabled) $.Values.OmsAgent.isSidecarScrapingEnabled }}
         - name: ama-logs-prometheus
-          image: "{{ template "addon_mcr_repository_base" $ }}/azuremonitor/containerinsights/ciprod:{{- default $amalogsLinuxDefaultImageTag $.Values.OmsAgent.imageTagLinux -}}"
+          image: "{{ template "addon_mcr_repository_base" $ }}{{ $.Values.OmsAgent.imageRepository | default "/azuremonitor/containerinsights/ciprod" }}:{{- default $amalogsLinuxDefaultImageTag $.Values.OmsAgent.imageTagLinux -}}"
         {{- if $.Values.OmsAgent.isImagePullPolicyAlways }}
           imagePullPolicy: Always
         {{- else }}
@@ -1084,7 +1084,7 @@ spec:
                 - NET_RAW
 {{- end }}
         - name: ama-logs
-          image: "{{ template "addon_mcr_repository_base" . }}/azuremonitor/containerinsights/ciprod:{{- default $amalogsLinuxDefaultImageTag .Values.OmsAgent.imageTagLinux -}}"
+          image: "{{ template "addon_mcr_repository_base" . }}{{ .Values.OmsAgent.imageRepository | default "/azuremonitor/containerinsights/ciprod" }}:{{- default $amalogsLinuxDefaultImageTag .Values.OmsAgent.imageTagLinux -}}"
         {{- if .Values.OmsAgent.isImagePullPolicyAlways }}
           imagePullPolicy: Always
         {{- else }}
@@ -1364,7 +1364,7 @@ spec:
               value: "3"
       containers:
         - name: ama-logs-windows
-          image: "{{ template "addon_mcr_repository_base" . }}/azuremonitor/containerinsights/ciprod:{{- default $amalogsWindowsDefaultImageTag .Values.OmsAgent.imageTagWindows -}}"
+          image: "{{ template "addon_mcr_repository_base" . }}{{ .Values.OmsAgent.imageRepository | default "/azuremonitor/containerinsights/ciprod" }}:{{- default $amalogsWindowsDefaultImageTag .Values.OmsAgent.imageTagWindows -}}"
         {{- if .Values.OmsAgent.isImagePullPolicyAlways }}
           imagePullPolicy: Always
         {{- else }}
@@ -1777,7 +1777,7 @@ spec:
                 - NET_ADMIN
                 - NET_RAW
         - name: ama-logs
-          image: "{{ template "addon_mcr_repository_base" . }}/azuremonitor/containerinsights/ciprod:{{- default $amalogsLinuxDefaultImageTag .Values.OmsAgent.imageTagLinux -}}"
+          image: "{{ template "addon_mcr_repository_base" . }}{{ .Values.OmsAgent.imageRepository | default "/azuremonitor/containerinsights/ciprod" }}:{{- default $amalogsLinuxDefaultImageTag .Values.OmsAgent.imageTagLinux -}}"
         {{- if .Values.OmsAgent.isImagePullPolicyAlways }}
           imagePullPolicy: Always
         {{- else }}

--- a/charts/azuremonitor-containerinsights-for-prod-clusters/values.yaml
+++ b/charts/azuremonitor-containerinsights-for-prod-clusters/values.yaml
@@ -34,6 +34,7 @@ OmsAgent:
   workspaceKey: "<your_workspace_key>"
   
   # Image configuration
+  imageRepository: "/azuremonitor/containerinsights/ciprod"
   imageTagLinux: <image_to_be_deployed_for_linux>
   imageTagWindows: <image_to_be_deployed_for_windows>
   isImagePullPolicyAlways: false

--- a/test/ginkgo-e2e/querylogs/querylogs_test.go
+++ b/test/ginkgo-e2e/querylogs/querylogs_test.go
@@ -20,11 +20,11 @@ var _ = Describe("When querying the logs for the table", func() {
 				Skip("ContainerLog test skipped because GENEVA_INTEGRATION is set to 'true'")
 			}
 			var err error
-			query := table + " | where TimeGenerated > ago(15m) | summarize count()"
+			query := table + " | where TimeGenerated > ago(5m) | summarize count()"
 			err = utils.QueryLogsForCount(LogsClient, AKSResourceId, query, false)
 			// If ContainerLogV2 is configured, query ContainerLogV2 table instead of ContainerLog
 			if err != nil && strings.Contains(table, "ContainerLog") {
-				query := "ContainerLogV2 | where TimeGenerated > ago(15m) | summarize count()"
+				query := "ContainerLogV2 | where TimeGenerated > ago(5m) | summarize count()"
 				err = utils.QueryLogsForCount(LogsClient, AKSResourceId, query, false)
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -46,7 +46,7 @@ var _ = Describe("When querying the logs for the ContainerInventory", func() {
 		func(column string) {
 			// Skip records with ContainerState 'Waiting' to avoid false positives due to the container being in a waiting state.
 			// If the pod name contains 'ama-logs', we include it to ensure we capture the ama-logs agent containers.
-			query := "ContainerInventory | where TimeGenerated > ago(1h) and (ContainerState !~ 'Waiting' or ContainerHostname contains 'ama-logs') | summarize countif(isempty(" + column + ") or isnull(" + column + "))"
+			query := "ContainerInventory | where TimeGenerated > ago(5m) and (ContainerState !~ 'Waiting' or ContainerHostname contains 'ama-logs') | summarize countif(isempty(" + column + ") or isnull(" + column + "))"
 			err := utils.QueryLogsForCount(LogsClient, AKSResourceId, query, true)
 			Expect(err).NotTo(HaveOccurred())
 		},

--- a/test/ginkgo-e2e/utils/query_logs_api_utils.go
+++ b/test/ginkgo-e2e/utils/query_logs_api_utils.go
@@ -131,7 +131,7 @@ func CompareResourcesInLogsAndKubeAPI(K8sClient *kubernetes.Clientset, logsClien
 		for _, node := range nodes {
 			resources = append(resources, node.Name)
 		}
-		query = logsTable + " | where TimeGenerated > ago(15m) | distinct Computer"
+		query = logsTable + " | where TimeGenerated > ago(5m) | distinct Computer"
 	} else if logsTable == "KubePodInventory" {
 		pods, err := GetAllAgentPods(K8sClient)
 		if err != nil {
@@ -144,7 +144,7 @@ func CompareResourcesInLogsAndKubeAPI(K8sClient *kubernetes.Clientset, logsClien
 			}
 			resources = append(resources, pod.Name)
 		}
-		query = logsTable + " | where TimeGenerated > ago(15m) | distinct Name"
+		query = logsTable + " | where TimeGenerated > ago(5m) | distinct Name"
 	}
 
 	return CompareResourcesHelper(logsClient, resourceID, query, resources)

--- a/test/testkube/testkube-test-crs.yaml
+++ b/test/testkube/testkube-test-crs.yaml
@@ -130,7 +130,7 @@ spec:
   content:
     git:
       uri: https://github.com/microsoft/Docker-Provider/
-      revision: zane/ci-agent-auto-deploy
+      revision: ci_prod
       paths:
       - test/ginkgo-e2e
   steps:

--- a/test/testkube/testkube-test-crs.yaml
+++ b/test/testkube/testkube-test-crs.yaml
@@ -130,7 +130,7 @@ spec:
   content:
     git:
       uri: https://github.com/microsoft/Docker-Provider/
-      revision: ci_prod
+      revision: zane/ci-agent-auto-deploy
       paths:
       - test/ginkgo-e2e
   steps:


### PR DESCRIPTION
**intro:**
test infra that uses helm chart to deploy ama-logs new images from built to aks clusters, then run e2e scripts to test the new images.

**key new file:**
test-ci-image-in-aks-cluster.yml: script to deploy ama-logs through helm chart, and trigger e2e scripts

**changes to existing e2e test scripts:**
change 15m windows to 5m to allow test not to wait long. after helm chart deployment and before trigger e2e test, we need wait for a period of time before querying the logs to avoid using logs from prev helm deployment. If we use 15m, we need wait until 20m for safety, by changing to 5m, we can just wait for 1m before running e2e test.

run a few tests using 5m query window and 10m waiting time. Log exists and test passed.

**test**: 
see #20260320.12 in ci build pipeline

