### PR TITLE
ci: auto-trigger build pipeline for robot upgrade branches

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -3,7 +3,11 @@ trigger:
   branches:
     include:
     - ci_prod
+    - auto/upgrade-telegraf-*
+    - auto/upgrade-go-*
+    - dependabot/*
 pr:
+  autoCancel: true
   branches:
     include:
     - ci_prod


### PR DESCRIPTION
## Summary

Update the ADO build pipeline trigger so that robot-raised PRs (Go upgrades, Telegraf upgrades, Dependabot) trigger the build automatically on branch push, without needing a manual `/azp run` comment.

## Changes

- **`trigger.branches.include`** — added bot branch patterns:
  - `auto/upgrade-telegraf-*` (telegraf upgrade bot)
  - `auto/upgrade-go-*` (Go upgrade bot)
  - `dependabot/*` (Dependabot)
- **`pr.autoCancel: true`** — cancels superseded PR builds when a new push arrives

## Context

Currently, robot PRs like [#1676](https://github.com/microsoft/Docker-Provider/pull/1676) (Go upgrade) and [#1669](https://github.com/microsoft/Docker-Provider/pull/1669) (Dependabot) don't auto-trigger the ADO build pipeline. This follows the same pattern used by ama-metrics to include bot branch names in the CI trigger.