### PR TITLE
Fix flaky arm64 multi-arch build: register binfmt with current QEMU

### DIFF
--- a/.pipelines/azure_pipeline_mergedbranches.yaml
+++ b/.pipelines/azure_pipeline_mergedbranches.yaml
@@ -17,6 +17,10 @@ variables:
   containerRegistry: 'containerinsightsprod'
   repoImageName: '${{ variables.containerRegistry }}.azurecr.io/public/azuremonitor/containerinsights/cidev'
   GOLANG_BASE_IMAGE: 'mcr.microsoft.com/oss/go/microsoft/golang:1.26.5'
+  # QEMU used to emulate linux/arm64 during the multi-arch docker build. Keep this current:
+  # older QEMU builds make the emulated gcc segfault at random while compiling ruby native
+  # gem extensions. MCR mirror of tonistiigi/binfmt, used to avoid Docker Hub rate limiting.
+  QEMU_BINFMT_IMAGE: 'mcr.microsoft.com/mirror/docker/tonistiigi/binfmt:qemu-v9.2.2-52'
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
   IS_MAIN_BRANCH: $[eq(variables['Build.SourceBranchName'], 'ci_prod')]
   IS_RELEASE: $[ne(variables['TELEMETRY_TAG'], '')]
@@ -168,7 +172,9 @@ extends:
             toolVersion: Latest
             targetDirectory: '$(Build.SourcesDirectory)'
       - job: build_linux
-        timeoutInMinutes: 120
+        # the emulated linux/arm64 leg is slow, and setup.sh retries native gem builds that
+        # segfault under emulation, so leave headroom rather than failing on the job timeout
+        timeoutInMinutes: 180
         dependsOn: common
         variables:
           linuxImagetag: $[ dependencies.common.outputs['setup.linuxImagetag'] ]
@@ -192,10 +198,22 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               mkdir -p $(Build.ArtifactStagingDirectory)/linux
-              sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
               docker system prune --all -f
               docker images -q --filter "dangling=true" | xargs docker rmi
-              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              # Register binfmt handlers for cross-arch (linux/arm64) emulation.
+              # NOTE: this previously used `multiarch/qemu-user-static --reset -p yes`, which pins the
+              # QEMU binary from that image into the kernel (-p yes => binfmt_misc 'F' flag). That image
+              # is abandoned (last push 2023-01, QEMU 7.2), and the apt qemu-user-static it sat on top of
+              # is frozen at QEMU 6.2 on ubuntu-22.04 -- apt only backports fixes, never new upstream
+              # versions. Emulated gcc segfaults at random on those, which broke the arm64 leg roughly
+              # half the time while compiling the ruby native gem extensions in kubernetes/linux/setup.sh.
+              # tonistiigi/binfmt tracks current QEMU releases and is what docker/setup-qemu-action uses.
+              # Pulled from the MCR mirror to avoid Docker Hub rate limiting.
+              docker run --rm --privileged $(QEMU_BINFMT_IMAGE) --uninstall 'qemu-*' || true
+              docker run --rm --privileged $(QEMU_BINFMT_IMAGE) --install all || exit 1
+              # fail fast (instead of 30+ minutes into the arm64 build) if emulation is not usable.
+              # NOTE: this script does not run under 'set -e', so check explicitly.
+              docker run --rm --platform linux/arm64 mcr.microsoft.com/azurelinux/base/core:3.0 uname -m || exit 1
               docker buildx create --name testbuilder
               docker buildx use testbuilder
               az --version

--- a/kubernetes/linux/setup.sh
+++ b/kubernetes/linux/setup.sh
@@ -80,19 +80,21 @@ echo "$(fluent-bit --version)" >> packages_version.txt
 # Retry wrapper for gem install commands.
 # Native extension builds under QEMU emulation for arm64 can hit sporadic
 # segfaults in GCC/make, so we retry transient failures automatically.
