### PR TITLE
Recover ama-logs workspace key from extension protected secret + checksum restart

### DIFF
--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
@@ -78,6 +78,7 @@ spec:
         agentVersion: "47.7.1"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
+        checksum/secret: {{ include (print $.Template.BasePath "/ama-logs-secret.yaml") . | sha256sum }}
         WSID: {{ .Values.OmsAgent.workspaceID | b64enc | quote }}
         kubernetes.azure.com/no-http-proxy-vars: "true"
 {{- end }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
@@ -108,6 +108,7 @@ spec:
         agentVersion: "azure-mdsd-1.40.3"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
+        checksum/secret: {{ include (print $.Template.BasePath "/ama-logs-secret.yaml") $ | sha256sum }}
         WSID: {{ $.Values.OmsAgent.workspaceID | b64enc | quote }}
         kubernetes.azure.com/no-http-proxy-vars: "true"
 {{- end }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
@@ -74,6 +74,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         dockerProviderVersion: "18.0.1-0"
         schema-versions: "v1"
+        checksum/secret: {{ include (print $.Template.BasePath "/ama-logs-secret.yaml") . | sha256sum }}
         WSID: {{ .Values.OmsAgent.workspaceID | b64enc | quote }}
         kubernetes.azure.com/no-http-proxy-vars: "true"
 {{- end }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
@@ -1,5 +1,37 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
+{{- /*
+  Fall back to the extension manager's protected-parameters secret when the workspace
+  key is not supplied in the rendered values. The extension manager persists protected
+  settings in the on-cluster secret "protected-ext-parameters-<release>" (created by the
+  config agent from the extension's protectedParameters). During an extension auto-update
+  the manager can stop re-delivering protectedParameters, leaving .Values.*.workspaceKey
+  empty. Without this fallback the chart would overwrite the live ama-logs-secret KEY with
+  an empty value, breaking the agent ~10-14 days later when cached credentials expire.
+
+  Only the workspace KEY is protected (and therefore recovered here). The workspace ID
+  (WSID) is a non-protected parameter that continues to be delivered, so it is taken from
+  values as-is.
+
+  The agent does NOT clear "protected-ext-parameters-<release>" when it drops the CR
+  reference, so this secret remains the source of truth for the key.
+
+  Note: lookup returns empty during `helm template`/`--dry-run`/first install; on a real
+  upgrade (extension manager flow) it returns the live secret. On first install the
+  incoming key is populated, so the fallback is a no-op there.
+*/ -}}
+{{- $protectedSecretName := printf "protected-ext-parameters-%s" .Release.Name -}}
+{{- $protectedSecret := (lookup "v1" "Secret" .Release.Namespace $protectedSecretName) -}}
+{{- $existingKey := "" -}}
+{{- if and $protectedSecret $protectedSecret.data -}}
+{{- if hasKey $protectedSecret.data "OmsAgent.workspaceKey" -}}{{- $existingKey = (index $protectedSecret.data "OmsAgent.workspaceKey" | b64dec) -}}{{- end -}}
+{{- if and (eq $existingKey "") (hasKey $protectedSecret.data "amalogs.secret.key") -}}{{- $existingKey = (index $protectedSecret.data "amalogs.secret.key" | b64dec) -}}{{- end -}}
+{{- end -}}
+{{- /* Resolve the effective workspace key, falling back to the protected-parameters secret when not supplied. */ -}}
+{{- $arcKey := .Values.amalogs.secret.key -}}
+{{- if or (eq (toString $arcKey) "<your_workspace_key>") (eq (toString $arcKey) "") -}}{{- $arcKey = $existingKey -}}{{- end -}}
+{{- $aksKey := .Values.OmsAgent.workspaceKey -}}
+{{- if or (eq (toString $aksKey) "<your_workspace_key>") (eq (toString $aksKey) "") -}}{{- $aksKey = $existingKey -}}{{- end -}}
 {{/* Arc has credential validation, AKS always renders */}}
 {{- if or (not $isArcExtension) (and $isArcExtension (and (ne .Values.amalogs.secret.key "<your_workspace_key>") (ne .Values.amalogs.secret.wsid "<your_workspace_id>") (or (ne .Values.amalogs.env.clusterName "<your_cluster_name>") (ne .Values.amalogs.env.clusterId "<your_cluster_id>") (ne .Values.Azure.Cluster.ResourceId "<your_cluster_id>")))) }}
 {{- $cloudEnv := lower .Values.global.commonGlobals.CloudEnvironment }}
@@ -23,7 +55,7 @@ type: Opaque
 data:
 {{- if $isArcExtension }}
   WSID: {{ required "A valid workspace id is required!" .Values.amalogs.secret.wsid | b64enc | quote }}
-  KEY: {{ required "A valid workspace key is required!" .Values.amalogs.secret.key | b64enc | quote }}
+  KEY: {{ required "A valid workspace key is required!" $arcKey | b64enc | quote }}
   DOMAIN: {{ .Values.amalogs.domain | b64enc | quote }}
   {{- if and (.Values.Azure.proxySettings.isProxyEnabled) (.Values.Azure.proxySettings.httpsProxy) (not .Values.amalogs.ignoreExtensionProxySettings) }}
   PROXY: {{ .Values.Azure.proxySettings.httpsProxy | b64enc | quote }}
@@ -37,7 +69,7 @@ data:
   {{- end }}
 {{- else }}
   WSID: {{ .Values.OmsAgent.workspaceID | b64enc | quote }}
-  KEY: {{ .Values.OmsAgent.workspaceKey | b64enc | quote }}
+  KEY: {{ $aksKey | b64enc | quote }}
 {{- if .Values.OmsAgent.isMoonCake }}
   DOMAIN: {{ b64enc "opinsights.azure.cn" }}
 {{- end }}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
@@ -1,6 +1,25 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
 {{- /*
+  Determine whether the cluster uses AAD (managed-identity) auth. Mirrors the evaluation used by
+  the daemonset/deployment templates. Compare as a lowercased string because Helm --set and quoted
+  YAML deliver this as a string, and any non-empty string is truthy in Go templates.
+*/ -}}
+{{- $isusingaadauth := false -}}
+{{- if not $isArcExtension -}}
+  {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
+    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- if and .Values.amalogs (hasKey .Values.amalogs "useAADAuth") -}}
+    {{- if eq (lower (toString .Values.amalogs.useAADAuth)) "true" -}}
+      {{- $isusingaadauth = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- /*
   Fall back to the extension manager's protected-parameters secret when the workspace
   key is not supplied in the rendered values. The extension manager persists protected
   settings in the on-cluster secret "protected-ext-parameters-<release>" (created by the
@@ -8,6 +27,10 @@
   the manager can stop re-delivering protectedParameters, leaving .Values.*.workspaceKey
   empty. Without this fallback the chart would overwrite the live ama-logs-secret KEY with
   an empty value, breaking the agent ~10-14 days later when cached credentials expire.
+
+  This recovery only applies to workspace-key (non-AAD) clusters. On AAD/managed-identity
+  clusters the workspace key is empty by design (auth uses a token, not a key), so the
+  fallback is gated on `not $isusingaadauth` and skipped entirely for those clusters.
 
   Only the workspace KEY is protected (and therefore recovered here). The workspace ID
   (WSID) is a non-protected parameter that continues to be delivered, so it is taken from
@@ -20,14 +43,16 @@
   upgrade (extension manager flow) it returns the live secret. On first install the
   incoming key is populated, so the fallback is a no-op there.
 */ -}}
+{{- $existingKey := "" -}}
+{{- if not $isusingaadauth -}}
 {{- $protectedSecretName := printf "protected-ext-parameters-%s" .Release.Name -}}
 {{- $protectedSecret := (lookup "v1" "Secret" .Release.Namespace $protectedSecretName) -}}
-{{- $existingKey := "" -}}
 {{- if and $protectedSecret $protectedSecret.data -}}
 {{- if hasKey $protectedSecret.data "OmsAgent.workspaceKey" -}}{{- $existingKey = (index $protectedSecret.data "OmsAgent.workspaceKey" | b64dec) -}}{{- end -}}
 {{- if and (eq $existingKey "") (hasKey $protectedSecret.data "amalogs.secret.key") -}}{{- $existingKey = (index $protectedSecret.data "amalogs.secret.key" | b64dec) -}}{{- end -}}
 {{- end -}}
-{{- /* Resolve the effective workspace key, falling back to the protected-parameters secret when not supplied. */ -}}
+{{- end -}}
+{{- /* Resolve the effective workspace key, falling back to the protected-parameters secret when not supplied (non-AAD only). */ -}}
 {{- $arcKey := .Values.amalogs.secret.key -}}
 {{- if or (eq (toString $arcKey) "<your_workspace_key>") (eq (toString $arcKey) "") -}}{{- $arcKey = $existingKey -}}{{- end -}}
 {{- $aksKey := .Values.OmsAgent.workspaceKey -}}

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
@@ -20,39 +20,48 @@
   {{- end -}}
 {{- end -}}
 {{- /*
-  Fall back to the extension manager's protected-parameters secret when the workspace
-  key is not supplied in the rendered values. The extension manager persists protected
-  settings in the on-cluster secret "protected-ext-parameters-<release>" (created by the
-  config agent from the extension's protectedParameters). During an extension auto-update
-  the manager can stop re-delivering protectedParameters, leaving .Values.*.workspaceKey
-  empty. Without this fallback the chart would overwrite the live ama-logs-secret KEY with
-  an empty value, breaking the agent ~10-14 days later when cached credentials expire.
+  Recover the workspace key from the extension manager's protected-parameters secret ONLY when the
+  cluster is already broken — i.e. the mandatory workspace key is missing from the rendered values.
+  The extension manager persists protected settings in the on-cluster secret
+  "protected-ext-parameters-<release>" (created by the config agent from the extension's
+  protectedParameters). During an extension auto-update the manager can stop re-delivering
+  protectedParameters, leaving .Values.*.workspaceKey empty. Without this recovery the chart would
+  overwrite the live ama-logs-secret KEY with an empty value, breaking the agent ~10-14 days later
+  when cached credentials expire.
 
-  This recovery only applies to workspace-key (non-AAD) clusters. On AAD/managed-identity
-  clusters the workspace key is empty by design (auth uses a token, not a key), so the
-  fallback is gated on `not $isusingaadauth` and skipped entirely for those clusters.
+  Logic:
+    if   not AAD auth                                    (workspace-key clusters only; AAD has no key)
+    and  the incoming workspace key is empty/placeholder (the credential that MUST be present is
+                                                          missing -> protectedParameters not delivered)
+    and  protected-ext-parameters-<release> exists       (authoritative recovery source)
+    then patch the workspace key from that secret.
 
-  Only the workspace KEY is protected (and therefore recovered here). The workspace ID
-  (WSID) is a non-protected parameter that continues to be delivered, so it is taken from
-  values as-is.
+  The lookup runs only on this missing-key path, so healthy clusters (key already supplied) skip the
+  live secret read entirely. On AAD/managed-identity clusters the key is empty by design (token auth),
+  so the whole block is gated on `not $isusingaadauth`. Only the workspace KEY is recovered; the WSID
+  is non-protected and is taken from values as-is. The agent does NOT clear the protected-ext-parameters
+  secret when it drops the CR reference, so it remains the source of truth.
 
-  The agent does NOT clear "protected-ext-parameters-<release>" when it drops the CR
-  reference, so this secret remains the source of truth for the key.
-
-  Note: lookup returns empty during `helm template`/`--dry-run`/first install; on a real
-  upgrade (extension manager flow) it returns the live secret. On first install the
-  incoming key is populated, so the fallback is a no-op there.
+  Note: lookup returns empty during `helm template`/`--dry-run`/first install; on a real upgrade
+  (extension manager flow) it returns the live secret. On first install the incoming key is populated,
+  so recovery is skipped. If the protected secret is also empty, the key renders empty either way.
 */ -}}
 {{- $existingKey := "" -}}
 {{- if not $isusingaadauth -}}
-{{- $protectedSecretName := printf "protected-ext-parameters-%s" .Release.Name -}}
-{{- $protectedSecret := (lookup "v1" "Secret" .Release.Namespace $protectedSecretName) -}}
-{{- if and $protectedSecret $protectedSecret.data -}}
-{{- if hasKey $protectedSecret.data "OmsAgent.workspaceKey" -}}{{- $existingKey = (index $protectedSecret.data "OmsAgent.workspaceKey" | b64dec) -}}{{- end -}}
-{{- if and (eq $existingKey "") (hasKey $protectedSecret.data "amalogs.secret.key") -}}{{- $existingKey = (index $protectedSecret.data "amalogs.secret.key" | b64dec) -}}{{- end -}}
+  {{- /* The incoming workspace key for the active path: Arc uses amalogs.secret.key, AKS uses OmsAgent.workspaceKey. */ -}}
+  {{- $incomingKey := .Values.OmsAgent.workspaceKey -}}
+  {{- if $isArcExtension -}}{{- $incomingKey = .Values.amalogs.secret.key -}}{{- end -}}
+  {{- if or (eq (toString $incomingKey) "<your_workspace_key>") (eq (toString $incomingKey) "") -}}
+    {{- /* Cluster is already broken (mandatory key missing) — recover from the on-cluster protected secret. */ -}}
+    {{- $protectedSecretName := printf "protected-ext-parameters-%s" .Release.Name -}}
+    {{- $protectedSecret := (lookup "v1" "Secret" .Release.Namespace $protectedSecretName) -}}
+    {{- if and $protectedSecret $protectedSecret.data -}}
+    {{- if hasKey $protectedSecret.data "OmsAgent.workspaceKey" -}}{{- $existingKey = (index $protectedSecret.data "OmsAgent.workspaceKey" | b64dec) -}}{{- end -}}
+    {{- if and (eq $existingKey "") (hasKey $protectedSecret.data "amalogs.secret.key") -}}{{- $existingKey = (index $protectedSecret.data "amalogs.secret.key" | b64dec) -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
-{{- end -}}
-{{- /* Resolve the effective workspace key, falling back to the protected-parameters secret when not supplied (non-AAD only). */ -}}
+{{- /* Resolve the effective workspace key, patching from the recovered value when not supplied (non-AAD only). */ -}}
 {{- $arcKey := .Values.amalogs.secret.key -}}
 {{- if or (eq (toString $arcKey) "<your_workspace_key>") (eq (toString $arcKey) "") -}}{{- $arcKey = $existingKey -}}{{- end -}}
 {{- $aksKey := .Values.OmsAgent.workspaceKey -}}


### PR DESCRIPTION
## Summary

Recover the Container Insights workspace key from the extension manager's
protected-parameters secret when it is not re-delivered to the chart, and roll
the agent pods (Linux **and** Windows) when the effective secret changes.

This prevents a class of failures where `ama-logs-secret` gets overwritten with
an empty workspace `KEY`, which silently breaks log ingestion ~10-14 days later
when the previously-cached credentials expire.

## Background / root cause

For workspace-key (non-AAD) clusters, the workspace key is delivered to the
chart as a **protected parameter**. The config agent persists it on-cluster in
`protected-ext-parameters-<release>` and passes it to Helm as
`OmsAgent.workspaceKey` (or `amalogs.secret.key` for Arc).

During an extension auto-update the extension manager can stop re-delivering the
protected parameters. When that happens, `.Values.OmsAgent.workspaceKey` renders
**empty**, and the chart overwrites the live `ama-logs-secret` `KEY` with an
empty value. The agent keeps working until its cached credentials expire, then
fails — making the root cause hard to correlate with the triggering update.

Importantly, the agent does **not** clear `protected-ext-parameters-<release>`
when it drops the CR reference, so that secret remains a valid source of truth
for the key.

## What this change does

### 1. Conditional workspace-key fallback (`ama-logs-secret.yaml`)
When the incoming workspace key is empty/placeholder, fall back to the existing
on-cluster `protected-ext-parameters-<release>` secret (data key
`OmsAgent.workspaceKey` for AKS, `amalogs.secret.key` for Arc) via Helm `lookup`.

Semantics (intentionally **conditional**, not unconditional):
- Incoming **real** key always wins → key rotation is preserved.
- Incoming **empty** key → use whatever is in the existing secret.

Only the **KEY** is recovered. The workspace **ID** (WSID) is a *non-protected*
parameter that continues to be delivered, so it is taken from values as-is.

### 2. `checksum/secret` on the AKS pod templates (Linux + Windows)
The Arc path already had `checksum/secret`; the AKS (non-Arc) path only had a
`WSID` annotation, which does **not** change when the workspace **KEY** changes.
Added `checksum/secret` to all three AKS workloads — `ama-logs-daemonset.yaml`,
`ama-logs-daemonset-windows.yaml`, and `ama-logs-deployment.yaml` — so pods roll
when the effective secret actually changes.

## Important nuance: AAD/MSI clusters

For `OmsAgent.isUsingAADAuth: "true"` clusters the workspace key is **empty by
design** (auth uses a managed-identity token, not a workspace key). The fix does
**not** special-case this and does **not** need to:

- On an AAD cluster the `protected-ext-parameters-<release>` secret is itself
  empty, so the fallback resolves to empty — exactly the value we want sent to
  the chart. No guard on `isUsingAADAuth` is required.

So the KEY-fallback is a **no-op for AAD clusters** and a **fix for legacy
workspace-key clusters that dropped protected settings**. The `checksum/secret`
change benefits both.

## Behavior matrix

| Cluster | Incoming key | Existing protected secret | Rendered KEY | Correct |
|---|---|---|---|---|
| AAD auth (healthy) | empty (intended) | empty | empty | ✅ |
| Key auth (healthy) | real key | real key | real key (incoming wins) | ✅ |
| Key auth (dropped protected params) | empty | retained key | recovered key | ✅ |
| Key auth (rotation) | new key | old key | new key (incoming wins) | ✅ |

## Testing

Validated against a **live AKS cluster running the real azure-monitor-logs
extension** (chart 3.3.0, `isUsingAADAuth: true`) using
`helm template --dry-run=server` (executes `lookup` server-side):

- Empty incoming key + key present in `protected-ext-parameters-*` → **recovered** ✅
- Real incoming key → **takes precedence** (rotation safe) ✅
- Current published rendering (no server lookup) + empty key → `KEY: ""`
  (reproduces the bug) ✅
- `helm lint` passes; Arc empty-key path still fails loudly via `required`.

## Notes

- `lookup` returns empty during `helm template`/client-side dry-run/first
  install; on a real `helm upgrade` (extension manager flow) it returns the live
  secret. On first install the incoming key is populated, so the fallback is a
  no-op there.
- `lookup` requires `get` on Secrets in the release namespace; the extension's
  Helm operator already has this.
