### PR TITLE
feat(release): add Fairfax and Mooncake Managed SDP support

### DIFF
--- a/.pipelines/ci-arc-k8s-extension-prod-release.yaml
+++ b/.pipelines/ci-arc-k8s-extension-prod-release.yaml
@@ -1,5 +1,10 @@
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
+parameters:
+- name: validateSovereignRolloutOnly
+  displayName: Validate Fairfax and Mooncake rollouts without deploying
+  type: boolean
+  default: false
 variables:
 - name: ACRName
   value: $(VAR_ACR_NAME)
@@ -1975,34 +1980,13 @@ extends:
           displayName: Ev2 - Monitoring
           inputs:
             Ev2MonintoringUrl: $(Ev2MonintoringUrl)
-    - stage: Stage_6
-      displayName: 'Fairfax & Mooncake: Create Escort JIT'
-      trigger: manual
-      pool:
-        name: Azure-Pipelines-CI-Test-EO
-        image: ci-1es-managed-windows-2022
-        os: windows
-      jobs:
-      - job: Job_1
-        displayName: Agentless job
-        condition: succeeded()
-        timeoutInMinutes: 7200
-        pool:
-          name: server
-        variables:
-        - name: OneESPT
-          value: true
-          readonly: true
-        - name: OneESPT.BuildType
-          value: Official
-          readonly: true
-        - name: OneESPT.OS
-          value: windows
-          readonly: true
-        steps: []
     - stage: Stage_7
-      displayName: Fairfax Region Testing
+      displayName: 'Fairfax: Managed SDP'
       trigger: manual
+      dependsOn: []
+      variables:
+      - name: ob_release_environment
+        value: Fairfax
       pool:
         name: Azure-Pipelines-CI-Test-EO
         image: ci-1es-managed-windows-2022
@@ -2065,7 +2049,7 @@ extends:
           value: windows
           readonly: true
         - name: ev2Environment
-          value: Production
+          value: Fairfax
         - name: Ev2MonintoringUrl
           value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
         displayName: Approval
@@ -2087,9 +2071,11 @@ extends:
         - approval
         variables:
         - name: ev2Environment
-          value: Production
+          value: Fairfax
+        - name: RELEASE_STAGE_NAME
+          value: SovereignStable
         - name: REGISTER_REGIONS_BATCH
-          value: "westcentralus,southcentralus,southeastasia,uksouth,westus2,australiaeast,eastus2,northcentralus,koreacentral,eastasia,japaneast,westeurope,northeurope,eastus,francecentral,westus,centralus,canadacentral,westus3,australiacentral,australiacentral2,australiasoutheast,brazilsouth,brazilsoutheast,canadaeast,centralindia,francesouth,germanycentral,germanynorth,germanynortheast,germanywestcentral,italynorth,japanwest,jioindiacentral,jioindiawest,koreasouth,norwayeast,norwaywest,polandcentral,qatarcentral,southafricanorth,southafricawest,southindia,swedencentral,swedensouth,switzerlandnorth,switzerlandwest,uaecentral,uaenorth,uknorth,uksouth2,ukwest,westindia,usgovvirginia"
+          value: "usgovvirginia,usgovtexas,usgovarizona"
         - name: Ev2MonintoringUrl
           value: https://azureservicedeploy.msft.net/api/monitorrollout
         - name: OneESPT.JobType
@@ -2227,6 +2213,7 @@ extends:
             UseServerMonitorTask: true
             SkipRegistrationIfExists: True
             ForceRegistration: true
+            ValidateOnly: ${{ parameters.validateSovereignRolloutOnly }}
             ApprovalServiceEnvironment: $(ev2Environment)
             ServiceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot
             RolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/RolloutSpec.json
@@ -2252,7 +2239,280 @@ extends:
           value: ev2-classic
           readonly: true
         - name: ev2Environment
-          value: Production
+          value: Fairfax
+        - name: Ev2MonintoringUrl
+          value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+        displayName: Agent job - Ev2 Ev2 Monitoring
+        pool:
+          name: server
+        dependsOn:
+        - Ev2_rollout_ev2_rollout
+        timeoutInMinutes: '0'
+        steps:
+        - task: vsrm-ev2.vss-server-ev2.1950188C-A844-4040-A014-A326BC8332D3.Ev2Agentless@1
+          displayName: Ev2 - Monitoring
+          inputs:
+            Ev2MonintoringUrl: $(Ev2MonintoringUrl)
+    - stage: Stage_8
+      displayName: 'Mooncake: Managed SDP'
+      trigger: manual
+      dependsOn: []
+      variables:
+      - name: ob_release_environment
+        value: Mooncake
+      pool:
+        name: Azure-Pipelines-CI-Test-EO
+        image: ci-1es-managed-windows-2022
+        os: windows
+      jobs:
+      - job: releaseGating
+        displayName: Release Gating
+        variables:
+        - name: OneESPT
+          value: true
+          readonly: true
+        - name: OneESPT.BuildType
+          value: Official
+          readonly: true
+        - name: OneESPT.OS
+          value: windows
+          readonly: true
+        - name: runCodesignValidationInjection
+          value: false
+        - name: Codeql.SkipTaskAutoInjection
+          value: true
+        - name: skipComponentGovernanceDetection
+          value: true
+        - name: skipNugetSecurityAnalysis
+          value: true
+        steps:
+        - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+          condition: false
+          inputs:
+            repository: none
+        - task: 1ESGPTRunTask@3.0.376
+          displayName: Branch Validation (1ES PT)
+          continueOnError: true
+          target:
+            container: host
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+            SYSTEM_TEAMPROJECT: $(System.TeamProject)
+            SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+            BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+            BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+            BUILD_REPOSITORY_NAME: $(Build.Repository.Name)
+            BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+            BUILD_REPOSITORYPROVIDER: $(Build.Repository.Provider)
+            BUILD_SOURCEVERSION: $(Build.SourceVersion)
+            TASK_MODE: audit
+          inputs:
+            repoId: microsoft/Docker-Provider
+            path: release_gating.py
+      - job: approval
+        variables:
+        - name: OneESPT
+          value: true
+          readonly: true
+        - name: OneESPT.BuildType
+          value: Official
+          readonly: true
+        - name: OneESPT.OS
+          value: windows
+          readonly: true
+        - name: ev2Environment
+          value: Mooncake
+        - name: Ev2MonintoringUrl
+          value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
+        displayName: Approval
+        pool:
+          name: server
+        timeoutInMinutes: 7200
+        dependsOn:
+        - releaseGating
+        steps:
+        - task: ApprovalTask@1
+          inputs:
+            environment: $(ev2Environment)
+            servicetreeguid: 3170cdd2-19f0-4027-912b-1027311691a2
+      - job: Ev2_rollout_ev2_rollout
+        displayName: Agent job - Ev2 Ev2 Rollout
+        timeoutInMinutes: '0'
+        condition: succeeded()
+        dependsOn:
+        - approval
+        variables:
+        - name: ev2Environment
+          value: Mooncake
+        - name: RELEASE_STAGE_NAME
+          value: SovereignStable
+        - name: REGISTER_REGIONS_BATCH
+          value: "chinaeast2,chinanorth2,chinaeast3,chinanorth3"
+        - name: Ev2MonintoringUrl
+          value: https://azureservicedeploy.msft.net/api/monitorrollout
+        - name: OneESPT.JobType
+          value: releaseJob
+          readonly: true
+        - name: OneESPT
+          value: true
+          readonly: true
+        - name: OneESPT.BuildType
+          value: Official
+          readonly: true
+        - name: OneESPT.OS
+          value: windows
+          readonly: true
+        - name: OneESPT.Workflow
+          value: ev2-classic
+          readonly: true
+        - name: runCodesignValidationInjection
+          value: false
+        - name: Codeql.SkipTaskAutoInjection
+          value: true
+        - name: skipComponentGovernanceDetection
+          value: true
+        - name: skipNugetSecurityAnalysis
+          value: true
+        - name: OneES_targetName
+          value: host
+        steps:
+        - task: 1ESGPTRunTask@3.0.376
+          displayName: Validate Hosted Pool Information (1ES PT)
+          continueOnError: false
+          target:
+            container: host
+          env:
+            HOST_ARCHITECTURE: amd64
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            SYSTEM_DEFINITIONID: $(System.DefinitionId)
+            SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+            SYSTEM_TEAMPROJECT: $(System.TeamProject)
+            SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+            BUILD_REPOSITORY_ID: $(Build.Repository.ID)
+            BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+            PIPELINEGOVERNANCESTATUS_AUDITED: variables['PipelineGovernanceStatus_Audited']
+            PIPELINECLASSIFICATION_AUDITED: variables['PipelineClassification_Audited']
+            BUILD_REASON: $(Build.Reason)
+          inputs:
+            repoId: microsoft/Docker-Provider
+            path: validateHostedPool.ps1
+            arguments: -TargetName '' -StepTargets '' -StepsLength 0 -SkipStatelessValidation True -OS windows -IgnoreProductionPoolCheck  -IsOfficialTemplate -IsProductionReleasePipeline
+        - task: DownloadPipelineArtifact@2
+          displayName: ⏬ Pipeline Artifact Download
+          inputs:
+            buildType: specific
+            project: $(resources.pipeline._ci-arc-k8s-extension-prod-release.projectID)
+            definition: $(resources.pipeline._ci-arc-k8s-extension-prod-release.pipelineID)
+            allowFailedBuilds: false
+            buildVersionToDownload: specific
+            pipelineId: $(resources.pipeline._ci-arc-k8s-extension-prod-release.runID)
+            pipeline: _ci-arc-k8s-extension-prod-release
+            targetPath: $(Pipeline.Workspace)/ev2Artifact
+          target:
+            container: host
+        - task: AzureArtifacts.drop-validator-task.drop-validator-task.DropValidatorTask@0
+          displayName: "\U0001F6E1 Validate SBoM Manifest (1ES PT)"
+          condition: succeeded()
+          continueOnError: False
+          timeoutInMinutes: 30
+          env:
+            SBOMVALIDATOR_TEMPIGNOREMISSING: true
+          inputs:
+            BuildDropPath: $(Pipeline.Workspace)/ev2Artifact/linux-drop
+            OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+            ValidateSignature: True
+            Verbosity: 'Verbose'
+        - task: 1ESGPTRunTask@3.0.376
+          displayName: Post-SBoM Validation (1ES PT)
+          continueOnError: true
+          target:
+            container: host
+          condition: succeeded()
+          env:
+            OutputPath: $(Agent.TempDirectory)/sbom_validation_results.json
+          inputs:
+            repoId: microsoft/Docker-Provider
+            path: post_sbom_validation.py
+        - task: 1ESGPTRunTask@3.0.376
+          displayName: Validate Source Build (1ES PT)
+          continueOnError: false
+          target:
+            container: host
+          env:
+            BuildDropPath: $(Pipeline.Workspace)/ev2Artifact/linux-drop
+            IsProduction: True
+            OneES_ArtifactType: $(DownloadPipelineArtifactResourceTypes)
+          inputs:
+            repoId: microsoft/Docker-Provider
+            path: validate_source_build.py
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+          displayName: "\U0001F6E1 Guardian: CodeSign Validation"
+          target:
+            container: host
+          condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+          continueOnError: true
+          timeoutInMinutes: 10
+          inputs:
+            Path: $(Pipeline.Workspace)/ev2Artifact
+            MaxThreads: $(OneES_UsableProcessorCount)
+            FailIfNoTargetsFound: false
+            ExcludePassesFromLog: False
+            Targets: f|**\*.dll;f|**\*.exe;f|**\*.sys;f|**\*.ps1;f|**\*.psm1;f|**\*.ps1xml;f|**\*.psc1;f|**\*.psd1;f|**\*.cdxml;f|**\*.vbs;f|**\*.js;f|**\*.wsf;-|.gdn\**;
+        - task: 1ESGPTRunTask@3.0.376
+          displayName: "\U0001F6E1 Guardian: Check CodeSign Validation Results (1ES PT)"
+          continueOnError: true
+          target:
+            container: host
+          condition: and(succeeded(), ne(variables['ONEES_ENFORCED_CODESIGNVALIDATION_ENABLED'], 'false'))
+          env:
+            OneES_PipelineWorkspace: $(Pipeline.Workspace)
+            OneES_DeleteCodeSignValidationResult: True
+            OneES_CustomPolicyFile: ''
+          inputs:
+            repoId: microsoft/Docker-Provider
+            path: check_csv_results.ps1
+        - task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+          condition: false
+          inputs:
+            repository: none
+          target:
+            container: host
+        - task: vsrm-ev2.ev2-rollout.ev2-rollout-task.Ev2RARollout@2
+          displayName: Ev2 Managed SDP - Deploy
+          inputs:
+            EndpointProviderType: ApprovalService
+            TaskAction: RegisterAndRollout
+            UseServerMonitorTask: true
+            SkipRegistrationIfExists: True
+            ForceRegistration: true
+            ValidateOnly: ${{ parameters.validateSovereignRolloutOnly }}
+            ApprovalServiceEnvironment: $(ev2Environment)
+            ServiceRootPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot
+            RolloutSpecPath: $(Pipeline.Workspace)/ev2Artifact/drop/build/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/RolloutSpec.json
+            StageMapName: Microsoft.Azure.SDP.Standard
+            Select: regions(*)
+            ConfigurationOverrides: $(configurationOverrides)
+          env:
+            ServiceTreeGuid: 3170cdd2-19f0-4027-912b-1027311691a2
+          target:
+            container: host
+      - job: Ev2_rollout_ev2_monitoring
+        variables:
+        - name: OneESPT
+          value: true
+          readonly: true
+        - name: OneESPT.BuildType
+          value: Official
+          readonly: true
+        - name: OneESPT.OS
+          value: windows
+          readonly: true
+        - name: OneESPT.Workflow
+          value: ev2-classic
+          readonly: true
+        - name: ev2Environment
+          value: Mooncake
         - name: Ev2MonintoringUrl
           value: 'https://azureservicedeploy.msft.net/api/monitorrollout'
         displayName: Agent job - Ev2 Ev2 Monitoring

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Fairfax.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Fairfax.json
@@ -1,16 +1,17 @@
 {
   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/ConfigurationSpecification.json",
   "Settings": {
-    "tenantId": "33e01921-4d64-4f8c-a055-5bdaffd5e33d",
-    "environment": "Prod",
-    "releaseStage": "Stable",
+    "tenantId": "$(aad.tenants.USME.id)",
+    "environment": "Fairfax",
+    "releaseStage": "SovereignStable",
     "adminSubscriptionId": "",
     "chartVersion": "",
     "isCustomerHidden": "",
     "registerRegionsCanary": "",
     "releaseTrainsPreviewPath": "",
     "releaseTrainsStablePath": "",
-    "registerRegionsBatch": "",
+    "registerRegionsBatch": "usgovvirginia,usgovtexas,usgovarizona",
+    "arcApiUrl": "https://usgovvirginia.dp.kubernetesconfiguration.azure.us",
     "resourceAudience": "",
     "spnClientId": "",
     "spnSecret": "",
@@ -25,7 +26,7 @@
       "Settings": {},
       "Regions": [
         {
-          "Name": "eastus2",
+          "Name": "usgovvirginia",
           "Settings": {
             "stampCount": 1,
             "azureResourceGroup": "ContainerInsightsExtension-Pilot-Release",

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Mooncake.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Mooncake.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/ConfigurationSpecification.json",
+  "Settings": {
+    "tenantId": "$(aad.tenants.CME.id)",
+    "environment": "Mooncake",
+    "releaseStage": "SovereignStable",
+    "adminSubscriptionId": "",
+    "chartVersion": "",
+    "isCustomerHidden": "",
+    "registerRegionsCanary": "",
+    "releaseTrainsPreviewPath": "",
+    "releaseTrainsStablePath": "",
+    "registerRegionsBatch": "chinaeast2,chinanorth2,chinaeast3,chinanorth3",
+    "arcApiUrl": "https://chinaeast2.dp.kubernetesconfiguration.azure.cn",
+    "resourceAudience": "",
+    "spnClientId": "",
+    "spnSecret": "",
+    "spnTenantId": "",
+    "managedIdentity": "",
+    "acrName": "",
+    "repoType": ""
+  },
+  "Geographies": [
+    {
+      "Name": "China",
+      "Settings": {},
+      "Regions": [
+        {
+          "Name": "chinaeast2",
+          "Settings": {
+            "stampCount": 1,
+            "azureResourceGroup": "ContainerInsightsExtension-Pilot-Release",
+            "subscriptionkey": "ContainerInsights-30c56c3a-54da-46ea-b004-06eb33432687"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Prod.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Configurations.Prod.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/ConfigurationSpecification.json",
+  "Settings": {
+    "tenantId": "33e01921-4d64-4f8c-a055-5bdaffd5e33d",
+    "environment": "Prod",
+    "releaseStage": "Stable",
+    "adminSubscriptionId": "",
+    "chartVersion": "",
+    "isCustomerHidden": "",
+    "registerRegionsCanary": "",
+    "releaseTrainsPreviewPath": "",
+    "releaseTrainsStablePath": "",
+    "registerRegionsBatch": "",
+    "arcApiUrl": "https://eastus2euap.dp.kubernetesconfiguration.azure.com",
+    "resourceAudience": "",
+    "spnClientId": "",
+    "spnSecret": "",
+    "spnTenantId": "",
+    "managedIdentity": "",
+    "acrName": "",
+    "repoType": ""
+  },
+  "Geographies": [
+    {
+      "Name": "United States",
+      "Settings": {},
+      "Regions": [
+        {
+          "Name": "eastus2",
+          "Settings": {
+            "stampCount": 1,
+            "azureResourceGroup": "ContainerInsightsExtension-Pilot-Release",
+            "subscriptionkey": "ContainerInsights-30c56c3a-54da-46ea-b004-06eb33432687"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Parameters/RolloutParameter.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Parameters/RolloutParameter.json
@@ -54,6 +54,10 @@
             "value": "__REGISTER_REGIONS_BATCH__"
           },
           {
+            "name": "ARC_API_URL",
+            "value": "__ARC_API_URL__"
+          },
+          {
             "name": "RESOURCE_AUDIENCE",
             "value": "__RESOURCE_AUDIENCE__"
           },

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/RolloutSpec.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/RolloutSpec.json
@@ -7,7 +7,7 @@
     "name": "ContainerInsightsExtension-Release",
     "configuration": {
       "serviceGroupScope": {
-        "specPath": "Configurations.Public.Prod.json"
+        "specPath": "Configurations.$rolloutinfra().json"
       }
     },
     "rolloutType": "Major",

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/ScopeBindings.json
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/ScopeBindings.json
@@ -38,6 +38,10 @@
           "replaceWith": "$config(registerRegionsBatch)"
         },
         {
+          "find": "__ARC_API_URL__",
+          "replaceWith": "$config(arcApiUrl)"
+        },
+        {
           "find": "__RESOURCE_AUDIENCE__",
           "replaceWith": "$config(resourceAudience)"
         },

--- a/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Scripts/arcExtensionRelease.sh
+++ b/deployment/arc-k8s-extension-release-v2-Managed-SDP/ServiceGroupRoot/Scripts/arcExtensionRelease.sh
@@ -12,6 +12,7 @@ CHART_VERSION=${CHART_VERSION}
 PACKAGE_CONFIG_NAME="${PACKAGE_CONFIG_NAME:-microsoft.azuremonitor.containers-pkg092025}"
 API_VERSION="${API_VERSION:-2021-05-01}"
 METHOD="${METHOD:-put}"
+ARC_API_URL="${ARC_API_URL:-}"
 REGISTRY_PATH_CANARY_STABLE="https://mcr.microsoft.com/azuremonitor/containerinsights/canary/stable/azuremonitor-containers"
 REGISTRY_PATH_PROD_STABLE="https://mcr.microsoft.com/azuremonitor/containerinsights/prod1/stable/azuremonitor-containers"
 
@@ -25,6 +26,10 @@ if [ -z "$IS_CUSTOMER_HIDDEN" ]; then
 fi
 if [ -z "$CHART_VERSION" ]; then
     echo "-e error chart version must be provided "
+    exit 1
+fi
+if [ -z "$ARC_API_URL" ]; then
+    echo "-e error Arc registration API URL must be provided "
     exit 1
 fi
 
@@ -212,6 +217,47 @@ cat <<EOF >> "request.json"
 EOF
     ;;
 
+  SovereignStable)
+if [ -z "$RELEASE_TRAINS_STABLE_PATH" ]; then
+    echo "-e error stable release train must be provided "
+    exit 1
+fi
+if [ -z "$REGISTER_REGIONS_BATCH" ]; then
+    echo "-e error sovereign release regions must be provided "
+    exit 1
+fi
+MCR_NAME_PATH="oci://mcr.microsoft.com/azuremonitor/containerinsights/prod1/stable/azuremonitor-containers"
+echo "Pulling chart from MCR:${MCR_NAME_PATH}"
+helm pull ${MCR_NAME_PATH} --version ${CHART_VERSION}
+if [ $? -eq 0 ]; then
+  echo "Pulling chart from MCR:${MCR_NAME_PATH}:${CHART_VERSION} completed successfully."
+else
+  echo "-e error Pulling chart from MCR:${MCR_NAME_PATH}:${CHART_VERSION} failed. Please review Ev2 pipeline logs for more details on the error."
+  exit 1
+fi
+# Sovereign clouds register only their stable production endpoint.
+cat <<EOF > "request.json"
+{
+    "artifactEndpoints": [
+        {
+            "Regions": [
+                $REGISTER_REGIONS_BATCH
+            ],
+            "Releasetrains": [
+                $RELEASE_TRAINS_STABLE_PATH
+            ],
+            "FullPathToHelmChart": "$REGISTRY_PATH_PROD_STABLE",
+            "ExtensionUpdateFrequencyInMinutes": 60,
+            "IsCustomerHidden": $IS_CUSTOMER_HIDDEN,
+            "ReadyforRollout": true,
+            "RollbackVersion": null,
+            "PackageConfigName": "$PACKAGE_CONFIG_NAME"
+        }
+    ]
+}
+EOF
+    ;;
+
   *)
     echo -n "unknown release stage"
     exit 1
@@ -253,7 +299,6 @@ else
 fi
 ACCESS_TOKEN=$(echo $ACCESS_TOKEN | tr -d '"' | tr -d '"\r\n')
 
-ARC_API_URL="https://eastus2euap.dp.kubernetesconfiguration.azure.com"
 EXTENSION_NAME="microsoft.azuremonitor.containers"
 
 echo "start send request"


### PR DESCRIPTION
## Summary
- replace the empty Escort JIT stage and public-cloud Fairfax registration with independent manual Fairfax and Mooncake Managed SDP stages
- select Prod, Fairfax, or Mooncake Ev2 configuration through `$rolloutinfra()` and bind the matching Arc registration endpoint
- add a sovereign stable-only registration payload plus a `ValidateOnly` pipeline parameter and fail-fast input validation

## Deployment prerequisites
Before either sovereign stage can roll out successfully:
- Service Tree service `3170cdd2-19f0-4027-912b-1027311691a2` needs tenant-local owner groups in USME and CME; without them Approval Service fails during `RegisterService`
- `Microsoft.Azure.SDP.Standard` must be onboarded and available in Fairfax and Mooncake
- the configured Ev2 managed identity, admin subscription, `ContainerInsights-30c56c3a-54da-46ea-b004-06eb33432687` subscription key, and Arc registration resource audience must be resolvable and authorized in each sovereign cloud

Managed SDP removes the pipeline-agent Escort JIT requirement once those pre-authorized sovereign identities and service registrations are in place.

## Validation
- Azure DevOps definition 1031 `previewRun` expanded all stages with Fairfax, Mooncake, and `ValidateOnly: true`
- changed Ev2 JSON parsed successfully
- shell syntax and isolated Public/Fairfax/Mooncake request-generation tests passed