### PR TITLE
Fix CVE-2026-41316: upgrade erb gem to 4.0.3.1 in ama-logs Linux image

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -118,6 +118,12 @@ gem_install_with_retry zlib -v "3.2.3" --no-document
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/zlib-3.1.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/zlib-3.1.1
 
+# Reinstall erb gem to fix CVE-2026-41316
+gem_install_with_retry erb -v "4.0.3.1" --no-document
+# uninstall old erb default gem
+rm -f /usr/lib/ruby/gems/3.3.0/specifications/default/erb-4.0.3.gemspec
+rm -rf /usr/lib/ruby/gems/3.3.0/gems/erb-4.0.3
+
 rm -f $TMPDIR/docker-cimprov*.sh
 rm -f $TMPDIR/mdsd.xml
 rm -f $TMPDIR/envmdsd

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -118,7 +118,10 @@ gem_install_with_retry zlib -v "3.2.3" --no-document
 rm /usr/lib/ruby/gems/3.3.0/specifications/default/zlib-3.1.1.gemspec
 rm -rf /usr/lib/ruby/gems/3.3.0/gems/zlib-3.1.1
 
-# Reinstall erb gem to fix CVE-2026-41316
+# Reinstall erb gem to fix CVE-2026-41316.
+# NOTE: when ruby is upgraded, check the default bundled erb version
+# (`ruby -rerb -e 'p ERB::VERSION'`). If it's 4.0.3.1 or higher, remove
+# this block and let the ruby package provide erb directly.
 gem_install_with_retry erb -v "4.0.3.1" --no-document
 # uninstall old erb default gem
 rm -f /usr/lib/ruby/gems/3.3.0/specifications/default/erb-4.0.3.gemspec


### PR DESCRIPTION
## Summary
Mitigates **CVE-2026-41316** in the `erb` Ruby default gem (HIGH) flagged by trivy on the ama-logs 3.4.0 candidate image.

Installs the patched `erb 4.0.3.1` from rubygems and removes the vulnerable default `erb-4.0.3` gemspec shipped with `ruby 3.3.10`, following the same pattern already used for `zlib` (CVE-2026-27820) directly above.

## Why install-and-delete instead of just upgrading ruby?

**No released Ruby version yet ships erb 4.0.3.1.**

| Ruby | bundled erb |
|---|---|
| 3.3.10, 3.3.11 (latest 3.3.x release) | **4.0.3** — vulnerable |
| 3.4.0 – 3.4.6 (latest 3.4.x release) | **4.0.4** — vulnerable |
| `ruby_3_3` branch HEAD (unreleased) | 4.0.3.1 |
| `ruby_3_4` branch HEAD (unreleased) | 4.0.4.1 |
| `master` | 6.0.4 |

The patched erb only lives in (1) the rubygems.org gem and (2) unreleased ruby maintenance branches. Until ruby 3.3.12 / 3.4.7 ships and AzureLinux picks it up, installing the gem and shadowing the default gemspec is the only available fix.

## Verification
- Confirmed `erb 4.0.3.1` exists on rubygems (published 2026-04-21, sha `871b7da4...`).
- Confirmed `ciprod:3.3.0` ships `ruby 3.3.10` with `erb-4.0.3.gemspec` in the default specs dir.

## Follow-up
Added an inline comment in `setup.sh` noting that whenever ruby is upgraded next, the maintainer should check the bundled erb version and drop this block if it's already 4.0.3.1+.
