### PR TITLE
Zane/fix fluentd procstat pattern

### DIFF
--- a/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -109,7 +109,7 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  pattern = "fluentd(?!.*under-supervisor)"
+  pattern = "ruby /usr/bin/fluentd"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true

--- a/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -31,6 +31,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "mdsd"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -46,6 +47,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "fluent-bit"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -61,6 +63,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "telegraf"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -76,6 +79,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "telegraf-process-metrics"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -90,6 +94,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "fluentd"
   [[inputs.procstat.filter]]
     name = "fluentd"
     process_names = ["fluentd"]
@@ -108,6 +113,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "crond"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -123,6 +129,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "inotifywait"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -137,6 +144,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "ruby"
   [[inputs.procstat.filter]]
     name = "ruby"
     process_names = ["ruby"]
@@ -155,3 +163,4 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+    ProcessName = "main"

--- a/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -64,7 +64,7 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  exe = "ruby"
+  pattern = "fluentd.*under-supervisor"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true
@@ -109,7 +109,7 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  pattern = "fluentd"
+  pattern = "fluentd(?!.*under-supervisor)"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true

--- a/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -49,7 +49,22 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  exe = "telegraf"
+  pattern = "telegraf(-rs|-prom-side-car)?.conf"
+  interval = "60s"
+  pid_finder = "native"
+  pid_tag = true
+  name_override = "agent_telemetry"
+  fieldpass = ["cpu_usage", "memory_rss"]
+  [inputs.procstat.tags]
+    Computer = "placeholder_hostname"
+    PodName = "placeholder_podname"
+    AgentVersion = "$AGENT_VERSION"
+    ControllerType = "$CONTROLLER_TYPE"
+    AksResourceId = "$AKS_RESOURCE_ID"
+
+[[inputs.procstat]]
+  name_prefix = "t.azm.ms/"
+  pattern = "telegraf-ama-logs-process-metrics.conf"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true

--- a/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/linux/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -64,7 +64,6 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  pattern = "fluentd.*under-supervisor"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true
@@ -76,6 +75,9 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+  [[inputs.procstat.filter]]
+    name = "fluentd"
+    process_names = ["fluentd"]
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -109,7 +111,6 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  pattern = "ruby /usr/bin/fluentd"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true
@@ -121,6 +122,9 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "$CONTROLLER_TYPE"
     AksResourceId = "$AKS_RESOURCE_ID"
+  [[inputs.procstat.filter]]
+    name = "ruby"
+    process_names = ["ruby"]
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"

--- a/build/windows/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/windows/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -32,7 +32,22 @@
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
-  exe = "telegraf"
+  pattern = "telegraf.conf"
+  interval = "60s"
+  pid_finder = "native"
+  pid_tag = true
+  name_override = "agent_telemetry"
+  fieldpass = ["cpu_usage", "memory_rss"]
+  [inputs.procstat.tags]
+    Computer = "placeholder_hostname"
+    PodName = "placeholder_podname"
+    AgentVersion = "$AGENT_VERSION"
+    ControllerType = "DaemonSet-Windows"
+    AksResourceId = "placeholder_aksresourceid"
+
+[[inputs.procstat]]
+  name_prefix = "t.azm.ms/"
+  pattern = "telegraf-ama-logs-process-metrics.conf"
   interval = "60s"
   pid_finder = "native"
   pid_tag = true

--- a/build/windows/installer/conf/telegraf-ama-logs-process-metrics.conf
+++ b/build/windows/installer/conf/telegraf-ama-logs-process-metrics.conf
@@ -29,6 +29,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "fluent-bit"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -44,6 +45,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "telegraf"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -59,6 +61,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "telegraf-process-metrics"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -74,6 +77,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "MonAgentLauncher"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -89,6 +93,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "MonAgentCore"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -104,6 +109,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "MonAgentHost"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -119,6 +125,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "MonAgentManager"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -134,6 +141,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "AzurePerfCollectorExtension"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -149,6 +157,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "AzureProfilerExtension"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -164,6 +173,7 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "AggregatorHost"
 
 [[inputs.procstat]]
   name_prefix = "t.azm.ms/"
@@ -179,3 +189,4 @@
     AgentVersion = "$AGENT_VERSION"
     ControllerType = "DaemonSet-Windows"
     AksResourceId = "placeholder_aksresourceid"
+    ProcessName = "powershell"


### PR DESCRIPTION
# problem 1
both ruby and fluentd has the keyword "ruby" and "fluentd" in its cmdline, so using pattern can't tell who is who. also using exe as filter does not work either, because fluentd is a gem under ruby, so the exe of fluentd process is also ruby. 

fix: use procstat.filter doc: https://docs.influxdata.com/telegraf/v1/input-plugins/procstat/#:~:text=This%20plugin%20allows%20to%20monitor,service%20that%20started%20the%20process.

tested, now values of fluentd and ruby matches what is showing inside container

<img width="1302" height="788" alt="image" src="https://github.com/user-attachments/assets/50350049-b6f1-40f0-b882-25a9946ba78b" />


manual check
fluentd (supervisor): 47.9 MB
ruby: 82.5 MB 

# problem 2:
main telegraf and the process metrics collection telegraf both use telegraf.exe so exe can be differentiate whether the telegraf process is main or process-metrics. 

fix: The only difference is the telegraf config files, so we can use pattern to differentiate between them.


# problem 3:
add a ProcessName field to make query easier.




# test
<img width="668" height="397" alt="image" src="https://github.com/user-attachments/assets/be897a10-c541-4f63-9910-4a7c17258f40" />



