### PR TITLE
Add retry logic for gem install to handle QEMU arm64 segfaults

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -77,9 +77,28 @@ echo "DOCKER_CIMPROV_VERSION=$docker_cimprov_version" >> packages_version.txt
 sudo tdnf install azcu-fluent-bit-4.0.14 -y
 echo "$(fluent-bit --version)" >> packages_version.txt
 
+# Retry wrapper for gem install commands.
+# Native extension builds under QEMU emulation for arm64 can hit sporadic
+# segfaults in GCC/make, so we retry transient failures automatically.
+gem_install_with_retry() {
+    local max_retries=3
+    local attempt=1
+    while [ $attempt -le $max_retries ]; do
+        echo "gem install attempt $attempt/$max_retries: gem install $@"
+        if gem install "$@"; then
+            return 0
+        fi
+        echo "WARNING: gem install failed (attempt $attempt/$max_retries)"
+        attempt=$((attempt + 1))
+        sleep 2
+    done
+    echo "ERROR: gem install failed after $max_retries attempts: gem install $@"
+    exit 1
+}
+
 # install fluentd
 fluentd_version="1.16.3"
-gem install fluentd -v $fluentd_version --no-document
+gem_install_with_retry fluentd -v $fluentd_version --no-document
 
 # remove the test directory from fluentd
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/fluentd-$fluentd_version/test/
@@ -87,14 +106,14 @@ rm -rf /usr/lib/ruby/gems/3.3.0/gems/fluentd-$fluentd_version/test/
 echo "$(fluentd --version)" >> packages_version.txt
 fluentd --setup ./fluent
 
-gem install gyoku iso8601 bigdecimal --no-doc
-gem install tomlrb -v "2.0.1" --no-document
-gem install ipaddress --no-document
-gem install jwt -v "2.7.1" --no-document
-gem install racc --no-document
+gem_install_with_retry gyoku iso8601 bigdecimal --no-doc
+gem_install_with_retry tomlrb -v "2.0.1" --no-document
+gem_install_with_retry ipaddress --no-document
+gem_install_with_retry jwt -v "2.7.1" --no-document
+gem_install_with_retry racc --no-document
 
 # Reinstall zlib gem to fix CVE-2026-27820
-gem install zlib -v "3.2.3" --no-document 
+gem_install_with_retry zlib -v "3.2.3" --no-document 
 # uninstall old zlib gem
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/zlib-3.1.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/zlib-3.1.1


### PR DESCRIPTION
## Problem

The `build_linux` job in the multi-arch build pipeline fails intermittently due to sporadic **GCC segfaults** when compiling Ruby native gem extensions under **QEMU emulation for arm64**. Each failure hits a different gem dependency of fluentd (http_parser.rb, msgpack, yajl-ruby). Because `setup.sh` has no error handling on `gem install`, the failure is silently ignored, and the build later fails at the Dockerfile `COPY --from=builder /usr/bin/fluentd` step with a confusing "not found" error.

Build [#116473](https://github-private.visualstudio.com/microsoft/microsoft%20Team/_build/results?buildId=116473) required **5 manual retries** before `build_linux` succeeded.

## Fix

Added a `gem_install_with_retry()` wrapper function in `kubernetes/linux/setup.sh` with:
- **3 retry attempts** per gem install command
- **`exit 1`** after exhausting retries (fail fast with a clear error)
- Applied to **all** `gem install` calls, not just fluentd

## Key Result — Retry logic validated in build [#116513](https://github-private.visualstudio.com/microsoft/microsoft%20Team/_build/results?buildId=116513)

The build succeeded on the **first pipeline attempt**. Logs show the retry logic was exercised:

- **amd64** — all gems installed on attempt 1/3, no retries needed
- **arm64** — `gem install fluentd` **failed on attempt 1/3** (QEMU segfault), then **succeeded on attempt 2/3**

```
#47 535.6 gem install attempt 1/3: gem install fluentd -v 1.16.3 --no-document
#47 627.8 WARNING: gem install failed (attempt 1/3)
#47 629.9 gem install attempt 2/3: gem install fluentd -v 1.16.3 --no-document
#47 951.4 Successfully installed fluentd-1.16.3
```

Without this fix, build #116513 would have failed and required another manual re-run.