### PR TITLE
fix: update testkube MongoDB image tag from 8.0.15 to 8.2.5

### DIFF
--- a/test/testkube/helm-testkube-values.yaml
+++ b/test/testkube/helm-testkube-values.yaml
@@ -114,7 +114,7 @@ mongodb:
     # -- MongoDB image repository
     repository: testkube-cloud-372110/testkube/mongodb
     # -- MongoDB image tag
-    tag: 8.0.15
+    tag: 8.2.5
     # -- MongoDB image pull Secret
     pullSecrets: []
   nodeSelector: 


### PR DESCRIPTION
## test cluster ci-logs-prod-aks-work-load-identity fails due to testkube mongoDB image pullback error

https://ms.portal.azure.com/#view/Microsoft_Azure_ContainerService/AksK8ResourceMenuBlade/~/overview-Deployment/aksClusterId/%2Fsubscriptions%2F9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb%2FresourceGroups%2Fci-logs-prod-aks%2Fproviders%2FMicrosoft.ContainerService%2FmanagedClusters%2Fci-logs-prod-aks-work-load-identity/resource~/%7B%22kind%22%3A%22Deployment%22%2C%22metadata%22%3A%7B%22name%22%3A%22testkube-mongodb%22%2C%22namespace%22%3A%22testkube%22%2C%22uid%22%3A%22d7bea9b8-caff-4c7b-a377-66ff6b9331bb%22%7D%2C%22spec%22%3A%7B%22selector%22%3A%7B%22matchLabels%22%3A%7B%22app.kubernetes.io%2Fcomponent%22%3A%22mongodb%22%2C%22app.kubernetes.io%2Finstance%22%3A%22testkube%22%2C%22app.kubernetes.io%2Fname%22%3A%22mongodb%22%7D%7D%7D%7D/preloadK8sObjectsO11yContext~/%7B%22useUpgradedTier%22%3Atrue%2C%22isK8sObjectsOverviewO11yEnabled%22%3Atrue%7D


The 8.0.15 tag has been removed from the upstream Testkube registry (us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb), causing ImagePullBackOff on nodes without cached images. Update to 8.2.5 which is the current default for Testkube chart 2.8.3.

## evidence

$ docker manifest inspect us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.15
no such manifest: us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.15

$ docker manifest inspect us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.2.5
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {