### PR TITLE
fix(ci): install openssl-devel on arm64 for fluentd openssl gem build

### DIFF
--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -16,7 +16,7 @@ sudo update-ca-trust
 # the mariner package version is behind the global packages so we are using different versions for arm64 and x86_64
 if [ "$ARCH" == "arm64" ]; then
     sudo tdnf install ruby-3.3.5-7.azl3.aarch64 -y
-    sudo tdnf install zlib-devel -y
+    sudo tdnf install zlib-devel openssl-devel -y
 else
     tdnf install -y gcc patch bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel
     wget https://github.com/rbenv/ruby-build/archive/refs/tags/v20251023.tar.gz -O ruby-build.tar.gz


### PR DESCRIPTION
## Problem

The `ContainerInsights-MultiArch-MergedBranches` Linux image build began failing on the **linux/arm64** builder:

```
gems/openssl-4.0.2/ext/openssl
checking for openssl/ssl.h... no
*** extconf.rb failed ***  OpenSSL library could not be found.
ERROR: gem install failed after 3 attempts: gem install fluentd -v 1.19.3
```

The **same commit** (`15567a7e4`) **succeeded** on Jul 11 (build 120799) and then **failed** on Jul 12 and Jul 13 (builds 120843, 120914) with **no source change** — so the trigger was external (rubygems.org), not this repo.

## Root cause

The Linux image resolves its Ruby gem tree fresh at build time (no lockfile). The dependency chain is:

`fluentd 1.19.3 → async-http (~> 0.86) → io-stream → openssl`

- `io-stream 0.13.1` (2026-06-13) had **no** runtime dependencies.
- `io-stream 0.13.2` (**published 2026-07-12**) added `openssl >= 3.3` as a runtime dependency.

Once `io-stream 0.13.2` shipped, `gem install fluentd -v 1.19.3` started pulling and **compiling** the `openssl` gem's native extension, which requires the OpenSSL development headers. The amd64 branch of `kubernetes/linux/setup.sh` already installs `openssl-devel`, but the arm64 branch installed only `zlib-devel`, so arm64 failed to find `openssl/ssl.h`.

Verified from the build logs:
- Green build 120799 (Jul 11): `Successfully installed fluentd-1.19.3` on both arches, openssl gem never installed.
- Red build 120914 (Jul 13): `Successfully installed openssl-4.0.2` on amd64 (has headers), 3x native-extension failure on arm64 (no headers).

## Fix

Install `openssl-devel` in the arm64 branch of `kubernetes/linux/setup.sh`, matching the amd64 branch.

## Notes
- The fluentd 1.16.3 -> 1.19.3 bump (#1728) introduced the async-http/io-stream chain; the io-stream 0.13.2 release exposed the latent missing dependency.
- Failing build: https://github-private.visualstudio.com/microsoft/_build/results?buildId=120914&view=results
