### PR TITLE
fix(helm): coerce OmsAgent.isUsingAADAuth to a boolean

### DIFF
--- a/charts/azuremonitor-containerinsights-for-prod-clusters/templates/ama-logs.yaml
+++ b/charts/azuremonitor-containerinsights-for-prod-clusters/templates/ama-logs.yaml
@@ -4,10 +4,15 @@
 {{- $addonTokenAdapterWindowsDefaultImageTag := dict "component" "addon-token-adapter-windows" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.imagetag"}}
 {{- $amalogsRSVPAImageTag := dict "component" "addon-resizer" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" -}}
 {{- $WinImageTag := default $amalogsWindowsDefaultImageTag .Values.OmsAgent.imageTagWindows -}}
-{{/* Determine isusingaadauth value from OmsAgent.isUsingAADAuth */}}
+{{/* Determine isusingaadauth value from OmsAgent.isUsingAADAuth.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-  {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+  {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+    {{- $isusingaadauth = true -}}
+  {{- end -}}
 {{- end -}}
 {{/* TODO This needs to be fixed post Canary validation */}}
 {{/* Extract cluster information from aksresourceid */}}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
@@ -1,15 +1,22 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{- $amalogsWindowsDefaultImageTag := dict "component" "ama-logs-win" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if not $isArcExtension -}}
   {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-    {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- if and .Values.amalogs (hasKey .Values.amalogs "useAADAuth") -}}
-    {{- $isusingaadauth = .Values.amalogs.useAADAuth -}}
+    {{- if eq (lower (toString .Values.amalogs.useAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $cloudEnv := lower .Values.global.commonGlobals.CloudEnvironment }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
@@ -1,15 +1,22 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{- $amalogsLinuxDefaultImageTag := dict "component" "ama-logs-linux" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if not $isArcExtension -}}
   {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-    {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- if and .Values.amalogs (hasKey .Values.amalogs "useAADAuth") -}}
-    {{- $isusingaadauth = .Values.amalogs.useAADAuth -}}
+    {{- if eq (lower (toString .Values.amalogs.useAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{/* Outer condition: AKS always renders, Arc renders with valid credentials */}}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-deployment-multitenancy.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-deployment-multitenancy.yaml
@@ -3,10 +3,15 @@
 {{/* AKS-only resource */}}
 {{- if not $isArcExtension }}
 {{- $amalogsLinuxDefaultImageTag := dict "component" "ama-logs-linux" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-  {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+  {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+    {{- $isusingaadauth = true -}}
+  {{- end -}}
 {{- end -}}
 {{- $cloudEnv := lower .Values.global.commonGlobals.CloudEnvironment }}
 {{- if and $isusingaadauth .Values.OmsAgent.isMultitenancyLogsEnabled }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
@@ -2,15 +2,22 @@
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{- $amalogsLinuxDefaultImageTag := dict "component" "ama-logs-linux" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" }}
 {{- $amalogsRSVPAImageTag := dict "component" "addon-resizer" "version" .Values.global.commonGlobals.Versions.Kubernetes | include "get.addonImageTag" -}}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if not $isArcExtension -}}
   {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-    {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- if and .Values.amalogs (hasKey .Values.amalogs "useAADAuth") -}}
-    {{- $isusingaadauth = .Values.amalogs.useAADAuth -}}
+    {{- if eq (lower (toString .Values.amalogs.useAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $cloudEnv := lower .Values.global.commonGlobals.CloudEnvironment }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-hpa.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-hpa.yaml
@@ -2,10 +2,15 @@
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{/* AKS-only resource */}}
 {{- if not $isArcExtension }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-  {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+  {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+    {{- $isusingaadauth = true -}}
+  {{- end -}}
 {{- end -}}
 {{- if and $isusingaadauth .Values.OmsAgent.isMultitenancyLogsEnabled }}
 ---

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-rbac.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-rbac.yaml
@@ -1,10 +1,15 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if not $isArcExtension -}}
   {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-    {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{/* Arc has rbac condition, AKS always renders */}}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-service.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-service.yaml
@@ -2,10 +2,15 @@
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{/* AKS-only resource */}}
 {{- if not $isArcExtension }}
-{{/* Determine isusingaadauth value */}}
+{{/* Determine isusingaadauth value.
+     Compare as a lowercased string because Helm --set and quoted YAML
+     both deliver this value as a string, and any non-empty string is
+     truthy in Go templates (so "false" would otherwise evaluate to true). */}}
 {{- $isusingaadauth := false -}}
 {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-  {{- $isusingaadauth = .Values.OmsAgent.isUsingAADAuth -}}
+  {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+    {{- $isusingaadauth = true -}}
+  {{- end -}}
 {{- end -}}
 {{- if and $isusingaadauth .Values.OmsAgent.isMultitenancyLogsEnabled }}
 ---


### PR DESCRIPTION
Helm --set and quoted YAML both deliver this value as a string. Any non-empty string is truthy in Go templates, so the literal string false was evaluating to true and enabling AAD-only RBAC/secret references in ama-logs.yaml. Compare the lowercased string to true to coerce it into a real boolean.