### PR TITLE
Merge ci_prod into auto/upgrade-telegraf-1.39.2 (pick up SR21 CFS NuGet fix)

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -372,6 +372,8 @@ extends:
           displayName: 'install prereqs'
         - task: CodeQL3000Init@0
           condition: eq(variables.IS_MAIN_BRANCH, true)
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to CFS NuGet feed'
         - script: |
             setlocal enabledelayedexpansion
             powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"
@@ -591,6 +593,8 @@ extends:
           displayName: 'install prereqs'
         - task: CodeQL3000Init@0
           condition: eq(variables.IS_MAIN_BRANCH, true)
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to CFS NuGet feed'
         - script: |
             setlocal enabledelayedexpansion
             powershell.exe -ExecutionPolicy Unrestricted -NoProfile -WindowStyle Hidden -File "build\windows\Makefile.ps1"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="PublicPackages" value="https://pkgs.dev.azure.com/github-private/microsoft/_packaging/microsoft_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/build/windows/Makefile.ps1
+++ b/build/windows/Makefile.ps1
@@ -73,10 +73,9 @@ if ($false -eq (Test-Path -Path $certsrcdir)) {
 Write-Host("set the cerificate generator source code directory : " + $certsrcdir + " ...")
 Set-Location -Path $certsrcdir
 
-Write-Host("Adding dotnet packages Newtonsoft.json and BouncyCastle ...")
-dotnet add package Newtonsoft.json
-dotnet add package BouncyCastle
-Write-Host("Successfully added dotnet packages") -ForegroundColor Green
+# Newtonsoft.Json and BouncyCastle are pinned as PackageReference in CertificateGenerator.csproj.
+# 'dotnet add package' without a version resolves the latest from the configured source, which
+# reaches api.nuget.org and un-pins the versions at build time. Restore below uses NuGet.config.
 dotnet build  -f $dotnetcoreframework
 Write-Host("Building Certificate generator code and ...") -ForegroundColor Green
 


### PR DESCRIPTION
Merges `ci_prod` into this branch to pick up #1756 (commit 66d115cc), which routes NuGet restore through the CFS feed.

**Why this matters:** pipeline 444 (`ContainerInsights-MultiArch-MergedBranches`) has an empty CI branch filter, so it builds *every* branch. Builds from this branch without the fix still restore from `api.nuget.org` and emit `CFSClean` network-isolation violations, which reset the 7-day lock-in streak for ICM 839785317 (AzRel Red Flag / MountainPass SR21).

The streak must stay clean through Aug 16 to resolve before the Aug 21 cohort deadline. No functional change to this branch's own work.
