### PR TITLE
fix(ci): remove dependsOn from manually-triggered Arc prod Stage_1

### DIFF
--- a/.pipelines/ci-arc-k8s-extension-prod-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-prod-release.yaml
@@ -608,8 +608,6 @@ extends:
             delayForMinutes: 1500
     - stage: Stage_1
       displayName: ci-arc-k8s-extension-all-regions-prod-release(MCR)
-      dependsOn:
-      - Wait_After_Canary
       trigger: manual
       pool:
         name: Azure-Pipelines-CI-Test-EO


### PR DESCRIPTION
## Problem

The merged PR #1715 added `trigger: manual` to `Stage_1` **and** kept an explicit `dependsOn: [Wait_After_Canary]`. Azure DevOps rejects this combination at compile time:

> Manually triggered stages cannot have dependencies. Please remove the dependsOn property.

## Fix

Remove the explicit `dependsOn` from `Stage_1`. In ADO, a stage with no `dependsOn` defaults to depending on the **preceding stage in the list** — which is `Wait_After_Canary` — so the ordering (`Canary → 25h bake → Stage_1`) is preserved. `trigger: manual` still enforces the human gate before any prod1/stable push.

This matches the existing `Stage_Canary_Regions` stage, which is also `trigger: manual` with no `dependsOn` and relies on default sequential ordering.

## Validation

- YAML parses: 13 stages, chain intact.
- `Stage_1` → `trigger=manual`, `dependsOn=None`.
- Diff is a 2-line removal only.