### PR TITLE
Fix Windows multiline test yamls

### DIFF
--- a/test/scenario/multiline/dotnet-win.yaml
+++ b/test/scenario/multiline/dotnet-win.yaml
@@ -17,12 +17,9 @@ spec:
       - name: dotnet-win-scripts-volume
         configMap:
           name: dotnet-win-test-scripts
-      nodeSelector:
-        kubernetes.io/os: windows
-        kubernetes.io/arch: amd64
       containers:
       - name: dotnet-win
-        image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+        image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
         volumeMounts:
           - mountPath: C:\dotnet-win-test-scripts
             name: dotnet-win-scripts-volume

--- a/test/scenario/multiline/golang-win.yaml
+++ b/test/scenario/multiline/golang-win.yaml
@@ -17,12 +17,9 @@ spec:
       - name: golang-win-scripts-volume
         configMap:
           name: golang-win-test-scripts
-      nodeSelector:
-        kubernetes.io/os: windows
-        kubernetes.io/arch: amd64
       containers:
       - name: golang-win
-        image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+        image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
         volumeMounts:
           - mountPath: C:\golang-win-test-scripts
             name: golang-win-scripts-volume

--- a/test/scenario/multiline/java-win.yaml
+++ b/test/scenario/multiline/java-win.yaml
@@ -17,12 +17,9 @@ spec:
       - name: java-win-scripts-volume
         configMap:
           name: java-win-test-scripts
-      nodeSelector:
-        kubernetes.io/os: windows
-        kubernetes.io/arch: amd64
       containers:
       - name: java-win
-        image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+        image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
         volumeMounts:
           - mountPath: C:\java-win-test-scripts
             name: java-win-scripts-volume

--- a/test/scenario/multiline/python-win.yaml
+++ b/test/scenario/multiline/python-win.yaml
@@ -17,12 +17,9 @@ spec:
       - name: python-win-scripts-volume
         configMap:
           name: python-win-test-scripts
-      nodeSelector:
-        kubernetes.io/os: windows
-        kubernetes.io/arch: amd64
       containers:
       - name: python-win
-        image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+        image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
         volumeMounts:
           - mountPath: C:\python-win-test-scripts
             name: python-win-scripts-volume


### PR DESCRIPTION
- Bump powershell base image from lts-nanoserver-1809 to lts-nanoserver-ltsc2022 to match the Windows nodepool OS on AKS test clusters (1809 nodes are no longer common).
- Drop hard-coded kubernetes.io/os and kubernetes.io/arch nodeSelector; AKS already places Windows pods correctly via image OS metadata, and the explicit selector blocks scheduling on clusters whose node labels differ.

Verified by deploying these jobs to zane-ama-logs-helm-test (ltsc2022 nodepool) and confirming logs flow through ContainerLogV2.