### PR TITLE
fix(agent): prevent panic in parseImageDetails for digest-pinned images

### DIFF
--- a/source/plugins/go/src/oms.go
+++ b/source/plugins/go/src/oms.go
@@ -1311,14 +1311,16 @@ func extractImageID(hash string) string {
 }
 
 func parseImageDetails(image string) (repo, name, tag string) {
-	slashLocation := strings.Index(image, "/")
-	colonLocation := strings.Index(image, ":")
-	atLocation := strings.Index(image, "@")
-
-	// Exclude the digest part for imageRepo/image/tag parsing, if present
-	if atLocation != -1 {
+	// Exclude the digest part for imageRepo/image/tag parsing, if present.
+	// This must happen before computing slash/colon positions, otherwise a colon
+	// inside the digest (e.g. "repo/name@sha256:...") would yield a colonLocation
+	// past the truncated string length and cause a slice out-of-range panic.
+	if atLocation := strings.Index(image, "@"); atLocation != -1 {
 		image = image[:atLocation]
 	}
+
+	slashLocation := strings.Index(image, "/")
+	colonLocation := strings.Index(image, ":")
 
 	// If colonLocation is -1 (not found), set it to the length of the image string
 	if colonLocation == -1 {

--- a/source/plugins/go/src/oms_test.go
+++ b/source/plugins/go/src/oms_test.go
@@ -219,3 +219,160 @@ func TestProcessIncludes(t *testing.T) {
 		t.Errorf("Expected result to be %v, but got %v", expectedResult, result)
 	}
 }
+
+func TestParseImageDetails(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		image        string
+		expectedRepo string
+		expectedName string
+		expectedTag  string
+	}{
+		// --- no registry/host ---
+		{
+			desc:         "bare name",
+			image:        "nginx",
+			expectedRepo: "",
+			expectedName: "nginx",
+			expectedTag:  "latest",
+		},
+		{
+			desc:         "name + tag",
+			image:        "nginx:1.21",
+			expectedRepo: "",
+			expectedName: "nginx",
+			expectedTag:  "1.21",
+		},
+		{
+			desc:         "name + digest, no tag",
+			image:        "nginx@sha256:abc123def456",
+			expectedRepo: "",
+			expectedName: "nginx",
+			expectedTag:  "latest",
+		},
+		// --- namespace/name (no host) ---
+		{
+			desc:         "namespace/name",
+			image:        "library/nginx",
+			expectedRepo: "library",
+			expectedName: "nginx",
+			expectedTag:  "latest",
+		},
+		{
+			desc:         "namespace/name + tag",
+			image:        "library/nginx:1.21",
+			expectedRepo: "library",
+			expectedName: "nginx",
+			expectedTag:  "1.21",
+		},
+		{
+			desc:         "namespace/name + digest, no tag",
+			image:        "library/nginx@sha256:abc123def456",
+			expectedRepo: "library",
+			expectedName: "nginx",
+			expectedTag:  "latest",
+		},
+		// --- host/path ---
+		{
+			desc:         "host/name + tag",
+			image:        "docker.io/library/nginx:1.21",
+			expectedRepo: "docker.io",
+			expectedName: "library/nginx",
+			expectedTag:  "1.21",
+		},
+		{
+			desc:         "host/multi-segment path + tag",
+			image:        "mcr.microsoft.com/azuremonitor/containerinsights/cidev:3.1.34",
+			expectedRepo: "mcr.microsoft.com",
+			expectedName: "azuremonitor/containerinsights/cidev",
+			expectedTag:  "3.1.34",
+		},
+		{
+			desc:         "host/multi-segment path + digest, no tag",
+			image:        "mcr.microsoft.com/azuremonitor/containerinsights/cidev@sha256:abc123",
+			expectedRepo: "mcr.microsoft.com",
+			expectedName: "azuremonitor/containerinsights/cidev",
+			expectedTag:  "latest",
+		},
+		{
+			// The crash that motivated the fix: digest-pinned, tagless image (ubiquitous on OpenShift).
+			desc:         "host/name + digest, no tag (OpenShift) - previously panicked",
+			image:        "quay.io/openshift-release-dev/ocp-release@sha256:ed3b2be8d2673f8669ba2a6d4951011b9b4d52eb4a28eb46ed87c05d175cc196",
+			expectedRepo: "quay.io",
+			expectedName: "openshift-release-dev/ocp-release",
+			expectedTag:  "latest",
+		},
+		{
+			desc:         "tag AND digest",
+			image:        "repo/name:1.0@sha256:abc123",
+			expectedRepo: "repo",
+			expectedName: "name",
+			expectedTag:  "1.0",
+		},
+		// --- known limitation: registry with an explicit :port is mis-split because the
+		// parser treats the first colon as the tag delimiter. Documented here as the
+		// current (non-panicking) behavior so any future change to it is intentional. ---
+		{
+			desc:         "host:port/name + tag (known quirk: port mistaken for tag)",
+			image:        "myregistry.io:5000/team/app:1.0",
+			expectedRepo: "",
+			expectedName: "myregistry.io",
+			expectedTag:  "5000/team/app:1.0",
+		},
+		{
+			desc:         "host:port/name + digest (known quirk)",
+			image:        "myregistry.io:5000/team/app@sha256:abc123",
+			expectedRepo: "",
+			expectedName: "myregistry.io",
+			expectedTag:  "5000/team/app",
+		},
+		{
+			desc:         "localhost:port/name (known quirk)",
+			image:        "localhost:5000/app",
+			expectedRepo: "",
+			expectedName: "localhost",
+			expectedTag:  "5000/app",
+		},
+		// --- edge case ---
+		{
+			desc:         "empty string",
+			image:        "",
+			expectedRepo: "",
+			expectedName: "",
+			expectedTag:  "latest",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			repo, name, tag := parseImageDetails(tc.image)
+			assert.Equal(t, tc.expectedRepo, repo, "repo mismatch for image %q", tc.image)
+			assert.Equal(t, tc.expectedName, name, "name mismatch for image %q", tc.image)
+			assert.Equal(t, tc.expectedTag, tag, "tag mismatch for image %q", tc.image)
+		})
+	}
+}
+
+func TestProcessIncludesDigestPinnedImage(t *testing.T) {
+	// Reproduces the crash where a digest-pinned, tagless image (e.g. on OpenShift)
+	// triggered a slice out-of-range panic in parseImageDetails via processIncludes.
+	kubernetesMetadataMap := map[string]interface{}{
+		"container_hash":  "ocp-release@sha256:ed3b2be8d2673f8669ba2a6d4951011b9b4d52eb4a28eb46ed87c05d175cc196",
+		"container_image": "quay.io/openshift-release-dev/ocp-release@sha256:ed3b2be8d2673f8669ba2a6d4951011b9b4d52eb4a28eb46ed87c05d175cc196",
+	}
+
+	includesList := []string{"imagerepo", "image", "imagetag", "imageid"}
+
+	expectedResult := map[string]interface{}{
+		"imageRepo": "quay.io",
+		"image":     "openshift-release-dev/ocp-release",
+		"imageTag":  "latest",
+		"imageID":   "sha256:ed3b2be8d2673f8669ba2a6d4951011b9b4d52eb4a28eb46ed87c05d175cc196",
+	}
+
+	result := processIncludes(kubernetesMetadataMap, includesList)
+
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("Expected result to be %v, but got %v", expectedResult, result)
+	}
+}