+# Retries are cheap: gems that already installed successfully are skipped, so each
+# attempt resumes where the previous one crashed rather than starting over.
 gem_install_with_retry() {
-    local max_retries=3
+    local max_retries=5
     local attempt=1
     while [ $attempt -le $max_retries ]; do
-        echo "gem install attempt $attempt/$max_retries: gem install $@"
+        echo "gem install attempt $attempt/$max_retries: gem install $*"
         if gem install "$@"; then
             return 0
         fi
-        echo "WARNING: gem install failed (attempt $attempt/$max_retries)"
+        echo "WARNING: gem install failed (attempt $attempt/$max_retries): gem install $*"
         attempt=$((attempt + 1))
-        sleep 2
+        sleep $((attempt * 5))
     done
-    echo "ERROR: gem install failed after $max_retries attempts: gem install $@"
+    echo "ERROR: gem install failed after $max_retries attempts: gem install $*"
     exit 1
 }
 

--- a/scripts/build/linux/install-build-pre-requisites.sh
+++ b/scripts/build/linux/install-build-pre-requisites.sh
@@ -70,9 +70,19 @@ install_docker_buildx()
     sudo mkdir -p $HOME/.docker/cli-plugins
     sudo mv buildx-v* $HOME/.docker/cli-plugins
 
-    # install the emulator support
-    sudo apt-get -y install qemu binfmt-support qemu-user-static
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    # install the emulator support.
+    # NOTE: `--install all` pins the QEMU binaries from this image into the kernel via binfmt_misc,
+    # so the image tag decides which QEMU actually emulates arm64. tonistiigi/binfmt tracks current
+    # QEMU releases; the previously used multiarch/qemu-user-static image is abandoned (QEMU 7.2) and
+    # the apt qemu-user-static it sat on is frozen at QEMU 6.2 on ubuntu-22.04. On those, the emulated
+    # gcc segfaults at random while compiling the ruby native gem extensions in
+    # kubernetes/linux/setup.sh. Keep this tag in sync with QEMU_BINFMT_IMAGE in
+    # .pipelines/azure_pipeline_mergedbranches.yaml.
+    QEMU_BINFMT_IMAGE="mcr.microsoft.com/mirror/docker/tonistiigi/binfmt:qemu-v9.2.2-52"
+    # '|| true' because this script runs under 'set -e' and the uninstall is a no-op (and may
+    # report failure) on a machine that has no emulators registered yet
+    docker run --rm --privileged ${QEMU_BINFMT_IMAGE} --uninstall 'qemu-*' || true
+    docker run --rm --privileged ${QEMU_BINFMT_IMAGE} --install all
 
     docker buildx create --name testbuilder
     docker buildx use testbuilder


### PR DESCRIPTION
## Problem

