### PR TITLE
Exclude azuresecuritylinuxagent namespace from log collection by default

### DIFF
--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -29,7 +29,7 @@ require_relative "ConfigParseErrorLogger"
 @logEnableKubernetesMetadata = ENV["AZMON_KUBERNETES_METADATA_ENABLED"]&.downcase == "true" || false
 @logKubernetesMetadataIncludeFields = "podlabels,podannotations,poduid,image,imageid,imagerepo,imagetag"
 @annotationBasedLogFiltering = false
-@allowed_system_namespaces = ['kube-system', 'gatekeeper-system', 'calico-system', 'azure-arc', 'kube-public', 'kube-node-lease']
+@allowed_system_namespaces = ['kube-system', 'gatekeeper-system', 'calico-system', 'azure-arc', 'kube-public', 'kube-node-lease', 'azuresecuritylinuxagent']
 @isAzMonMultiTenancyLogCollectionEnabled = false
 @isAzMonMultiTenancyFallbackIngestionDisabled = false
 @isAzMonMultiTenancyLogCollectionAdvancedMode = false

--- a/build/common/installer/scripts/tomlparser.rb
+++ b/build/common/installer/scripts/tomlparser.rb
@@ -11,10 +11,10 @@ require_relative "ConfigParseErrorLogger"
 @configSchemaVersion = ""
 # Setting default values which will be used in case they are not set in the configmap or if configmap doesnt exist
 @collectStdoutLogs = true
-@stdoutExcludeNamespaces = "kube-system,gatekeeper-system"
+@stdoutExcludeNamespaces = "kube-system,gatekeeper-system,azuresecuritylinuxagent"
 @stdoutIncludeSystemPods = ""
 @collectStderrLogs = true
-@stderrExcludeNamespaces = "kube-system,gatekeeper-system"
+@stderrExcludeNamespaces = "kube-system,gatekeeper-system,azuresecuritylinuxagent"
 @stderrIncludeSystemPods = ""
 @collectClusterEnvVariables = true
 @logTailPath = "/var/log/containers/*.log"
@@ -187,12 +187,12 @@ def parseConfigMap
       return parsedConfig
     else
       puts "config::configmap container-azm-ms-agentconfig for settings not mounted, using defaults"
-      @excludePath = "*_kube-system_*.log"
+      @excludePath = "*_kube-system_*.log,*_azuresecuritylinuxagent_*.log"
       return nil
     end
   rescue => errorStr
     ConfigParseErrorLogger.logError("Exception while parsing config map for log collection/env variable settings: #{errorStr}, using defaults, please check config map for errors")
-    @excludePath = "*_kube-system_*.log"
+    @excludePath = "*_kube-system_*.log,*_azuresecuritylinuxagent_*.log"
     return nil
   end
 end
@@ -575,7 +575,7 @@ else
   if (File.file?(@configMapMountPath))
     ConfigParseErrorLogger.logError("config::unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
   end
-  @excludePath = "*_kube-system_*.log"
+  @excludePath = "*_kube-system_*.log,*_azuresecuritylinuxagent_*.log"
 end
 
 # Write the settings to file, so that they can be set as environment variables

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -20,10 +20,10 @@ data:
           # In the absense of this configmap, default value for enabled is true
           enabled = true
           # exclude_namespaces setting holds good only if enabled is set to true
-          # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
-          # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
-          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # kube-system,gatekeeper-system,azuresecuritylinuxagent log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system,azuresecuritylinuxagent, remove them from the following setting.
+          # If you want to continue to disable kube-system,gatekeeper-system,azuresecuritylinuxagent log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
+          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
+          exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
           # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]
@@ -32,10 +32,10 @@ data:
           # Default value for enabled is true
           enabled = true
           # exclude_namespaces setting holds good only if enabled is set to true
-          # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
-          # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
-          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # kube-system,gatekeeper-system,azuresecuritylinuxagent log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system,azuresecuritylinuxagent, remove them from the following setting.
+          # If you want to continue to disable kube-system,gatekeeper-system,azuresecuritylinuxagent log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
+          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
+          exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
           # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]

--- a/kubernetes/container-azm-ms-agentconfig.yaml
+++ b/kubernetes/container-azm-ms-agentconfig.yaml
@@ -25,7 +25,7 @@ data:
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
-          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system, azuresecuritylinuxagent. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.stderr]
@@ -37,7 +37,7 @@ data:
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           exclude_namespaces = ["kube-system","gatekeeper-system","azuresecuritylinuxagent"]
           # If you want to collect logs from only selective pods inside system namespaces add them to the following setting. Provide namepace:controllerName of the system pod. NOTE: this setting is only for pods in system namespaces
-          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system. The system namespace used should not be present in exclude_namespaces
+          # Valid values for system namespaces are: kube-system, azure-arc, gatekeeper-system, kube-public, kube-node-lease, calico-system, azuresecuritylinuxagent. The system namespace used should not be present in exclude_namespaces
           # collect_system_pod_logs = ["kube-system:coredns"]
 
        [log_collection_settings.env_var]


### PR DESCRIPTION
## What
Adds `azuresecuritylinuxagent` to the built-in default exclusion lists so logs from the `azuresecuritylinuxagent` namespace (deployed by a sister team) are not collected by ama-logs out of the box.

## Changes
- **`build/common/installer/scripts/tomlparser.rb`**
  - `@stdoutExcludeNamespaces` and `@stderrExcludeNamespaces` defaults now include `azuresecuritylinuxagent`.
  - `@excludePath` defaults (no-configmap, parse-error, unsupported-schema-version branches) now include `*_azuresecuritylinuxagent_*.log`.
- **`kubernetes/container-azm-ms-agentconfig.yaml`**
  - Example stdout/stderr `exclude_namespaces` arrays and surrounding comments updated.

## Effect
- Fluent Bit `tail` input skips opening files in this namespace via `Exclude_Path` (no I/O, no parsing).
- out_oms additionally drops any record with this namespace as a backstop.

## Caveat
The customer-supplied configmap **replaces** the default arrays. If a customer has an `exclude_namespaces` setting in their configmap that does not include `azuresecuritylinuxagent`, the namespace will still be collected. Documenting this and deciding whether to force-append is left as a follow-up.