### PR TITLE
Onboard build pipeline to CFS network isolation (CFSClean) in audit mode

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -35,6 +35,11 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    # SFI SR21 (MountainPass): onboard to CFS network isolation in AUDIT mode.
+    # 'Permissive' reports public-feed (CFSClean) violations without failing the
+    # build. Drop 'Permissive' to flip to enforcing once builds are violation-free.
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: Azure-Pipelines-CI-Test-EO
       image: ci-1es-managed-ubuntu-2204


### PR DESCRIPTION
## What
Onboards the 1ES build pipeline (`.pipelines/azure_pipeline_mergedbranches.yaml`, pipeline id 444) to the **CFSClean** network isolation policy in **audit mode** (`settings.networkIsolationPolicy: Permissive,CFSClean`).

## Why
Part of SFI Network Isolation / AzRel Red Flag **MountainPass SR21** (CFS adoption). This pipeline (ADO `github-private/microsoft`, id 444) is flagged for restoring packages from public feeds. `Permissive` reports CFSClean violations on each run **without failing the build**, so this can land safely and surface the exact violating endpoints before remediation.

## Effect
- Non-breaking: builds continue to pass; violations are reported in the "Stop Network Isolation" task / `GetPolicyViolationDetails`.
- No package-restore behavior changes in this PR.

## Next steps (follow-up PRs)
- Route NuGet via CFS (`NuGet.Config` + `NuGetAuthenticate`); vendor Go modules; route/pre-bake Ruby gems; replace Chocolatey (Windows) with a pre-baked image; mirror GitHub-release binaries (ORAS/Trivy/cmetrics); handle apt / Docker Hub.
- Once builds are violation-free, drop `Permissive` to enforce and reach the 7-day lock-in.