### PR TITLE
Revert 3.4.1 chart changes

### DIFF
--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset-windows.yaml
@@ -255,8 +255,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.uid
-          - name: EXTENSION_DROPPED_CONFIG_FIX_ENABLED
-            value: "true"
           volumeMounts:
           - mountPath: C:\ProgramData\docker\containers
             name: docker-windows-containers

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-daemonset.yaml
@@ -292,8 +292,6 @@ spec:
               value: "4320"
             - name: PROMETHEUS_METRICS_SCRAPING_DISABLED
               value: "{{ $.Values.OmsAgent.isPrometheusMetricsScrapingDisabled }}"
-            - name: EXTENSION_DROPPED_CONFIG_FIX_ENABLED
-              value: "true"
           {{- if (eq $cloudEnv "usnat") }}
             - name: MCR_URL
               value: "https://mcr.microsoft.eaglex.ic.gov/v2/"

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-deployment.yaml
@@ -365,8 +365,6 @@ spec:
               value: "{{ .Values.OmsAgent.isTelegrafLivenessprobeEnabled | default false }}"
             - name: AZMON_WINDOWS_FLUENT_BIT_ENABLED
               value: "{{ .Values.OmsAgent.isWindowsAMAFluentBitEnabled | default false }}"
-            - name: EXTENSION_DROPPED_CONFIG_FIX_ENABLED
-              value: "true"
 {{- end }}
 {{- if $isArcExtension }}
             - name: HOSTNAME

--- a/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
+++ b/charts/azuremonitor-containerinsights/templates/ama-logs-secret.yaml
@@ -1,65 +1,5 @@
 {{- $arcSettings := include "arc-extension-settings" . | fromYaml }}
 {{- $isArcExtension := $arcSettings.isArcExtension }}
-{{- /*
-  Determine whether the cluster uses AAD (managed-identity) auth. Mirrors the evaluation used by
-  the daemonset/deployment templates. Compare as a lowercased string because Helm --set and quoted
-  YAML deliver this as a string, and any non-empty string is truthy in Go templates.
-*/ -}}
-{{- $isusingaadauth := false -}}
-{{- if not $isArcExtension -}}
-  {{- if hasKey .Values.OmsAgent "isUsingAADAuth" -}}
-    {{- if eq (lower (toString .Values.OmsAgent.isUsingAADAuth)) "true" -}}
-      {{- $isusingaadauth = true -}}
-    {{- end -}}
-  {{- end -}}
-{{- else -}}
-  {{- if and .Values.amalogs (hasKey .Values.amalogs "useAADAuth") -}}
-    {{- if eq (lower (toString .Values.amalogs.useAADAuth)) "true" -}}
-      {{- $isusingaadauth = true -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-{{- /*
-  Recover the workspace key from the extension manager's protected-parameters secret ONLY when the
-  cluster is already broken — i.e. the mandatory workspace key is missing from the rendered values.
-  The extension manager persists protected settings in the on-cluster secret
-  "protected-ext-parameters-<release>" (created by the config agent from the extension's
-  protectedParameters). During an extension auto-update the manager can stop re-delivering
-  protectedParameters, leaving .Values.*.workspaceKey empty. Without this recovery the chart would
-  overwrite the live ama-logs-secret KEY with an empty value, breaking the agent ~10-14 days later
-  when cached credentials expire.
-
-  Logic:
-    if   not AAD auth                                    (workspace-key clusters only; AAD has no key)
-    and  the incoming workspace key is empty/placeholder (the credential that MUST be present is
-                                                          missing -> protectedParameters not delivered)
-    and  protected-ext-parameters-<release> exists       (authoritative recovery source)
-    then patch the workspace key from that secret.
-
-  The lookup runs only on this missing-key path, so healthy clusters (key already supplied) skip the
-  live secret read entirely. On AAD/managed-identity clusters the key is empty by design (token auth),
-  so the whole block is gated on `not $isusingaadauth`. Only the workspace KEY is recovered; the WSID
-  is non-protected and is taken from values as-is. The agent does NOT clear the protected-ext-parameters
-  secret when it drops the CR reference, so it remains the source of truth.
-
-  Note: lookup returns empty during `helm template`/`--dry-run`/first install; on a real upgrade
-  (extension manager flow) it returns the live secret. On first install the incoming key is populated,
-  so recovery is skipped. If the protected secret is also empty, the key renders empty either way.
-*/ -}}
-{{- $aksKey := .Values.OmsAgent.workspaceKey -}}
-{{- if and (not $isusingaadauth) (not $isArcExtension) -}}
-  {{- if or (eq (toString $aksKey) "<your_workspace_key>") (eq (toString $aksKey) "") -}}
-    {{- /* Cluster is already broken (mandatory key missing) — recover from the on-cluster protected secret. */ -}}
-    {{- $protectedSecretName := printf "protected-ext-parameters-%s" .Release.Name -}}
-    {{- $protectedSecret := (lookup "v1" "Secret" .Release.Namespace $protectedSecretName) -}}
-    {{- if and $protectedSecret $protectedSecret.data -}}
-      {{- if hasKey $protectedSecret.data "OmsAgent.workspaceKey" -}}
-        {{- $aksKey = (index $protectedSecret.data "OmsAgent.workspaceKey" | b64dec) -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
 {{/* Arc has credential validation, AKS always renders */}}
 {{- if or (not $isArcExtension) (and $isArcExtension (and (ne .Values.amalogs.secret.key "<your_workspace_key>") (ne .Values.amalogs.secret.wsid "<your_workspace_id>") (or (ne .Values.amalogs.env.clusterName "<your_cluster_name>") (ne .Values.amalogs.env.clusterId "<your_cluster_id>") (ne .Values.Azure.Cluster.ResourceId "<your_cluster_id>")))) }}
 {{- $cloudEnv := lower .Values.global.commonGlobals.CloudEnvironment }}
@@ -97,7 +37,7 @@ data:
   {{- end }}
 {{- else }}
   WSID: {{ .Values.OmsAgent.workspaceID | b64enc | quote }}
-  KEY: {{ $aksKey | b64enc | quote }}
+  KEY: {{ .Values.OmsAgent.workspaceKey | b64enc | quote }}
 {{- if .Values.OmsAgent.isMoonCake }}
   DOMAIN: {{ b64enc "opinsights.azure.cn" }}
 {{- end }}


### PR DESCRIPTION
This PR reverts the 3.4.1 chart changes made to fix the dropped protected config issue for clusters with scope lock property: https://github.com/microsoft/Docker-Provider/commit/03c4bb511dbd186376eca23785560171a102885e#diff-bdbe3f6af1edbbc1f49d473dc24743b948b27e4b4486895fc15d2ea294a9ea51. 

Since the chart is already rollout to the impacted clusters and the bug is also fixed by the extension team, we can revert the fix.