### PR TITLE
fix(ci): use variable reference for AllNodesClientId in e2e test stage

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -1062,7 +1062,7 @@ extends:
           azureSubscription: 'ContainerInsights_Build_Subscription_CI'
           environmentName: 'CI-Agent-Dev-Aks-All-Nodes'
           dependsOnDeployJob: 'Deploy_AmaLogs_ci_logs_dev_aks_all_nodes'
-          azureClientId: 'AllNodesClientId'
+          azureClientId: $(AllNodesClientId)
           azureTenantId: $(CI_BUILD_AZURE_TENANT_ID)
           teamsWebhookUri: $(TeamsWebhookUri)
           additionalTestParams: 'PerNodeLogCoverage=true'


### PR DESCRIPTION
## Problem

The `ci-logs-dev-aks-all-nodes` E2E test was failing on `KubePodInventory` (and other log-query tests) with:

```
Failed to query logs: DefaultAzureCredential: failed to acquire a token.
...
ManagedIdentityCredential authentication failed. the requested identity isn't assigned to this resource
{
  "error": "invalid_request",
  "error_description": "Identity not found"
}
```

## Root cause

In `.pipelines/azure_pipeline_mergedbranches.yaml`, the E2E test stage for the `ci-logs-dev-aks-all-nodes` cluster was passing the **literal string** `'AllNodesClientId'` as `azureClientId` instead of the variable reference `$(AllNodesClientId)`.

Every other cluster stage in the file uses the `$(...)` form (e.g. `$(AksWorkLoadIdentityClientId)`, `$(WcusFipsClientId)`, `$(NetworkFlowLogsClientId)`), which substitutes the actual workload-identity client GUID from the variable group. The literal string was being plumbed all the way into the test pod as `AZURE_CLIENT_ID`, so no managed identity matched and token acquisition failed.

## Fix

```diff
-          azureClientId: 'AllNodesClientId'
+          azureClientId: $(AllNodesClientId)
```

## Note

This assumes a variable named `AllNodesClientId` exists in the variable group bound to this pipeline (containing the workload-identity client ID GUID for the `ci-logs-dev-aks-all-nodes` cluster). If it doesn't yet, it needs to be added there alongside the other `*ClientId` variables — otherwise the substitution will be empty and the test will still fail with the same auth error.