### PR TITLE
fix(ci): pin --server-side=true alongside --force-conflicts for helm 4 upgrade

### DIFF
--- a/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
+++ b/.pipelines/helm-deploy-templates/ama-logs-helm-deploy.yaml
@@ -121,5 +121,5 @@ jobs:
             ${{ else }}:
               overrideValues: 'global.commonGlobals.CloudEnvironment=${{ parameters.cloudEnvironment }},global.commonGlobals.Region=${{ parameters.region }},global.commonGlobals.Versions.Kubernetes=$(K8S_VERSION),OmsAgent.aksResourceID=$(AKS_RESOURCE_ID),OmsAgent.workspaceID=${{ parameters.workspaceId }},OmsAgent.imageRepository=${{ parameters.imageRepository }},OmsAgent.imageTagLinux=${{ parameters.amalogsLinuxImage }},OmsAgent.imageTagWindows=${{ parameters.amalogsWindowsImage }}'
             waitForExecution: false
-            arguments: '--timeout 10m --install --force-conflicts'
+            arguments: '--timeout 10m --install --server-side=true --force-conflicts'
             


### PR DESCRIPTION
## Problem

Stage_3 of [ci-aks-prod-release.yaml](.pipelines/ci-aks-prod-release.yaml) failed on 2026-05-22 for `Monitoring-Model-Cluster-WCUS` (and `Monitoring-Model-Cluster-WEU`) with:

```
Error: UPGRADE FAILED: invalid client update option(s): forceConflicts enabled when serverSideApply disabled
```

## Root cause

PR #1667 added `--force-conflicts` to handle SSA field-ownership conflicts, but Helm 4's `helm upgrade --server-side` defaults to **`auto`**, which resolves to:

| Prior release `ApplyMethod` | `auto` resolves to |
|---|---|
| `ssa` (server-side apply) | `true` ✅ |
| `client-side apply` (e.g., release created by Helm 3) | `false` ❌ |

When `auto → false` and `forceConflicts=true`, Helm rejects the combination **client-side**, before reaching the cluster (see [`pkg/kube/client.go:729`](https://github.com/helm/helm/blob/v4.2.0/pkg/kube/client.go#L729)).

That perfectly explains the observed asymmetry: clusters whose last revision was already SSA (e.g., `ci-logs-prod-aks-work-load-identity` at rev 49) succeeded; `Monitoring-Model-Cluster-*` releases (originally Helm 3, `ApplyMethod = client-side apply`) failed.

## Fix

Add `--server-side=true` so SSA is always engaged when `--force-conflicts` is set.

### Why `=true` (not bare `--server-side`)

- `helm upgrade` defines `--server-side` as a **StringVar** (`"true"|"false"|"auto"`). Bare `--server-side` would consume the next token as the value.
- `helm install` defines `--server-side` as a **BoolVar**.
- The explicit `=true` form is unambiguous for both subcommands.

## Production cluster recovery

Already manually re-deployed both failed clusters out-of-band using the corrected command:

| Cluster | Before | After |
|---|---|---|
| Monitoring-Model-Cluster-WCUS | rev 13 (failed), CSA | **rev 14 (deployed), SSA** |
| Monitoring-Model-Cluster-WEU  | rev 8  (failed), CSA | **rev 9 (deployed), SSA**  |

As a side-effect, both releases' `ApplyMethod` flipped CSA → SSA, so any future `auto` resolution on those releases will produce `true` and would succeed even without this fix. This PR is still needed for any other cluster whose release history is still CSA (and to keep behavior deterministic for new clusters).

## Test plan

The next prod-release pipeline run will exercise this path against both prod clusters; both are now on SSA, so the fix is verified in production via the manual recovery.