### PR TITLE
fix: add --force-conflicts to helm deploy to resolve server-side apply conflict

### DIFF
--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -121,7 +121,7 @@ jobs:
             ${{ else }}:
               overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},global.commonGlobals.Versions.Kubernetes=$(K8S_VERSION),OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageRepository=${{ parameters.imageRepository }},OmsAgent.imageTagLinux=${{ parameters.amalogsLinuxImage }},OmsAgent.imageTagWindows=${{ parameters.amalogsWindowsImage }}'
             waitForExecution: false
-            arguments: '--timeout 10m --install'
+            arguments: '--timeout 10m --install --force-conflicts'
         - task: AzureCLI@2
           displayName: Verify Deployment
           inputs:


### PR DESCRIPTION
# problem:
helm chart deployment fails in this cluster https://github-private.visualstudio.com/microsoft/_build/results?buildId=116992&view=logs&j=e0d6c3c5-8898-56d1-7145-a67bdb7b228d&t=f00d8ec0-2a89-5ba3-6227-d5b730b66c7c

# why:
Helm 4 uses server-side apply by default. Someone previously used kubectl edit to modify container images, making kubectl-edit the field manager. Helm can't overwrite fields owned by another manager without explicit permission.

# fix:
Add --force-conflicts to helm upgrade arguments, allowing Helm to take ownership of conflicting fields.

# test:
Ran helm upgrade --force-conflicts manually against ci-logs-prod-aks-geneva-integration-multi-tenancy — succeeded (revision 22).