### PR DESCRIPTION
## Summary

`parseImageDetails` could panic with `slice bounds out of range` when processing **digest-pinned, tagless** container images (e.g. `quay.io/openshift-release-dev/ocp-release@sha256:...`), which are ubiquitous on OpenShift. The panic crashed fluent-bit's `out_oms` plugin during flush and crash-looped the `ama-logs` daemonset on affected clusters (observed restartCount in the hundreds, with intermittent/zero `ContainerLogV2` ingestion).

## Root cause

`colonLocation` (the tag delimiter) was computed on the **full** image string, *before* the `@<digest>` suffix was stripped:

```go
slashLocation := strings.Index(image, "/")
colonLocation := strings.Index(image, ":")   // finds ':' inside "sha256:"
atLocation := strings.Index(image, "@")
if atLocation != -1 { image = image[:atLocation] }   // image is now shorter
...
name = image[slashLocation+1 : colonLocation]        // colonLocation > len(image) -> panic
```

For `quay.io/openshift-release-dev/ocp-release@sha256:ed3b...`:
- `colonLocation` = 48 (the `:` in `sha256:`)
- after `@` truncation, `len(image)` = 41
- `name = image[8:48]` → `slice bounds out of range [:48] with length 41`

The existing `if colonLocation < len(image)` guard only protected the `tag` slice; the panic happened one block earlier on the **unguarded** `name` slice. This path is reached through KubernetesMetadata enrichment: `FLBPluginFlush` → `PostDataHelper` → `processIncludes` → `parseImageDetails`.

## Fix

Move the `@<digest>` truncation to the top of the function so `slashLocation` and `colonLocation` are computed on the already-cleaned string and can never exceed its length. Behavior is unchanged for all previously-working formats.

## Tests

- **`TestParseImageDetails`** — table-driven, 15 cases covering every reference form: bare name, `name:tag`, `name@digest`, `namespace/name` (+tag/+digest), `host/path` (+tag/+digest), multi-segment paths, `tag` **and** `digest`, the OpenShift digest-tagless case (the panic repro), `registry:port` quirks, and empty string.
- **`TestProcessIncludesDigestPinnedImage`** — exercises the end-to-end metadata path that previously panicked.

`go build ./...` and `go test ./source/plugins/go/src` both pass.

## Notes

The simplified parser still mis-splits a registry with an explicit `:port` (e.g. `myregistry.io:5000/team/app:1.0`) — this is pre-existing, **non-panicking** behavior and is documented as a known limitation in the new tests.