The `linux/arm64` leg of the multi-arch build fails **~50% of the time** on `ci_prod` — 9 of the last 20 runs. Most recently [build 123410](https://github-private.visualstudio.com/microsoft/_build/results?buildId=123410&view=logs&j=3733dcd5-bcd6-55a4-4a00-94b1688239b5&t=e63853df-020b-5d43-710f-9c8c2c5d4c66), whose only code change was a one-line telegraf version bump.

The emulated `gcc` segfaults at random while compiling the ruby native gem extensions in `kubernetes/linux/setup.sh`. All three retries in that build died in a **different** place, which is what makes it clearly environmental rather than a code defect:

| Attempt | Crash site |
|---|---|
| 1 | `ossl_pkey_dh.o` (openssl gem) — `Segmentation fault (core dumped)` |
| 2 | `aarch64-unknown-linux-gnu-gcc: internal compiler error: Segmentation fault signal terminated program cc1` |
| 3 | `epoll.o` (io-event gem) — `Segmentation fault (core dumped)` |

Further evidence that this is not code-related:

- Commit `66d115cc2` both **failed** (123192) and **succeeded** (123209, 123210) with no changes in between.
- `linux/amd64` compiles the exact same gem set in ~80s, every time.
- The failure always lands in emulated native compilation, never in ruby/gem logic.

**Why it got worse recently.** Two changes significantly increased the amount of C compiled under emulation:
- fluentd 1.19.x pulled in `async-http` → `async` → `io-event`, a native epoll extension.
- `setup.sh` deletes the bundled `openssl` default gem for CVE reasons, which forces a full openssl gem source build.

## Root cause

The emulator was ancient.

`docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` pins the QEMU binary **from that image** into the kernel via the `binfmt_misc` `F` (fix-binary) flag. That image was **last published 2023-01-17 and tops out at QEMU 7.2**.

The `apt-get install qemu binfmt-support qemu-user-static` line above it doesn't help either — Ubuntu freezes upstream versions per release and only backports fixes, so jammy is pinned at **QEMU 6.2** (`1:6.2+dfsg-2ubuntu6.31`, 31 Ubuntu revisions later and still 6.2). It was also redundant, since the `--reset -p yes` immediately overwrote whatever it registered.

Random `cc1` segfaults under old `qemu-user` are a well-known problem, and the standard remedy is to register handlers from a current QEMU build.

## Fix

**`.pipelines/azure_pipeline_mergedbranches.yaml`**
- Register binfmt handlers with `tonistiigi/binfmt:qemu-v9.2.2-52` (QEMU **9.2.2**) — the image `docker/setup-qemu-action` uses. Pulled from the **MCR mirror**, since this pipeline already documents working around Docker Hub rate limiting.
- Uninstall existing handlers first, so the new QEMU actually takes effect rather than losing to a stale `F`-flag registration.
- Drop the redundant apt QEMU install.
- Add an arm64 smoke test, so broken emulation fails the job in seconds instead of 30+ minutes into the build.
- Job timeout 120 → 180 min, so the added retries can't trade a segfault for a timeout.

**`kubernetes/linux/setup.sh`**
- Gem install retries 3 → 5 with backoff, as defense in depth. Retries are cheap because already-installed gems are skipped, so each attempt resumes where the previous one crashed (visible in 123410: 905s → 241s → 399s).
- Log the failing command in the retry warning, and switch the log/error messages from `$@` to `$*`. Inside a quoted string `$@` expands to one word per argument; `echo` re-joins them with spaces so the rendered output is unchanged, making this a readability fix rather than a bug fix. The invocation itself stays `gem install "$@"`, which must keep argument boundaries intact.

**`scripts/build/linux/install-build-pre-requisites.sh`**
- Same QEMU change, so local dev builds match CI.

## Validation

Queued as [build 123605](https://github-private.visualstudio.com/microsoft/_build/results?buildId=123605) on this branch. **`build_linux` succeeded**, including the ORAS push and ESRP signing steps that build 123410 never reached.

QEMU registration now reports current emulators:

```
Status: Downloaded newer image for mcr.microsoft.com/mirror/docker/tonistiigi/binfmt:qemu-v9.2.2-52
uninstalling: qemu-* not found
installing: arm64 OK
...
"supported": [ "linux/amd64", ..., "linux/arm64", ... ]
"emulators": [ "qemu-aarch64", ... ]
```

The arm64 smoke test passes (`aarch64`), and the previously fatal gem builds now complete on the **first** attempt:

```
#47 970.4  gem install attempt 1/5: gem install fluentd -v 1.19.3 --no-document
#47 2041.6 Successfully installed openssl-4.0.2
#47 2118.3 Successfully installed io-event-1.19.5
#47 2118.3 Successfully installed fluentd-1.19.3
```

Across the whole build log:
- **0** occurrences of `Segmentation fault` / `internal compiler error` / `core dumped` (123410 had 3)
- **0** gem retry warnings — every `gem install` succeeded on attempt 1
- Multi-arch manifest pushed: `cidev:3.6.0-3-gd08216c60-20260814170628`

Also verified before pushing: YAML parses, the rendered inline script and both shell scripts pass `bash -n`, the retry wrapper was unit-tested (succeeds on retry, exits 1 after exhaustion), and the binfmt flags were checked against the upstream README.

`set -e` semantics were audited in both scripts, since they differ: the ADO inline script has **no** `set -e` (proven by 123410's log continuing past the failed build), so the new critical steps use explicit `|| exit 1`; the dev prereq script **does** (line 6), so the no-op `--uninstall` uses `|| true` while `--install` is left to abort on genuine failure.

> Note: `Docker windows build for ltsc2019` hit an unrelated transient failure in 123605 and passed on the pipeline's automatic retry. This PR contains no Windows changes.

## Follow-up (not in this PR)

The QEMU tag is pinned deliberately, for reproducibility. It's worth revisiting periodically, and longer term a native arm64 build agent would remove the emulation risk entirely rather than just making it much less likely.
