### PR TITLE
fix(cve): bump Linux fluentd 1.16.3 -> 1.19.3 (Bug 38718958, ICM 830469080)

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -97,7 +97,10 @@ gem_install_with_retry() {
 }
 
 # install fluentd
-fluentd_version="1.16.3"
+# Bumped 1.16.3 -> 1.19.3 to fix CVE-2026-44024, CVE-2026-44025, CVE-2026-44160,
+# CVE-2026-44161. This also pulls fixed transitive gems concurrent-ruby (>= 1.3.7,
+# fixes CVE-2026-54904/54905/54906) and msgpack (>= 1.8.2, fixes CVE-2026-54522).
+fluentd_version="1.19.3"
 gem_install_with_retry fluentd -v $fluentd_version --no-document
 
 # remove the test directory from fluentd

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -97,9 +97,13 @@ gem_install_with_retry() {
 }
 
 # install fluentd
-# Bumped 1.16.3 -> 1.19.3 to fix CVE-2026-44024, CVE-2026-44025, CVE-2026-44160,
-# CVE-2026-44161. This also pulls fixed transitive gems concurrent-ruby (>= 1.3.7,
-# fixes CVE-2026-54904/54905/54906) and msgpack (>= 1.8.2, fixes CVE-2026-54522).
+# Bumped 1.16.3 -> 1.19.3 to fix fluentd CVE-2026-44024, CVE-2026-44025,
+# CVE-2026-44160, CVE-2026-44161.
+# Related transitive gem CVEs clear at build time because nothing pins these gems:
+#   - msgpack (direct fluentd dep, constraint >= 1.3.1, < 2.0.0): resolves to the
+#     latest matching (>= 1.8.2), fixing CVE-2026-54522.
+#   - concurrent-ruby (indirect, unpinned): resolves to the latest (>= 1.3.7),
+#     fixing CVE-2026-54904/54905/54906.
 fluentd_version="1.19.3"
 gem_install_with_retry fluentd -v $fluentd_version --no-document
 


### PR DESCRIPTION
## Summary
Bumps the **Linux** ama-logs image fluentd gem **1.16.3 → 1.19.3** to remediate CVEs flagged by ICM 830469080 (ADO Bug 38718958).

## CVEs addressed
**fluentd (direct):**
- CVE-2026-44024 (RCE via arbitrary file write, `\` placeholder) — Critical
- CVE-2026-44025 (info disclosure, `in_monitor_agent`) — High
- CVE-2026-44160 (DoS/decompression amplification, `in_http`/`in_forward`) — High
- CVE-2026-44161 (SSRF, `out_http`) — High

All four fixed in fluentd 1.19.3 (GitHub advisory GHSA-44hj-4m45-frj3).

**Transitive gems (unpinned; resolved fresh at build):**
- msgpack → ≥ 1.8.2 (fixes CVE-2026-54522); fluentd 1.19.3 constraint `>= 1.3.1, < 2.0.0`, latest 1.8.3.
- concurrent-ruby → ≥ 1.3.7 (fixes CVE-2026-54904/54905/54906).

## Scope
- **Linux only.** fluentd 1.19.3 requires Ruby ≥ 3.2; the Linux image ships Ruby 3.3. ✅
- **Windows image is intentionally out of scope** (Ruby 3.1.1 < 3.2) and tracked separately — `kubernetes/windows/Dockerfile` stays at fluentd 1.16.3.

## Pre-PR QA performed
- fluentd 1.19.3 verified present on RubyGems, `ruby_version >= 3.2`, non-prerelease.
- CVE fix-versions confirmed against GitHub Advisory DB / OpenCVE / Snyk.
- Transitive resolution verified via RubyGems dependency API (msgpack constraint + latest; concurrent-ruby unpinned latest).
- Reference sweep: no `Gemfile.lock` pins; no other Linux fluentd pin.

## Validation gate (post-build)
This bump crosses fluentd 1.16 → 1.19, which pulls new runtime gems (async-http, zstd-ruby, base64, csv, drb, uri, …). Before merge it needs the **multi-line log-stitching A/B validation** against a CI-built image on an AKS cluster (Linux + Windows nodepools).

## Risk
Low-to-moderate: single dependency version change, well-scoped; primary risk is runtime behavior of the new fluentd/gems, which the A/B validation covers.

Refs: ADO Bug 38718958 · ICM 830469080
