### PR TITLE
Fix Telegraf Env Handling issue

### DIFF
--- a/kubernetes/linux/main.sh
+++ b/kubernetes/linux/main.sh
@@ -1214,7 +1214,7 @@ else
             if [ "${CONTAINER_TYPE}" == "PrometheusSidecar" ] && [ -e "/opt/telegraf-test-prom-side-car.conf" ]; then
                   if [ "${MUTE_PROM_SIDECAR}" != "true" ]; then
                         echo "****************Start Telegraf in Test Mode**************************"
-                        /opt/telegraf --config /opt/telegraf-test-prom-side-car.conf --input-filter file -test
+                        /opt/telegraf --non-strict-env-handling --config /opt/telegraf-test-prom-side-car.conf --input-filter file -test
                         if [ $? -eq 0 ]; then
                               mv "/opt/telegraf-test-prom-side-car.conf" "/etc/opt/microsoft/docker-cimprov/telegraf-prom-side-car.conf"
                               echo "Moving test conf file to telegraf side-car conf since test run succeeded"
@@ -1226,7 +1226,7 @@ else
             else
                   if [ -e "/opt/telegraf-test.conf" ]; then
                         echo "****************Start Telegraf in Test Mode**************************"
-                        /opt/telegraf --config /opt/telegraf-test.conf --input-filter file -test
+                        /opt/telegraf --non-strict-env-handling --config /opt/telegraf-test.conf --input-filter file -test
                         if [ $? -eq 0 ]; then
                               mv "/opt/telegraf-test.conf" "/etc/opt/microsoft/docker-cimprov/telegraf.conf"
                               echo "Moving test conf file to telegraf daemonset conf since test run succeeded"
@@ -1237,7 +1237,7 @@ else
       else
             if [ -e "/opt/telegraf-test-rs.conf" ]; then
                   echo "****************Start Telegraf in Test Mode**************************"
-                  /opt/telegraf --config /opt/telegraf-test-rs.conf --input-filter file -test
+                  /opt/telegraf --non-strict-env-handling --config /opt/telegraf-test-rs.conf --input-filter file -test
                   if [ $? -eq 0 ]; then
                         mv "/opt/telegraf-test-rs.conf" "/etc/opt/microsoft/docker-cimprov/telegraf-rs.conf"
                         echo "Moving test conf file to telegraf replicaset conf since test run succeeded"
@@ -1389,7 +1389,7 @@ elif [ "${MUTE_PROM_SIDECAR}" != "true" ]; then
     elif [ "${CONTROLLER_TYPE}" != "ReplicaSet" ] && [ "${CONTAINER_TYPE}" != "PrometheusSidecar" ] && [ "${LOGS_AND_EVENTS_ONLY}" == "true" ]; then
         echo "not starting telegraf for LOGS_AND_EVENTS_ONLY daemonset"
     else
-        /opt/telegraf --config $telegrafConfFile &
+        /opt/telegraf --non-strict-env-handling --config $telegrafConfFile &
     fi
 else
     echo "not starting telegraf (no metrics to scrape since MUTE_PROM_SIDECAR is true)"
@@ -1413,7 +1413,7 @@ if [ "${AZMON_COLLECT_AMA_LOGS_PROCESS_METRICS}" == "true" ]; then
             appinsightsKey=$(echo "$APPLICATIONINSIGHTS_AUTH" | base64 -d | tr -d '\n')
             sed -i -e "s/placeholder_appinsights_key/$appinsightsKey/g" $amaLogsProcessMetricsConfFile
             # Use /proc so telegraf only collect process metrics inside ama-logs containers.
-            HOST_PROC=/proc /opt/telegraf --config $amaLogsProcessMetricsConfFile &
+            HOST_PROC=/proc /opt/telegraf --non-strict-env-handling --config $amaLogsProcessMetricsConfFile &
         else
             echo "APPLICATIONINSIGHTS_AUTH or AKS_RESOURCE_ID not set, skipping ama-logs process metrics monitoring"
         fi

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -16,6 +16,7 @@ sudo update-ca-trust
 # the mariner package version is behind the global packages so we are using different versions for arm64 and x86_64
 if [ "$ARCH" == "arm64" ]; then
     sudo tdnf install ruby-3.3.5-7.azl3.aarch64 -y
+    sudo tdnf install zlib-devel -y
 else
     tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
     wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20251023.tar.gz -O ruby-build.tar.gz


### PR DESCRIPTION
This PR contains following changes: 

- Telegraf version >=1.38.0 makes the strict environment variable handling the default: https://docs.influxdata.com/telegraf/v1/release-notes/#v1380. To keep the existing behavior as it is, run Telegraf using --non-strict-env-handling flag.
- Zlib gem installation is failing intermittently for Arm64 as it depends on zlib-devel header files. 