### PR TITLE
fix: schedule testkube MongoDB on non-FIPS nodes

### DIFF
--- a/test/testkube/helm-testkube-values.yaml
+++ b/test/testkube/helm-testkube-values.yaml
@@ -117,9 +117,16 @@ mongodb:
     tag: 8.0.15
     # -- MongoDB image pull Secret
     pullSecrets: []
-  nodeSelector: 
+  nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.azure.com/fips_enabled
+            operator: DoesNotExist
   # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
   # -- Uncomment to schedule a multi-arch image to any available architecture type in a GGP Standard k8s cluster.
   #  tolerations:


### PR DESCRIPTION
MongoDB 8.0.15 core dumps on FIPS-enabled Azure Linux (Mariner) nodes due to crypto incompatibility. Add nodeAffinity rule to exclude nodes with kubernetes.azure.com/fips_enabled label so MongoDB schedules on non-FIPS Ubuntu/Azure Linux nodes instead.

failure: https://github-private.visualstudio.com/microsoft/_build/results?buildId=115940&view=logs&j=42bb4d3f-029b-553c-72ba-ad97c7d14c22&t=cd9c9f01-dc90-5cd5-9d20-6002fde8fd05&s=57c7e66c-ce80-5b96-c032-7bbe77afcd19